### PR TITLE
Exclude tests directory from SonarQube analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,8 +15,8 @@ sonar.sources=.
 # Coverage configuration
 sonar.python.coverage.reportPaths=coverage.xml
 
-# Exclude CIRISGUI and non-PL/SQL files from PL/SQL analysis
-sonar.exclusions=CIRISGUI/**/*,ciris_engine/persistence/migrations/*.sql
+# Exclude CIRISGUI, tests, and non-PL/SQL files from PL/SQL analysis
+sonar.exclusions=CIRISGUI/**/*,ciris_engine/persistence/migrations/*.sql,tests/**/*
 
 # Include all Python files
 sonar.inclusions=**/*.py


### PR DESCRIPTION
## Summary
- Exclude tests directory from SonarQube source code analysis to prevent test files from affecting code quality metrics

## Test plan
- [ ] Verify SonarQube configuration syntax is valid
- [ ] Confirm tests directory is excluded in next SonarQube scan

🤖 Generated with [Claude Code](https://claude.ai/code)