### PR TITLE
Fix test failures in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,23 @@ jobs:
         with:
           python-version: '3.12'
 
+      # Clean up any cached files and test databases
+      - name: Clean Python Cache and Test Artifacts
+        run: |
+          find . -type d -name __pycache__ -exec rm -rf {} + || true
+          find . -type f -name "*.pyc" -delete || true
+          find . -type f -name "*.pyo" -delete || true
+          rm -rf .pytest_cache || true
+          # Clean up test databases
+          rm -f test_*.db || true
+          rm -f ciris_engine.db || true
+          rm -rf data/*.db || true
+
       # Install dependencies (pytest and coverage)
       - name: Install Dependencies
         run: |
+          pip install --upgrade pip
+          pip install typing_extensions>=4.0.0
           pip install -r requirements.txt
           pip install pytest pytest-cov
 

--- a/ciris_engine/runtime/ciris_runtime.py
+++ b/ciris_engine/runtime/ciris_runtime.py
@@ -42,10 +42,11 @@ from ciris_engine.registries.base import ServiceRegistry, Priority
 logger = logging.getLogger(__name__)
 
 
-class CIRISRuntime(RuntimeInterface):
+class CIRISRuntime:
     """
     Main runtime orchestrator for CIRIS Agent.
     Handles initialization of all components and services.
+    Implements the RuntimeInterface protocol.
     """
     
     def __init__(

--- a/ciris_engine/runtime/runtime_interface.py
+++ b/ciris_engine/runtime/runtime_interface.py
@@ -2,7 +2,12 @@ from typing import Protocol, Optional, runtime_checkable
 
 @runtime_checkable
 class RuntimeInterface(Protocol):
-    """Protocol for CIRIS runtimes."""
+    """
+    Protocol for CIRIS runtimes.
+    
+    Note: Do not inherit from this Protocol. Instead, implement the methods
+    and use isinstance() checks with @runtime_checkable to verify compliance.
+    """
 
     async def initialize(self) -> None:
         """Initialize runtime and all services."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,3 +17,25 @@ try:
 except ImportError:
     # If python-dotenv is not installed, silently continue
     pass
+
+# Import API fixtures to ensure port randomization
+from .fixtures_api import randomize_api_port, api_port
+
+import pytest
+import asyncio
+import gc
+
+@pytest.fixture(autouse=True, scope="function")
+def cleanup_after_test():
+    """
+    Ensure proper cleanup after each test.
+    This helps prevent interference between tests, especially when Discord is involved.
+    """
+    yield
+    
+    # Force garbage collection to clean up any lingering objects
+    gc.collect()
+    
+    # Add a small delay to allow sockets to close
+    import time
+    time.sleep(0.1)

--- a/tests/fixtures_api.py
+++ b/tests/fixtures_api.py
@@ -1,0 +1,35 @@
+"""Fixtures for API-related tests to ensure proper isolation."""
+import os
+import socket
+import pytest
+from typing import Generator
+
+
+def get_free_port() -> int:
+    """Get a free port by binding to port 0 and getting the assigned port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(('', 0))
+        s.listen(1)
+        port = s.getsockname()[1]
+    return port
+
+
+@pytest.fixture(autouse=True)
+def randomize_api_port(monkeypatch) -> Generator[int, None, None]:
+    """
+    Automatically randomize API port for all tests to prevent conflicts.
+    This fixture is autouse=True, so it applies to all tests automatically.
+    """
+    # Only randomize if we're in a test environment with Discord token
+    if os.getenv("DISCORD_BOT_TOKEN"):
+        port = get_free_port()
+        monkeypatch.setenv("CIRIS_API_PORT", str(port))
+        yield port
+    else:
+        yield 8080  # Default port when no Discord token
+
+
+@pytest.fixture
+def api_port() -> int:
+    """Get the current API port being used."""
+    return int(os.getenv("CIRIS_API_PORT", "8080"))


### PR DESCRIPTION
## Summary
- Fix MockLLMService protocol compliance issues
- Resolve TypeError with Protocol inheritance in different Python environments
- Improve test isolation when Discord token is present

## Changes
1. **MockLLMService Protocol Compliance**
   - Changed `get_client()` to `_get_client()` to match protocol expectations
   - Updated both `ciris_engine/services/mock_llm/service.py` and `tests/adapters/mock_llm/service.py`

2. **Fixed Protocol Inheritance Issue**
   - Removed inheritance from `RuntimeInterface` Protocol in `CIRISRuntime`
   - Added documentation clarifying proper Protocol usage
   - This fixes `TypeError: object.__new__() takes exactly one argument` errors

3. **GitHub Actions Improvements**
   - Updated to use Python 3.12 (matching local environment)
   - Added cache and database cleanup steps
   - Explicitly install typing_extensions
   - Clean up test artifacts before runs

4. **Test Isolation**
   - Added `fixtures_api.py` for automatic API port randomization
   - Updated `conftest.py` with cleanup fixtures
   - Prevents port conflicts when Discord token is present

## Test Results
- All tests pass locally with and without Discord token
- These changes should resolve the 28 failing tests in GitHub Actions

🤖 Generated with [Claude Code](https://claude.ai/code)