### PR TITLE
fix: Show adapter-specific service names in API system status

### DIFF
--- a/BUILD_INFO.txt
+++ b/BUILD_INFO.txt
@@ -1,7 +1,7 @@
 # Build Information
 Code Hash: bb2c8fc43834
-Build Time: 2025-07-17T14:27:43.637758
-Git Commit: 5173637054d567ea0fc1ecd094e682d81de13184
+Build Time: 2025-07-17T16:08:52.426194
+Git Commit: df9427b34101a80e94b28b8498d1d4daf8354cb6
 Git Branch: main
 
 This hash is a SHA-256 of all Python source files in the repository.

--- a/ciris_engine/logic/adapters/api/routes/system.py
+++ b/ciris_engine/logic/adapters/api/routes/system.py
@@ -472,13 +472,27 @@ async def get_services_status(
                 service_name = parts[2]  # 'APICommunicationService_127803015745648', etc.
                 
                 # Clean up service name (remove instance ID)
+                original_service_name = service_name
                 if '_' in service_name:
                     service_name = service_name.split('_')[0]
                 
-                # Map ServiceType enum to category
+                # Extract adapter type from service name and create display name
+                adapter_prefix = ''
+                display_name = service_name
+                
+                if 'Discord' in service_name:
+                    adapter_prefix = 'DISCORD'
+                elif 'API' in service_name:
+                    adapter_prefix = 'API'
+                elif 'CLI' in service_name:
+                    adapter_prefix = 'CLI'
+                
+                # Map ServiceType enum to category and set display name
                 service_type = 'unknown'
                 if 'COMMUNICATION' in service_type_enum:
                     service_type = 'adapter'
+                    if adapter_prefix:
+                        display_name = f"{adapter_prefix}-COMM"
                 elif 'MEMORY' in service_type_enum:
                     service_type = 'graph'
                 elif 'LLM' in service_type_enum:
@@ -487,10 +501,20 @@ async def get_services_status(
                     service_type = 'infrastructure'
                 elif 'TOOL' in service_type_enum:
                     service_type = 'tool'
+                    if adapter_prefix:
+                        display_name = f"{adapter_prefix}-TOOL"
                 elif 'WISE_AUTHORITY' in service_type_enum:
                     service_type = 'governance'
+                    if adapter_prefix:
+                        display_name = f"{adapter_prefix}-WISE"
                 elif 'RUNTIME_CONTROL' in service_type_enum:
                     service_type = 'runtime'
+                    if adapter_prefix:
+                        display_name = f"{adapter_prefix}-RUNTIME"
+                
+                # Use display name for adapter services
+                if adapter_prefix and display_name != service_name:
+                    service_name = display_name
             else:
                 source = 'unknown'
                 service_type = 'unknown'


### PR DESCRIPTION
## Summary
- Updates API `/v1/system/services` endpoint to return adapter-specific service names
- Fixes duplicate service name issue on system status page

## Changes
- TOOL services now show as DISCORD-TOOL, API-TOOL, CLI-TOOL
- WISE services show as DISCORD-WISE, API-WISE, CLI-WISE  
- COMMUNICATION services show as DISCORD-COMM, API-COMM, CLI-COMM
- RUNTIME_CONTROL services show as DISCORD-RUNTIME, API-RUNTIME, CLI-RUNTIME

This ensures the UI can properly display which adapter is providing each service, avoiding confusion when multiple adapters provide the same service type.

## Test plan
- [x] Updated API endpoint logic
- [ ] Deploy to agents.ciris.ai
- [ ] Verify system status page shows adapter-specific names

🤖 Generated with [Claude Code](https://claude.ai/code)