### PR TITLE
fix: Show adapter-specific service names in system status

### DIFF
--- a/BUILD_INFO.txt
+++ b/BUILD_INFO.txt
@@ -1,7 +1,7 @@
 # Build Information
-Code Hash: bb2c8fc43834
-Build Time: 2025-07-17T16:08:52.426194
-Git Commit: df9427b34101a80e94b28b8498d1d4daf8354cb6
+Code Hash: 7510470bf4b3
+Build Time: 2025-07-17T16:17:23.263894
+Git Commit: 4176a47536bea39628796d2832b5ee8cd4399d23
 Git Branch: main
 
 This hash is a SHA-256 of all Python source files in the repository.

--- a/ciris_engine/logic/adapters/api/routes/system.py
+++ b/ciris_engine/logic/adapters/api/routes/system.py
@@ -468,8 +468,18 @@ async def get_services_status(
             # Handle registry services (format: registry.ServiceType.ENUM.ServiceName_id)
             elif service_key.startswith('registry.') and len(parts) >= 3:
                 source = parts[0]  # 'registry'
-                service_type_enum = parts[1]  # 'ServiceType.COMMUNICATION', etc.
-                service_name = parts[2]  # 'APICommunicationService_127803015745648', etc.
+                
+                # Handle both 3-part and 4-part keys
+                if len(parts) >= 4 and parts[1] == 'ServiceType':
+                    # Format: registry.ServiceType.ENUM.ServiceName_id
+                    service_type_enum = f"{parts[1]}.{parts[2]}"  # 'ServiceType.TOOL'
+                    service_name = parts[3]  # 'APIToolService_127803015745648'
+                    logger.debug(f"4-part key: {service_key}, service_name: {service_name}")
+                else:
+                    # Fallback: registry.ENUM.ServiceName
+                    service_type_enum = parts[1]  # 'ServiceType.COMMUNICATION', etc.
+                    service_name = parts[2]  # Service name or enum value
+                    logger.debug(f"3-part key: {service_key}, service_name: {service_name}")
                 
                 # Clean up service name (remove instance ID)
                 original_service_name = service_name


### PR DESCRIPTION
## Summary
- Fixes API route to correctly parse 4-part service keys
- Services now display with adapter prefixes (DISCORD-TOOL, API-TOOL, etc.)

## Problem
The system status page was showing duplicate service names like multiple 'TOOL' or 'WISE' entries without indicating which adapter provided them.

## Solution  
Updated the service key parsing in  endpoint to:
1. Handle the actual 4-part key format: `registry.ServiceType.ENUM.ServiceName_id`
2. Extract adapter type from service class names (e.g., APIToolService -> API)
3. Create prefixed display names (e.g., API-TOOL, DISCORD-WISE)

## Result
Services now clearly show which adapter provides them:
- API-COMM, API-TOOL
- DISCORD-COMM, DISCORD-TOOL, DISCORD-WISE

🤖 Generated with [Claude Code](https://claude.ai/code)