### PR TITLE
fix: Database retry logic and CI improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,7 @@ jobs:
       # Commit BUILD_INFO.txt if on main branch (only in repos without branch protection)
       - name: Commit version info
         if: github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository != 'CIRISai/CIRISAgent'
+        continue-on-error: true  # Don't fail the workflow if commit fails
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
@@ -103,8 +104,14 @@ jobs:
               echo "BUILD_INFO.txt has not changed, skipping commit"
             else
               git commit -m "chore: Update BUILD_INFO.txt [skip ci]"
-              git push
-              echo "BUILD_INFO.txt has been committed"
+              # Try to push, but don't fail if it doesn't work (e.g., in forks)
+              if git push; then
+                echo "BUILD_INFO.txt has been committed"
+              else
+                echo "::warning::Could not push BUILD_INFO.txt (this is normal in forks or with restricted permissions)"
+                echo "BUILD_INFO.txt changes:"
+                git show --name-status
+              fi
             fi
           else
             echo "BUILD_INFO.txt was not created"
@@ -135,6 +142,6 @@ jobs:
             if [[ "${{ github.repository }}" == "CIRISai/CIRISAgent" ]]; then
               echo "- 📝 Version info generated (not committed due to branch protection)" >> $GITHUB_STEP_SUMMARY
             else
-              echo "- 📝 Version info updated in BUILD_INFO.txt" >> $GITHUB_STEP_SUMMARY
+              echo "- 📝 Version info commit attempted (may be skipped in forks)" >> $GITHUB_STEP_SUMMARY
             fi
           fi

--- a/BUILD_INFO.txt
+++ b/BUILD_INFO.txt
@@ -1,7 +1,7 @@
 # Build Information
 Code Hash: 7364650d14ec
-Build Time: 2025-07-18T13:25:22.330287
-Git Commit: 3cd92c67b5b714da4fd711dd96987402f88796b3
+Build Time: 2025-07-18T14:21:01.301259
+Git Commit: 32d180e852da6922799fac785875a8872149bf3c
 Git Branch: main
 
 This hash is a SHA-256 of all Python source files in the repository.

--- a/ciris_engine/logic/adapters/discord/adapter.py
+++ b/ciris_engine/logic/adapters/discord/adapter.py
@@ -587,8 +587,11 @@ class DiscordPlatform(Service):
                 await self._discord_client_task
             except asyncio.CancelledError:
                 logger.info("DiscordPlatform: Discord client task successfully cancelled.")
-                # Don't re-raise during stop - we're already shutting down
-                pass  # NOSONAR: Intentionally not re-raising during shutdown
+                # Only re-raise if our current task is being cancelled
+                current_task = asyncio.current_task()
+                if current_task and current_task.cancelled():
+                    raise
+                # Otherwise, we're in normal shutdown - don't propagate the cancellation
 
         logger.info("DiscordPlatform: Stopped.")
     

--- a/ciris_engine/logic/persistence/db/core.py
+++ b/ciris_engine/logic/persistence/db/core.py
@@ -1,6 +1,7 @@
 import sqlite3
 import logging
-from typing import Optional
+import time
+from typing import Optional, Any, Union
 from datetime import datetime
 from ciris_engine.logic.config.db_paths import get_sqlite_db_full_path
 from ciris_engine.schemas.persistence.tables import (
@@ -16,6 +17,7 @@ from ciris_engine.schemas.persistence.tables import (
     WA_CERT_TABLE_V1 as wa_cert_table_v1,
 )
 from .migration_runner import run_migrations
+from .retry import is_retryable_error, DEFAULT_MAX_RETRIES, DEFAULT_BASE_DELAY, DEFAULT_MAX_DELAY
 
 logger = logging.getLogger(__name__)
 
@@ -44,15 +46,106 @@ def _ensure_adapters_registered() -> None:
         _adapters_registered = True
 
 
-def get_db_connection(db_path: Optional[str] = None, busy_timeout: Optional[int] = None) -> sqlite3.Connection:
+class RetryConnection:
+    """SQLite connection wrapper with automatic retry on write operations."""
+    
+    # SQL commands that modify data
+    WRITE_COMMANDS = {'INSERT', 'UPDATE', 'DELETE', 'CREATE', 'DROP', 'ALTER', 'REPLACE'}
+    
+    def __init__(self, conn: sqlite3.Connection, 
+                 max_retries: int = DEFAULT_MAX_RETRIES,
+                 base_delay: float = DEFAULT_BASE_DELAY,
+                 max_delay: float = DEFAULT_MAX_DELAY,
+                 enable_retry: bool = True):
+        self._conn = conn
+        self._max_retries = max_retries
+        self._base_delay = base_delay
+        self._max_delay = max_delay
+        self._enable_retry = enable_retry
+    
+    def _is_write_operation(self, sql: str) -> bool:
+        """Check if SQL command is a write operation."""
+        if not sql:
+            return False
+        # Get first word of SQL command
+        first_word = sql.strip().split()[0].upper()
+        return first_word in self.WRITE_COMMANDS
+    
+    def _retry_execute(self, method_name: str, *args: Any, **kwargs: Any) -> Any:
+        """Execute with retry logic for write operations."""
+        # Check if this is a write operation
+        sql = args[0] if args else kwargs.get('sql', '')
+        is_write = self._is_write_operation(sql)
+        
+        # If retry is disabled or this is not a write operation, execute directly
+        if not self._enable_retry or not is_write:
+            method = getattr(self._conn, method_name)
+            return method(*args, **kwargs)
+        
+        # Retry logic for write operations
+        last_error = None
+        for attempt in range(self._max_retries + 1):
+            try:
+                method = getattr(self._conn, method_name)
+                return method(*args, **kwargs)
+            except Exception as e:
+                if not is_retryable_error(e) or attempt == self._max_retries:
+                    raise
+                
+                last_error = e
+                delay = min(self._base_delay * (2 ** attempt), self._max_delay)
+                
+                logger.debug(
+                    f"Database busy on write operation (attempt {attempt + 1}/{self._max_retries + 1}), "
+                    f"retrying in {delay:.2f}s: {e}"
+                )
+                
+                time.sleep(delay)
+        
+        # Should not reach here
+        raise last_error if last_error else RuntimeError("Unexpected retry loop exit")
+    
+    def execute(self, *args: Any, **kwargs: Any) -> sqlite3.Cursor:
+        """Execute SQL with retry for write operations."""
+        return self._retry_execute('execute', *args, **kwargs)
+    
+    def executemany(self, *args: Any, **kwargs: Any) -> sqlite3.Cursor:
+        """Execute many SQL statements with retry for write operations."""
+        return self._retry_execute('executemany', *args, **kwargs)
+    
+    def executescript(self, *args: Any, **kwargs: Any) -> sqlite3.Cursor:
+        """Execute SQL script with retry."""
+        # Scripts may contain multiple operations, so always retry
+        if not self._enable_retry:
+            return self._conn.executescript(*args, **kwargs)
+        return self._retry_execute('executescript', *args, **kwargs)
+    
+    def __getattr__(self, name: str) -> Any:
+        """Delegate all other attributes to the underlying connection."""
+        return getattr(self._conn, name)
+    
+    def __enter__(self) -> 'RetryConnection':
+        """Context manager entry."""
+        self._conn.__enter__()
+        return self
+    
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> Any:
+        """Context manager exit."""
+        return self._conn.__exit__(exc_type, exc_val, exc_tb)
+
+
+def get_db_connection(db_path: Optional[str] = None, busy_timeout: Optional[int] = None, 
+                     enable_retry: bool = True) -> Union[sqlite3.Connection, RetryConnection]:
     """Establishes a connection to the SQLite database with foreign key support.
     
     Args:
         db_path: Optional path to database file
         busy_timeout: Optional busy timeout in milliseconds (e.g., 5000 for 5 seconds)
+        enable_retry: Enable automatic retry for write operations (default: True)
     
     Returns:
-        SQLite connection with row factory and foreign keys enabled
+        SQLite connection with row factory and foreign keys enabled.
+        By default, returns a RetryConnection that automatically retries write operations.
     """
     # Ensure adapters are registered before creating connection
     _ensure_adapters_registered()
@@ -63,9 +156,19 @@ def get_db_connection(db_path: Optional[str] = None, busy_timeout: Optional[int]
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA foreign_keys = ON;")
     
-    # Set busy timeout if specified
+    # Enable WAL mode for better concurrency
+    conn.execute("PRAGMA journal_mode=WAL;")
+    
+    # Set busy timeout if specified (also used as a fallback)
     if busy_timeout is not None:
         conn.execute(f"PRAGMA busy_timeout = {busy_timeout};")
+    else:
+        # Default 5 second busy timeout as a fallback
+        conn.execute("PRAGMA busy_timeout = 5000;")
+    
+    # Return wrapped connection with retry logic by default
+    if enable_retry:
+        return RetryConnection(conn)
     
     return conn
 


### PR DESCRIPTION
## Summary

This PR fixes the failing `test_concurrent_write_serialization` test and improves CI handling for forks.

## Changes

### 1. Database Retry Logic
- Added `RetryConnection` wrapper class that automatically retries write operations
- Modified `get_db_connection()` to return `RetryConnection` by default
- Only write operations (INSERT, UPDATE, DELETE, etc.) are retried - reads remain fast
- Enabled WAL mode and default busy timeout for better concurrency
- Fixes concurrent write test failures without modifying 80+ call sites

### 2. GitHub Actions Improvements
- Added `continue-on-error` to version commit step
- Improved error handling for git push failures in forks
- Changed failures to warnings with clear messages

### 3. Discord Adapter Fix
- Properly handle `asyncio.CancelledError` in stop method
- Only re-raise if current task is being cancelled

## Test Results
- ✅ `test_concurrent_write_serialization` now passes
- ✅ All persistence tests pass
- ✅ All authentication tests pass
- ✅ Critical test suites verified

## Impact
The retry logic is transparent to existing code - all database operations automatically benefit from retry protection on write operations without any code changes needed across the 43k line codebase.

🤖 Generated with [Claude Code](https://claude.ai/code)