### PR TITLE
fix: GUI TypeScript build errors

### DIFF
--- a/CIRISGUI/apps/agui/app/config/page.tsx
+++ b/CIRISGUI/apps/agui/app/config/page.tsx
@@ -58,8 +58,9 @@ interface ConfigItem {
   key: string;
   value: any;
   updated_at: string;
-  updated_by: string;
-  is_sensitive: boolean;
+  updated_by?: string;
+  is_sensitive?: boolean;
+  description?: string;
 }
 
 interface ConfigSection {


### PR DESCRIPTION
Fixes TypeScript errors preventing GUI Docker build:
- Handle undefined sectionName in config page  
- Make ConfigItem fields optional to match API response

These were blocking deployment.