### PR TITLE
fix: Correct AdapterInfo config field name

### DIFF
--- a/CIRISGUI/apps/agui/app/config/page.tsx
+++ b/CIRISGUI/apps/agui/app/config/page.tsx
@@ -182,7 +182,7 @@ export default function ConfigPage() {
           if (
             !adapter.adapter_id.toLowerCase().includes(searchLower) &&
             !adapter.adapter_type.toLowerCase().includes(searchLower) &&
-            !JSON.stringify(adapter.config_params).toLowerCase().includes(searchLower)
+            !JSON.stringify(adapter.config || {}).toLowerCase().includes(searchLower)
           ) {
             return;
           }


### PR DESCRIPTION
Fixes TypeScript error in GUI build - use 'config' not 'config_params'