### PR TITLE
fix: Lowercase Docker repository for GUI image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,8 +122,8 @@ jobs:
           file: ./docker/gui/Dockerfile
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/ciris-gui:latest
-            ghcr.io/${{ github.repository_owner }}/ciris-gui:${{ github.sha }}
+            ghcr.io/cirisai/ciris-gui:latest
+            ghcr.io/cirisai/ciris-gui:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Fixes GUI Docker build failure by using lowercase repository owner.

Docker requires all repository names to be lowercase, but github.repository_owner returns 'CIRISAI' in uppercase.

This hardcodes the lowercase version to fix the build.