### PR TITLE
fix: OAuth callback User type mismatch

### DIFF
--- a/CIRISGUI/apps/agui/app/oauth/callback/page.tsx
+++ b/CIRISGUI/apps/agui/app/oauth/callback/page.tsx
@@ -38,17 +38,13 @@ export default function OAuthCallbackPage() {
       // Extract provider from state (we'll encode it in the state parameter)
       const provider = state.split(':')[0];
       
-      const response = await cirisClient.auth.handleOAuthCallback(provider, code, state);
+      const user = await cirisClient.auth.handleOAuthCallback(provider, code, state);
       
       // Set the authentication state
-      setUser(response);
-      setToken(response.access_token);
+      setUser(user);
       
-      // Store token for future requests
-      if (typeof window !== 'undefined') {
-        localStorage.setItem('authToken', response.access_token);
-        localStorage.setItem('user', JSON.stringify(response));
-      }
+      // The handleOAuthCallback method already stores the token internally
+      // No need to manually set token or localStorage as the SDK handles it
       
       // Redirect to dashboard
       router.push('/dashboard');


### PR DESCRIPTION
Fixes GUI TypeScript build error in OAuth callback page.

The handleOAuthCallback method returns a User object, not a LoginResponse with access_token.
The SDK already handles token storage internally via AuthStore.

This removes the incorrect access_token reference and simplifies the OAuth flow.