### PR TITLE
fix: ResourceUsage type structure in GUI

### DIFF
--- a/CIRISGUI/apps/agui/app/system/page.tsx
+++ b/CIRISGUI/apps/agui/app/system/page.tsx
@@ -347,7 +347,7 @@ export default function SystemPage() {
               <div className="bg-gray-50 px-4 py-5 sm:p-6 rounded-lg border-2 border-gray-200">
                 <dt className="text-sm font-medium text-gray-500">Memory Usage</dt>
                 <dd className="mt-2 text-2xl font-semibold text-gray-900">
-                  {resources?.current_usage?.memory_mb ? `${resources.current_usage.memory_mb.toFixed(1)} MB` : 'N/A'}
+                  {resources?.memory_mb ? `${resources.memory_mb.toFixed(1)} MB` : 'N/A'}
                 </dd>
               </div>
               


### PR DESCRIPTION
Fixes GUI TypeScript build error in system page.

The ResourceUsage interface is flat (memory_mb is a direct property), not nested under current_usage.

This final fix should allow the GUI Docker image to build successfully and enable deployment.