### PR TITLE
fix: Add missing role type exports

### DIFF
--- a/CIRISGUI/apps/agui/lib/ciris-sdk/types.ts
+++ b/CIRISGUI/apps/agui/lib/ciris-sdk/types.ts
@@ -1,11 +1,15 @@
 // CIRIS TypeScript SDK - Type Definitions
 // Mirrors the Python SDK models for consistency
 
+// Role Types
+export type APIRole = 'OBSERVER' | 'ADMIN' | 'AUTHORITY' | 'SYSTEM_ADMIN';
+export type WARole = 'OBSERVER' | 'ADMIN' | 'AUTHORITY';
+
 // Base Types
 export interface User {
   user_id: string;
   username: string;
-  role: 'OBSERVER' | 'ADMIN' | 'AUTHORITY' | 'SYSTEM_ADMIN';
+  role: APIRole;
   permissions: string[];
   created_at: string;
   last_login?: string;


### PR DESCRIPTION
The GUI users page imports APIRole and WARole types but they weren't defined in the SDK.

Added the type definitions and updated User interface to use APIRole type.

This should fix the final TypeScript build error.