### PR TITLE
fix: Change ORACLE to AUTHORITY role

### DIFF
--- a/CIRISGUI/apps/agui/app/api-demo/page.tsx
+++ b/CIRISGUI/apps/agui/app/api-demo/page.tsx
@@ -493,12 +493,12 @@ export default function ApiDemoPage() {
           endpoint: 'POST /v1/users/{userId}/mint-wa',
           method: 'POST' as const,
           execute: () => cirisClient.users.mintWiseAuthority('demo_user', {
-            wa_role: 'ORACLE',
+            wa_role: 'AUTHORITY',
             signature: 'ed25519_signature_here'
           }),
           params: {
             userId: 'demo_user',
-            wa_role: 'ORACLE',
+            wa_role: 'AUTHORITY',
             signature: 'ed25519_signature_here'
           }
         }


### PR DESCRIPTION
WARole type only includes OBSERVER, ADMIN, AUTHORITY.
Changed ORACLE references to AUTHORITY in the API demo page.

This is the absolute final fix for GUI TypeScript errors.