### PR TITLE
fix: Remove root role and fix case

### DIFF
--- a/CIRISGUI/apps/agui/app/users/page-full.tsx
+++ b/CIRISGUI/apps/agui/app/users/page-full.tsx
@@ -80,9 +80,7 @@ export default function UsersPage() {
 
   const getWARoleBadgeColor = (role: WARole) => {
     switch (role) {
-      case 'root':
-        return 'bg-red-100 text-red-800 ring-2 ring-red-600';
-      case 'authority':
+      case 'AUTHORITY':
         return 'bg-purple-100 text-purple-800 ring-2 ring-purple-600';
       default:
         return 'bg-green-100 text-green-800';


### PR DESCRIPTION
Fixed role case issues in users page:
- Removed 'root' case (not in WARole)
- Changed 'authority' to 'AUTHORITY' to match type definition

WARole = OBSERVER  < /dev/null |  ADMIN | AUTHORITY (all uppercase)