### PR TITLE
fix: Remove invalid sha prefix in Docker tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,11 +96,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/ciris-agent
+          images: ghcr.io/cirisai/ciris-agent
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix={{branch}}-
+            type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image

--- a/CIRISGUI/apps/agui/app/users/page-full.tsx
+++ b/CIRISGUI/apps/agui/app/users/page-full.tsx
@@ -92,11 +92,11 @@ export default function UsersPage() {
       <div className="px-4 sm:px-6 lg:px-8">
         <div className="sm:flex sm:items-center">
           <div className="sm:flex-auto">
-              <h1 className="text-2xl font-semibold text-gray-900">User Management</h1>
-              <p className="mt-2 text-sm text-gray-700">
-                Manage users, roles, and Wise Authority assignments
-              </p>
-            </div>
+            <h1 className="text-2xl font-semibold text-gray-900">User Management</h1>
+            <p className="mt-2 text-sm text-gray-700">
+              Manage users, roles, and Wise Authority assignments
+            </p>
+          </div>
             <div className="mt-4 sm:mt-0 sm:ml-16 sm:flex-none space-x-2">
               {hasRole('SYSTEM_ADMIN') && (
                 <>


### PR DESCRIPTION
## Summary
- Fixed Docker tag generation in GitHub Actions that was causing build failures
- Removed 'prefix={{branch}}-' from sha tag type that was creating invalid tags like '-168f212'
- Also hardcoded repository owner to 'cirisai' to ensure lowercase

## Issue
The Docker build was failing with:
```
ERROR: failed to build: invalid tag "ghcr.io/cirisai/ciris-agent:-168f212": invalid reference format
```

This was caused by the metadata action generating invalid tags when the branch name was empty or improperly parsed.

## Solution
- Changed `type=sha,prefix={{branch}}-` to `type=sha`
- Changed `ghcr.io/${{ github.repository_owner }}/ciris-agent` to `ghcr.io/cirisai/ciris-agent`

This ensures all generated tags are valid Docker tag formats.

🤖 Generated with [Claude Code](https://claude.ai/code)