### PR TITLE
chore: Trigger build after GHCR permissions fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
 name: Build and Deploy
+# GitHub Container Registry permissions fixed in org settings
 
 on:
   push:


### PR DESCRIPTION
## Summary
This PR adds a comment to trigger a new build after fixing GitHub Container Registry permissions in the organization settings.

## Context
Previous builds were failing with:
```
ERROR: failed to push ghcr.io/cirisai/ciris-agent:main: 403 Forbidden
```

## Solution
Organization package permissions have been updated to allow members to create public packages. This build should now succeed in pushing Docker images to ghcr.io.

🤖 Generated with [Claude Code](https://claude.ai/code)