### PR TITLE
fix: Add missing @radix-ui/react-accordion dependency

### DIFF
--- a/CIRISGUI/apps/agui/package.json
+++ b/CIRISGUI/apps/agui/package.json
@@ -12,6 +12,7 @@
     "@headlessui/react": "^2.2.4",
     "@heroicons/react": "^2.2.0",
     "@phosphor-icons/react": "^2.1.10",
+    "@radix-ui/react-accordion": "^1.2.1",
     "@tailwindcss/postcss": "^4.1.11",
     "@tanstack/react-query": "^5.0.0",
     "axios": "^1.6.0",


### PR DESCRIPTION
## Summary
Fixes GUI Docker build failure by adding missing npm dependency.

## Issue
The GUI build was failing with:
```
Type error: Cannot find module '@radix-ui/react-accordion' or its corresponding type declarations.
```

## Solution
Added `@radix-ui/react-accordion` to the dependencies in `CIRISGUI/apps/agui/package.json`.

This dependency is imported by `components/ui/Accordion.tsx` but was missing from package.json.

🤖 Generated with [Claude Code](https://claude.ai/code)