### PR TITLE
fix: Update nginx to use host networking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ This ensures type safety, validation, and clear contracts throughout the system.
    - Use `disallow_any_explicit = True` to catch Dict[str, Any]
    - Run mypy as part of CI/CD pipeline
 
-## Current Status (July 18, 2025)
+## Current Status (July 19, 2025)
 
 ### 🎉 Major Achievements
 
@@ -147,6 +147,34 @@ This ensures type safety, validation, and clear contracts throughout the system.
    - Fixed SQLite datetime adapter warnings
    - All SDK endpoint tests passing
    - CI/CD runs tests in Docker for consistency
+
+## Recent Achievements (July 2025)
+
+### Infrastructure Improvements (July 19, 2025)
+1. **Containerized Nginx**
+   - Replaced standalone nginx service with containerized version
+   - Supports both dev (single agent) and production (multi-agent) configurations
+   - Per-agent OAuth callback paths: `/oauth/{agent}/callback`
+   - Default API route: `/v1/` → Datum agent
+   - Agent-specific routes: `/api/{agent}/v1/*`
+
+2. **Shared OAuth Configuration**
+   - OAuth config now in shared volume: `/home/ciris/shared/oauth`
+   - All agents can mount and share OAuth credentials
+   - Migration script for existing configurations
+   - Google OAuth already configured in production
+
+3. **CI/CD Improvements**
+   - Fixed fork PR builds - they now build without pushing
+   - Only same-repo PRs and main branch push to registry
+   - Build summary shows what action was taken
+   - Prevents "installation not allowed to Write" errors
+
+4. **GUI Fixes**
+   - Fixed ResourceUsage SDK type to match nested API response
+   - Resource metrics now display correctly in System page
+   - Per-agent OAuth callback support in GUI
+   - Dynamic callback URL generation based on selected agent
 
 ## Recent Achievements (July 2025)
 

--- a/deployment/docker-compose.dev-prod.yml
+++ b/deployment/docker-compose.dev-prod.yml
@@ -5,9 +5,7 @@ services:
   nginx:
     image: ciris-nginx:latest  # Will be pulled from ghcr.io and tagged locally
     container_name: ciris-nginx
-    ports:
-      - "80:80"
-      - "443:443"
+    network_mode: host  # Use host network to access containers on bridge
     volumes:
       # SSL certificates from host
       - /etc/letsencrypt:/etc/letsencrypt:ro
@@ -16,8 +14,6 @@ services:
       - ciris-gui
       - agent-datum
     restart: unless-stopped
-    networks:
-      - ciris-network
   # Development: Single Datum agent with Mock LLM for testing
   agent-datum:
     image: ciris-agent:latest  # Will be pulled from ghcr.io and tagged locally

--- a/deployment/nginx/agents.ciris.ai-dev.conf
+++ b/deployment/nginx/agents.ciris.ai-dev.conf
@@ -2,11 +2,11 @@
 # Single Datum agent with GUI
 
 upstream datum {
-    server agent-datum:8080;
+    server 127.0.0.1:8080;
 }
 
 upstream ciris_gui {
-    server ciris-gui:3000;
+    server 127.0.0.1:3000;
 }
 
 # Redirect HTTP to HTTPS


### PR DESCRIPTION
## Summary
Fixes nginx container networking issue preventing it from connecting to other containers.

## Problem
- Nginx container couldn't resolve service names like 'agent-datum'
- Containers are on default bridge network, not custom network

## Solution
- Use host network mode for nginx container
- Update nginx config to use localhost instead of service names
- This allows nginx to reach containers exposed on host ports

## Testing
- Nginx container now starts successfully
- Can connect to agent on port 8080 and GUI on port 3000

🤖 Generated with [Claude Code](https://claude.ai/code)