### PR TITLE
fix: Update disk usage to use correct ResourceUsage field

### DIFF
--- a/CIRISGUI/apps/agui/app/system/page.tsx
+++ b/CIRISGUI/apps/agui/app/system/page.tsx
@@ -415,7 +415,7 @@ export default function SystemPage() {
                 <div className="flex justify-between items-center">
                   <span className="text-sm font-medium text-gray-700">Disk Usage</span>
                   <span className="text-lg font-bold text-green-600">
-                    {resources?.disk_usage_gb ? `${resources.disk_usage_gb.toFixed(1)} GB` : 'N/A'}
+                    {resources?.current_usage?.disk_used_mb ? `${(resources.current_usage.disk_used_mb / 1024).toFixed(1)} GB` : 'N/A'}
                   </span>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
Fixes GUI Docker build failure caused by incorrect ResourceUsage field reference.

## Problem
- Build was failing with: "Property 'disk_usage_gb' does not exist on type 'ResourceUsage'"
- This was leftover from the old flat ResourceUsage structure

## Solution
- Updated to use 
- Convert MB to GB for display (divide by 1024)

## Testing
- TypeScript compiles successfully
- Disk usage displays correctly in System page

🤖 Generated with [Claude Code](https://claude.ai/code)