### PR TITLE
fix: Prevent forks from attempting to push to upstream registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.repository == 'CIRISAI/CIRISAgent' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -110,7 +110,7 @@ jobs:
         with:
           context: .
           file: ./docker/agent/Dockerfile
-          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          push: ${{ github.repository == 'CIRISAI/CIRISAgent' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
@@ -122,7 +122,7 @@ jobs:
         with:
           context: ./CIRISGUI
           file: ./docker/gui/Dockerfile
-          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          push: ${{ github.repository == 'CIRISAI/CIRISAgent' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
           tags: |
             ghcr.io/cirisai/ciris-gui:latest
             ghcr.io/cirisai/ciris-gui:${{ github.sha }}
@@ -136,7 +136,7 @@ jobs:
         with:
           context: ./deployment/nginx
           file: ./deployment/nginx/Dockerfile
-          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          push: ${{ github.repository == 'CIRISAI/CIRISAgent' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
           tags: |
             ghcr.io/cirisai/ciris-nginx:latest
             ghcr.io/cirisai/ciris-nginx:${{ github.sha }}
@@ -152,7 +152,9 @@ jobs:
         run: |
           echo "## Build Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ "${{ github.repository }}" != "CIRISAI/CIRISAgent" ]]; then
+            echo "✅ Built images locally (fork - no push)" >> $GITHUB_STEP_SUMMARY
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
               echo "✅ Built images locally (fork PR - no push)" >> $GITHUB_STEP_SUMMARY
             else


### PR DESCRIPTION
## Summary
- Only allow docker push when repository is CIRISAI/CIRISAgent
- Forks running builds on their main branch now build locally only
- Updated build summary to show fork status correctly

## Problem
Fork repositories were failing CI builds because they were trying to push images to ghcr.io/cirisai/* which they don't have permission to access.

## Solution
Added a check to ensure only the upstream repository (CIRISAI/CIRISAgent) attempts to push Docker images. Forks will still build images locally for testing but won't attempt to push them.

## Test Plan
- [x] Fork builds should now pass (build locally only)
- [x] Upstream builds continue to push images as before
- [x] PR builds from forks work correctly (no push)
- [x] PR builds from same repo work correctly (push allowed)

🤖 Generated with [Claude Code](https://claude.ai/code)