### PR TITLE
fix: Make Datum use consistent /api/datum path

### DIFF
--- a/CIRISGUI/apps/agui/config/agents.ts
+++ b/CIRISGUI/apps/agui/config/agents.ts
@@ -13,7 +13,7 @@ export const AGENTS: AgentConfig[] = [
     id: 'datum',
     name: 'Datum',
     description: 'A humble data point that provides singular, focused observations',
-    apiUrl: process.env.NEXT_PUBLIC_DATUM_URL || 'https://agents.ciris.ai',
+    apiUrl: process.env.NEXT_PUBLIC_DATUM_URL || 'https://agents.ciris.ai/api/datum',
     port: 8080,
   },
   {

--- a/deployment/nginx/agents.ciris.ai-dev.conf
+++ b/deployment/nginx/agents.ciris.ai-dev.conf
@@ -45,17 +45,19 @@ server {
         return 204;
     }
 
-    # Main GUI application
-    location / {
-        proxy_pass http://ciris_gui;
+    # Datum API route (for compatibility with multi-agent setup)
+    location ~ ^/api/datum/(.*)$ {
+        proxy_pass http://datum/v1/$1$is_args$args;
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
-        proxy_cache_bypass $http_upgrade;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        
+        # WebSocket support
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_read_timeout 86400;
     }
 
     # Default API endpoint (Datum at root /v1)
@@ -73,19 +75,17 @@ server {
         proxy_read_timeout 86400;
     }
 
-    # Datum API route (for compatibility with multi-agent setup)
-    location ~ ^/api/datum/(.*)$ {
-        proxy_pass http://datum/v1/$1$is_args$args;
+    # Main GUI application
+    location / {
+        proxy_pass http://ciris_gui;
         proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        
-        # WebSocket support
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_read_timeout 86400;
     }
 
     # OAuth Callback Route - Single agent in dev


### PR DESCRIPTION
## Summary
- Updated GUI config to use /api/datum for Datum agent (consistent with other agents)
- Reordered nginx locations to fix routing precedence issues
- OAuth now works through /api/datum/v1/auth/oauth/google/login

## Problem
The Datum agent was configured to use the root path while all other agents use /api/{agent}. This inconsistency broke OAuth when using the expected path pattern.

Additionally, nginx location matching was putting the root / location before /api/datum/, causing all /api/* requests to be routed to the GUI instead of the API.

## Solution
1. Changed Datum's apiUrl from 'https://agents.ciris.ai' to 'https://agents.ciris.ai/api/datum'
2. Moved /api/datum/ location block before the root / location in nginx config

## Test Plan
- [x] OAuth login URL works: /api/datum/v1/auth/oauth/google/login
- [x] Health check works: /api/datum/v1/system/health  
- [x] GUI correctly uses new path for OAuth flow

🤖 Generated with [Claude Code](https://claude.ai/code)