### PR TITLE
fix: Remove duplicate /v1/ in nginx proxy_pass

### DIFF
--- a/deployment/nginx/agents.ciris.ai-dev.conf
+++ b/deployment/nginx/agents.ciris.ai-dev.conf
@@ -47,7 +47,7 @@ server {
 
     # Datum API route (for compatibility with multi-agent setup)
     location ~ ^/api/datum/(.*)$ {
-        proxy_pass http://datum/v1/$1$is_args$args;
+        proxy_pass http://datum/$1$is_args$args;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
Fixes nginx routing for /api/datum/* paths by removing duplicate /v1/ prefix.

## Problem
The nginx configuration was adding an extra /v1/ prefix:
- Request: /api/datum/v1/auth/oauth/google/login
- Regex captures: v1/auth/oauth/google/login
- Proxy passes to: /v1/v1/auth/oauth/google/login (404!)

## Solution
Changed proxy_pass from http://datum/v1/$1 to http://datum/$1

## Test Plan
- [x] /api/datum/v1/system/health returns 200
- [x] /api/datum/v1/auth/oauth/google/login returns OAuth URL

🤖 Generated with [Claude Code](https://claude.ai/code)