### PR TITLE
fix: OAuth callback URLs and staged CD deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -277,11 +277,16 @@ jobs:
             docker tag ghcr.io/cirisai/ciris-gui:latest ciris-gui:latest
             docker tag ghcr.io/cirisai/ciris-nginx:latest ciris-nginx:latest
             
-            # Stop existing containers
-            docker-compose -f deployment/docker-compose.dev-prod.yml down || true
-            
-            # Start development deployment with mock LLM
-            docker-compose -f deployment/docker-compose.dev-prod.yml up -d
+            # Use staged deployment script if available
+            if [ -f "deployment/deploy-staged.sh" ]; then
+              echo "Using staged deployment for zero-downtime update..."
+              chmod +x deployment/deploy-staged.sh
+              ./deployment/deploy-staged.sh
+            else
+              # Fallback to regular deployment
+              docker-compose -f deployment/docker-compose.dev-prod.yml down || true
+              docker-compose -f deployment/docker-compose.dev-prod.yml up -d
+            fi
             
             # Clean up old images
             docker image prune -f


### PR DESCRIPTION
## Summary
- Fix OAuth login endpoints to use dynamic callback URLs
- Remove hardcoded localhost:3000 URLs that were breaking production OAuth
- Update CD workflow to use staged deployment for zero-downtime updates

## Changes
1. **OAuth Fixes**:
   - OAuth login now uses OAUTH_CALLBACK_BASE_URL env var or constructs from request
   - Fixed GitHub OAuth callback to use same dynamic URL pattern
   - All OAuth providers now redirect to /oauth/datum/callback consistently

2. **CD Deployment Fix**:
   - Workflow now uses deploy-staged.sh script when available
   - Prevents container name conflicts
   - Enables zero-downtime deployments

## Testing
- Manual cleanup performed on production
- Ready for deployment through CD pipeline