### PR TITLE
fix: Remove .ciris_keys file creation from Dockerfile

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -35,12 +35,10 @@ COPY --from=builder /root/.local /home/ciris/.local
 # Copy application code
 COPY --chown=ciris:ciris . .
 
-# Create necessary directories and files with proper permissions
+# Create necessary directories with proper permissions
 RUN mkdir -p /app/data /app/logs && \
-    touch /app/.ciris_keys && \
-    chown -R ciris:ciris /app/data /app/logs /app/.ciris_keys && \
-    chmod 750 /app/data /app/logs && \
-    chmod 600 /app/.ciris_keys
+    chown -R ciris:ciris /app/data /app/logs && \
+    chmod 750 /app/data /app/logs
 
 # Switch to non-root user
 USER ciris


### PR DESCRIPTION
## Summary
This PR fixes the container startup error that was preventing the agent from running.

## Problem
The Dockerfile was creating `.ciris_keys` as a **file** using `touch`, but the application code expects it to be a **directory**. This caused the error:
```
[Errno 17] File exists: '.ciris_keys'
```

## Solution
Removed the file creation from the Dockerfile. The application will now create the directory structure it needs on startup.

## Testing
- Built and tested the image locally
- Verified the container starts without the file exists error
- Confirmed the application creates the `.ciris_keys` directory as expected

This is a critical fix needed to restore production functionality.