### PR TITLE
chore: Trigger rebuild with fixed .ciris_keys handling

### DIFF
--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -36,6 +36,7 @@ COPY --from=builder /root/.local /home/ciris/.local
 COPY --chown=ciris:ciris . .
 
 # Create necessary directories with proper permissions
+# Note: .ciris_keys directory will be copied from repo if it exists
 RUN mkdir -p /app/data /app/logs && \
     chown -R ciris:ciris /app/data /app/logs && \
     chmod 750 /app/data /app/logs


### PR DESCRIPTION
## Summary
- Adds clarifying comment to Dockerfile about .ciris_keys directory handling
- Triggers new Docker image build with the previous fix already merged

## Context
The previous fix removing `touch .ciris_keys` was merged but the Docker images weren't rebuilt. This PR triggers a new build with:
1. No file creation in Dockerfile (already fixed)
2. Proper copying of .ciris_keys directory from repository
3. Preservation of encryption keys for Datum agent

## Test plan
- [ ] CI/CD will build new Docker images
- [ ] Images will NOT contain a .ciris_keys file
- [ ] The .ciris_keys directory from repo will be properly copied
- [ ] Container should start without "File exists" error

🤖 Generated with [Claude Code](https://claude.ai/code)