### PR TITLE
fix: Update OAuth callback URLs to include agent name and provider

### DIFF
--- a/ciris_engine/logic/adapters/api/routes/auth.py
+++ b/ciris_engine/logic/adapters/api/routes/auth.py
@@ -33,7 +33,7 @@ from ciris_engine.schemas.runtime.api import APIRole
 OAUTH_CONFIG_DIR = ".ciris"
 OAUTH_CONFIG_FILE = "oauth.json"
 PROVIDER_NAME_DESC = "Provider name"
-OAUTH_CALLBACK_PATH = "/oauth/datum/callback"
+OAUTH_CALLBACK_PATH = "/v1/auth/oauth/datum/{provider}/callback"
 DEFAULT_OAUTH_BASE_URL = "https://agents.ciris.ai"
 
 from ..dependencies.auth import (

--- a/deployment/nginx/agents.ciris.ai-dev.conf
+++ b/deployment/nginx/agents.ciris.ai-dev.conf
@@ -91,8 +91,8 @@ server {
     }
 
     # OAuth Callback Route - Single agent in dev
-    location ~ ^/oauth/datum/callback$ {
-        proxy_pass http://datum/v1/auth/oauth/callback$is_args$args;
+    location ~ ^/v1/auth/oauth/datum/(\w+)/callback$ {
+        proxy_pass http://datum/v1/auth/oauth/$1/callback$is_args$args;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
- Change OAuth callback path to include both agent name and provider
- Update nginx routing to handle the new callback URL pattern
- Fix redirect_uri_mismatch error with Google OAuth

## Problem
The OAuth callback URL was using `/oauth/datum/callback` but:
1. Google OAuth console expects a different URL
2. The pattern doesn't support multiple OAuth providers (discord, github)
3. Multi-agent deployments need the agent name in the URL

## Solution
Updated the callback URL pattern to:
`/v1/auth/oauth/{agent}/{provider}/callback`

Example URLs:
- Google: `https://agents.ciris.ai/v1/auth/oauth/datum/google/callback`
- Discord: `https://agents.ciris.ai/v1/auth/oauth/datum/discord/callback`
- GitHub: `https://agents.ciris.ai/v1/auth/oauth/datum/github/callback`

Nginx now routes these to the correct API endpoint: `/v1/auth/oauth/{provider}/callback`

## Test plan
- [x] Update Google OAuth console redirect URI
- [ ] Test OAuth login flow works after deployment
- [ ] Verify callback URL is correctly generated

🤖 Generated with [Claude Code](https://claude.ai/code)