### PR TITLE
CRITICAL: Fix deployment and OAuth callback issues

### DIFF
--- a/ciris_engine/logic/adapters/api/routes/auth.py
+++ b/ciris_engine/logic/adapters/api/routes/auth.py
@@ -386,7 +386,7 @@ async def oauth_login(
             # Construct from request headers
             base_url = f"{request.url.scheme}://{request.headers.get('host', 'localhost')}"
         
-        callback_url = redirect_uri or f"{base_url}{OAUTH_CALLBACK_PATH}"
+        callback_url = redirect_uri or f"{base_url}{OAUTH_CALLBACK_PATH.replace('{provider}', provider)}"
         
         # Build authorization URL based on provider
         if provider == "google":
@@ -484,7 +484,7 @@ async def oauth_callback(
                         "code": code,
                         "client_id": client_id,
                         "client_secret": client_secret,
-                        "redirect_uri": os.getenv("OAUTH_CALLBACK_BASE_URL", DEFAULT_OAUTH_BASE_URL) + OAUTH_CALLBACK_PATH,
+                        "redirect_uri": os.getenv("OAUTH_CALLBACK_BASE_URL", DEFAULT_OAUTH_BASE_URL) + OAUTH_CALLBACK_PATH.replace('{provider}', provider),
                         "grant_type": "authorization_code"
                     }
                 )
@@ -576,7 +576,7 @@ async def oauth_callback(
                         "code": code,
                         "client_id": client_id,
                         "client_secret": client_secret,
-                        "redirect_uri": os.getenv("OAUTH_CALLBACK_BASE_URL", DEFAULT_OAUTH_BASE_URL) + OAUTH_CALLBACK_PATH,
+                        "redirect_uri": os.getenv("OAUTH_CALLBACK_BASE_URL", DEFAULT_OAUTH_BASE_URL) + OAUTH_CALLBACK_PATH.replace('{provider}', provider),
                         "grant_type": "authorization_code"
                     }
                 )

--- a/deployment/deploy-staged.sh
+++ b/deployment/deploy-staged.sh
@@ -192,6 +192,8 @@ else
     AGENT_ENV=$(docker inspect "$AGENT_CONTAINER" --format='{{range .Config.Env}}{{println .}}{{end}}' | grep -E '^(DISCORD_|OPENAI_|ANTHROPIC_|CIRIS_|OAUTH_)' | sed 's/^/-e /')
     AGENT_VOLUMES=$(docker inspect "$AGENT_CONTAINER" --format='{{range .Mounts}}{{if eq .Type "volume"}}-v {{.Name}}:{{.Destination}} {{end}}{{end}}')
     AGENT_NETWORK=$(docker inspect "$AGENT_CONTAINER" --format='{{range $k, $v := .NetworkSettings.Networks}}{{$k}}{{end}}' | head -1)
+    # Get the command from the running container
+    AGENT_CMD=$(docker inspect "$AGENT_CONTAINER" --format='{{join .Config.Cmd " "}}')
     
     # Create staged container (not running)
     docker create \
@@ -199,7 +201,8 @@ else
         --network "$AGENT_NETWORK" \
         $AGENT_ENV \
         $AGENT_VOLUMES \
-        "ciris-agent:latest"
+        "ciris-agent:latest" \
+        $AGENT_CMD
     
     log "Staged container created. Monitoring current agent for graceful exit..."
     


### PR DESCRIPTION
## CRITICAL PRODUCTION FIXES

This PR fixes two critical issues preventing deployments and OAuth logins:

### 1. Staged deployment missing command arguments
**Problem**: The deploy-staged.sh script was not copying the container command when creating staged containers. This caused containers to start without arguments like `--adapter api --adapter discord --mock-llm`, making them exit immediately.

**Fix**: Added command extraction from the running container:
```bash
AGENT_CMD=$(docker inspect "$AGENT_CONTAINER" --format='{{join .Config.Cmd " "}}')
```

### 2. OAuth callback URL provider placeholder not replaced
**Problem**: The OAUTH_CALLBACK_PATH contains `{provider}` placeholder that wasn't being replaced with the actual provider name, causing redirect_uri_mismatch errors.

**Fix**: Replace the placeholder with the actual provider:
```python
callback_url = redirect_uri or f"{base_url}{OAUTH_CALLBACK_PATH.replace('{provider}', provider)}"
```

## Impact
- Deployments were failing silently with containers exiting on start
- OAuth logins were completely broken with redirect_uri_mismatch errors
- Production has been manually updated with these fixes

## Test plan
- [x] Verify staged deployment copies container command
- [x] Test OAuth login with Google works after fix
- [ ] Merge and deploy through CD pipeline

🤖 Generated with [Claude Code](https://claude.ai/code)