### PR TITLE
fix: Update GUI OAuth callback URL format

### DIFF
--- a/CIRISGUI/apps/agui/app/login/page.tsx
+++ b/CIRISGUI/apps/agui/app/login/page.tsx
@@ -45,7 +45,7 @@ export default function LoginPage() {
       
       // Direct navigation to OAuth login endpoint (no auth required)
       // Use per-agent OAuth callback path
-      const redirectUri = encodeURIComponent(`${window.location.origin}/oauth/${selectedAgent}/callback`);
+      const redirectUri = encodeURIComponent(`${window.location.origin}/v1/auth/oauth/${selectedAgent}/google/callback`);
       const apiUrl = process.env.NODE_ENV === 'development' 
         ? process.env.NEXT_PUBLIC_CIRIS_API_URL || 'http://localhost:8080'
         : agent.apiUrl;


### PR DESCRIPTION
Updates the GUI to use the correct OAuth callback URL format to match the API changes.

Changes from: `/oauth/{agent}/callback`
To: `/v1/auth/oauth/{agent}/google/callback`

This fixes the redirect_uri_mismatch error when logging in with Google OAuth.

🤖 Generated with [Claude Code](https://claude.ai/code)