### PR TITLE
CRITICAL: Fix OAuth callback to use GET instead of POST

### DIFF
--- a/ciris_engine/logic/adapters/api/routes/auth.py
+++ b/ciris_engine/logic/adapters/api/routes/auth.py
@@ -437,7 +437,7 @@ async def oauth_login(
         )
 
 
-@router.post("/auth/oauth/{provider}/callback")
+@router.get("/auth/oauth/{provider}/callback")
 async def oauth_callback(
     provider: str,
     code: str,


### PR DESCRIPTION
OAuth providers always use GET for callbacks, not POST. This was causing 'Method Not Allowed' errors.

Changed the OAuth callback endpoint from POST to GET to match OAuth standards.

🤖 Generated with [Claude Code](https://claude.ai/code)