### PR TITLE
fix: Add Suspense wrapper to OAuth callback page for build fix

### DIFF
--- a/CIRISGUI/apps/agui/app/oauth/datum/google/callback/page.tsx
+++ b/CIRISGUI/apps/agui/app/oauth/datum/google/callback/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, Suspense } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { useAuth } from '../../../../../contexts/AuthContext';
 
-export default function GoogleOAuthCallbackPage() {
+function GoogleOAuthCallbackContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const { setUser, setToken } = useAuth();
@@ -48,5 +48,19 @@ export default function GoogleOAuthCallbackPage() {
         <h2 className="text-3xl font-extrabold text-gray-900">Completing authentication...</h2>
       </div>
     </div>
+  );
+}
+
+export default function GoogleOAuthCallbackPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="text-center">
+          <h2 className="text-3xl font-extrabold text-gray-900">Loading...</h2>
+        </div>
+      </div>
+    }>
+      <GoogleOAuthCallbackContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
This PR fixes the GUI build failure by properly wrapping the OAuth callback page component in Suspense.

## The Issue
The build was failing with a prerender error because the OAuth callback page uses `useSearchParams` which requires client-side rendering.

## The Fix  
Wrapped the component content in a Suspense boundary, following the same pattern used in other dynamic pages in the codebase.

## Testing
Successfully built the GUI Docker image locally:
```
docker build -t test-gui -f ../docker/gui/Dockerfile .
✓ Compiled successfully
✓ Build completed
```

This should finally get our OAuth flow deployed!