### PR TITLE
fix: CIRISManager deployment and installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -311,7 +311,7 @@ jobs:
               echo "Installing CIRISManager..."
               cd /home/ciris/CIRISAgent
               apt-get install -y python3-pip python3-venv
-              pip3 install -e . -f setup_manager.py
+              pip3 install -e . --config-settings editable_mode=compat
             fi
             
             # Create CIRISManager config if it doesn't exist

--- a/ciris_manager/cli.py
+++ b/ciris_manager/cli.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+CIRISManager CLI entry point.
+"""
+import argparse
+import asyncio
+import sys
+import yaml
+from pathlib import Path
+
+from ciris_manager.manager import CIRISManager
+from ciris_manager.config.settings import CIRISManagerConfig
+
+
+def generate_default_config(config_path: str):
+    """Generate a default configuration file."""
+    default_config = {
+        'docker': {
+            'compose_file': '/home/ciris/CIRISAgent/deployment/docker-compose.yml'
+        },
+        'watchdog': {
+            'check_interval': 30,
+            'crash_threshold': 3,
+            'crash_window': 300
+        },
+        'container_management': {
+            'interval': 300,
+            'pull_images': True
+        },
+        'api': {
+            'host': '127.0.0.1',
+            'port': 8888
+        }
+    }
+    
+    Path(config_path).parent.mkdir(parents=True, exist_ok=True)
+    
+    with open(config_path, 'w') as f:
+        yaml.dump(default_config, f, default_flow_style=False)
+    
+    print(f"Generated default configuration at: {config_path}")
+
+
+async def run_manager(config_path: str):
+    """Run the CIRISManager."""
+    try:
+        config = CIRISManagerConfig.from_file(config_path)
+        manager = CIRISManager(config)
+        
+        print(f"Starting CIRISManager...")
+        print(f"Compose file: {config.docker.compose_file}")
+        print(f"Container check interval: {config.container_management.interval}s")
+        print(f"Watchdog interval: {config.watchdog.check_interval}s")
+        
+        await manager.start()
+        
+        # Keep running until interrupted
+        try:
+            while True:
+                await asyncio.sleep(1)
+        except KeyboardInterrupt:
+            print("\nShutting down CIRISManager...")
+            await manager.stop()
+            
+    except Exception as e:
+        print(f"Error running CIRISManager: {e}")
+        sys.exit(1)
+
+
+def main():
+    """Main CLI entry point."""
+    parser = argparse.ArgumentParser(description="CIRIS Container Manager")
+    parser.add_argument(
+        '--config',
+        default='/etc/ciris-manager/config.yml',
+        help='Path to configuration file (default: /etc/ciris-manager/config.yml)'
+    )
+    parser.add_argument(
+        '--generate-config',
+        action='store_true',
+        help='Generate a default configuration file and exit'
+    )
+    
+    args = parser.parse_args()
+    
+    if args.generate_config:
+        generate_default_config(args.config)
+        sys.exit(0)
+    
+    # Check if config exists
+    if not Path(args.config).exists():
+        print(f"Configuration file not found: {args.config}")
+        print(f"Generate one with: ciris-manager --generate-config --config {args.config}")
+        sys.exit(1)
+    
+    # Run the manager
+    try:
+        asyncio.run(run_manager(args.config))
+    except KeyboardInterrupt:
+        print("\nExiting...")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/deployment/deploy-ciris-manager.sh
+++ b/deployment/deploy-ciris-manager.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# Deploy CIRISManager to production
+
+set -e
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+log() { echo -e "${GREEN}[$(date '+%Y-%m-%d %H:%M:%S')]${NC} $1"; }
+warn() { echo -e "${YELLOW}[$(date '+%Y-%m-%d %H:%M:%S')] WARNING:${NC} $1"; }
+error() { echo -e "${RED}[$(date '+%Y-%m-%d %H:%M:%S')] ERROR:${NC} $1"; }
+
+log "Deploying CIRISManager..."
+
+# Step 1: Ensure we're in the right directory
+cd /home/ciris/CIRISAgent || {
+    error "Failed to cd to /home/ciris/CIRISAgent"
+    exit 1
+}
+
+# Step 2: Update repository
+log "Updating repository..."
+git pull origin main || warn "Failed to pull latest changes"
+
+# Step 3: Install Python dependencies
+log "Installing Python dependencies..."
+apt-get update
+apt-get install -y python3-pip python3-venv python3-dev
+
+# Step 4: Create and activate virtual environment
+log "Setting up Python environment..."
+if [ ! -d "venv" ]; then
+    python3 -m venv venv
+fi
+source venv/bin/activate
+
+# Step 5: Install CIRISManager in development mode
+log "Installing CIRISManager..."
+pip install --upgrade pip
+pip install pyyaml aiofiles
+
+# Add ciris_manager to Python path
+export PYTHONPATH="/home/ciris/CIRISAgent:$PYTHONPATH"
+
+# Create wrapper script
+log "Creating ciris-manager wrapper..."
+cat > /usr/local/bin/ciris-manager << 'EOF'
+#!/bin/bash
+cd /home/ciris/CIRISAgent
+export PYTHONPATH="/home/ciris/CIRISAgent:$PYTHONPATH"
+if [ -d "venv" ]; then
+    source venv/bin/activate
+fi
+python3 -m ciris_manager.cli "$@"
+EOF
+chmod +x /usr/local/bin/ciris-manager
+
+# Step 6: Create configuration
+log "Creating CIRISManager configuration..."
+mkdir -p /etc/ciris-manager
+
+if [ ! -f "/etc/ciris-manager/config.yml" ]; then
+    ciris-manager --generate-config --config /etc/ciris-manager/config.yml
+    
+    # Update compose file path
+    sed -i 's|/home/ciris/CIRISAgent/deployment/docker-compose.yml|/home/ciris/CIRISAgent/deployment/docker-compose.dev-prod.yml|' /etc/ciris-manager/config.yml
+    
+    log "Configuration created at /etc/ciris-manager/config.yml"
+else
+    log "Configuration already exists"
+fi
+
+# Step 7: Install systemd service
+log "Installing systemd service..."
+if [ ! -f "/etc/systemd/system/ciris-manager.service" ]; then
+    cp deployment/ciris-manager.service /etc/systemd/system/
+    
+    # Update service file to use wrapper
+    sed -i 's|ExecStart=.*|ExecStart=/usr/local/bin/ciris-manager --config /etc/ciris-manager/config.yml|' /etc/systemd/system/ciris-manager.service
+    
+    systemctl daemon-reload
+    log "Service installed"
+else
+    log "Service already installed"
+    systemctl daemon-reload
+fi
+
+# Step 8: Start containers if not running
+log "Checking container status..."
+if ! docker ps --format "{{.Names}}" | grep -q "ciris-agent-datum"; then
+    log "Starting containers..."
+    docker-compose -f deployment/docker-compose.dev-prod.yml up -d
+else
+    log "Containers already running"
+fi
+
+# Step 9: Enable and start CIRISManager
+log "Starting CIRISManager service..."
+systemctl enable ciris-manager
+systemctl restart ciris-manager
+
+# Wait a moment for service to start
+sleep 2
+
+# Step 10: Check status
+log "Checking service status..."
+if systemctl is-active ciris-manager >/dev/null 2>&1; then
+    echo -e "${GREEN}✓ CIRISManager is active${NC}"
+    systemctl status ciris-manager --no-pager | head -10
+else
+    error "CIRISManager failed to start"
+    journalctl -u ciris-manager -n 20 --no-pager
+    exit 1
+fi
+
+# Step 11: Verify API health
+log "Verifying API health..."
+sleep 5
+if curl -sf http://localhost:8080/v1/system/health >/dev/null; then
+    echo -e "${GREEN}✓ API is healthy${NC}"
+else
+    warn "API health check failed - container may still be starting"
+fi
+
+log "CIRISManager deployment complete!"
+echo ""
+echo "Commands:"
+echo "  systemctl status ciris-manager    # Check service status"
+echo "  journalctl -u ciris-manager -f    # Follow service logs"
+echo "  docker ps                         # Check containers"
+echo ""

--- a/deployment/manual-staged-deploy.sh
+++ b/deployment/manual-staged-deploy.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Manual intervention script for failed staged deployment
+
+set -e
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+log() { echo -e "${GREEN}[$(date '+%Y-%m-%d %H:%M:%S')]${NC} $1"; }
+warn() { echo -e "${YELLOW}[$(date '+%Y-%m-%d %H:%M:%S')] WARNING:${NC} $1"; }
+error() { echo -e "${RED}[$(date '+%Y-%m-%d %H:%M:%S')] ERROR:${NC} $1"; }
+
+# Check current state
+log "Checking current deployment state..."
+
+# List all containers
+echo -e "\nCurrent containers:"
+docker ps -a --format "table {{.Names}}\t{{.Status}}\t{{.Image}}" | grep -E "ciris|NAMES" || true
+
+# Check for staged container
+if docker ps -a --format "{{.Names}}" | grep -q "ciris-agent-datum-staged"; then
+    log "Found staged container waiting for deployment"
+    
+    # Check if old container is still running
+    if docker ps --format "{{.Names}}" | grep -q "ciris-agent-datum"; then
+        warn "Old container is still running"
+        
+        # Ask for confirmation
+        echo -e "\n${YELLOW}Manual intervention required:${NC}"
+        echo "1. Stop the old container and deploy staged version"
+        echo "2. Remove staged container and keep current version"
+        echo "3. Exit without changes"
+        
+        read -p "Choose option (1-3): " choice
+        
+        case $choice in
+            1)
+                log "Stopping old container and deploying staged version..."
+                docker stop ciris-agent-datum || true
+                docker rm ciris-agent-datum || true
+                docker rename ciris-agent-datum-staged ciris-agent-datum
+                docker start ciris-agent-datum
+                log "Staged container deployed successfully!"
+                ;;
+            2)
+                log "Removing staged container..."
+                docker rm ciris-agent-datum-staged || true
+                log "Staged container removed. Current version kept."
+                ;;
+            3)
+                log "Exiting without changes."
+                exit 0
+                ;;
+            *)
+                error "Invalid option"
+                exit 1
+                ;;
+        esac
+    else
+        log "Old container is not running. Deploying staged version..."
+        docker rm ciris-agent-datum || true
+        docker rename ciris-agent-datum-staged ciris-agent-datum
+        docker start ciris-agent-datum
+        log "Staged container deployed successfully!"
+    fi
+else
+    log "No staged container found"
+    
+    # Check if deployment needs to be rerun
+    if ! docker ps --format "{{.Names}}" | grep -q "ciris-agent-datum"; then
+        warn "Agent container is not running!"
+        echo -e "\n${YELLOW}Would you like to start the containers?${NC}"
+        read -p "Start containers? (y/n): " start_choice
+        
+        if [[ "$start_choice" == "y" ]]; then
+            log "Starting containers..."
+            cd /home/ciris/CIRISAgent
+            docker-compose -f deployment/docker-compose.dev-prod.yml up -d
+            log "Containers started"
+        fi
+    fi
+fi
+
+# Show final state
+echo -e "\n${GREEN}Final container state:${NC}"
+docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Image}}" | grep -E "ciris|NAMES" || true
+
+# Check health
+echo -e "\n${GREEN}Checking API health:${NC}"
+if curl -f http://localhost:8080/v1/system/health 2>/dev/null; then
+    echo -e "\n${GREEN}✓ API is healthy${NC}"
+else
+    echo -e "\n${RED}✗ API health check failed${NC}"
+fi

--- a/deployment/production-troubleshoot.sh
+++ b/deployment/production-troubleshoot.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+# Production troubleshooting script for CIRISManager and agent deployment
+
+set -e
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log() { echo -e "${GREEN}[$(date '+%Y-%m-%d %H:%M:%S')]${NC} $1"; }
+warn() { echo -e "${YELLOW}[$(date '+%Y-%m-%d %H:%M:%S')] WARNING:${NC} $1"; }
+error() { echo -e "${RED}[$(date '+%Y-%m-%d %H:%M:%S')] ERROR:${NC} $1"; }
+info() { echo -e "${BLUE}[$(date '+%Y-%m-%d %H:%M:%S')] INFO:${NC} $1"; }
+
+echo -e "${BLUE}=== CIRIS Production Troubleshooting ===${NC}"
+echo ""
+
+# Step 1: Check current container state
+log "Step 1: Checking container state..."
+echo -e "\nAll containers:"
+docker ps -a --format "table {{.Names}}\t{{.Status}}\t{{.Image}}" | grep -E "ciris|NAMES" || true
+
+# Check for staged containers
+if docker ps -a --format "{{.Names}}" | grep -q "staged"; then
+    warn "Found staged containers - deployment may be incomplete"
+fi
+
+# Step 2: Check container health
+log "\nStep 2: Checking container health..."
+for container in ciris-agent-datum ciris-gui ciris-nginx; do
+    if docker ps --format "{{.Names}}" | grep -q "^${container}$"; then
+        STATUS=$(docker inspect "$container" --format='{{.State.Status}}' 2>/dev/null || echo "unknown")
+        HEALTH=$(docker inspect "$container" --format='{{.State.Health.Status}}' 2>/dev/null || echo "no healthcheck")
+        echo -e "  ${container}: Status=${STATUS}, Health=${HEALTH}"
+        
+        if [[ "$HEALTH" == "unhealthy" ]]; then
+            warn "Container $container is unhealthy!"
+            echo "    Last 5 log lines:"
+            docker logs "$container" --tail 5 2>&1 | sed 's/^/    /'
+        fi
+    else
+        error "  ${container}: NOT RUNNING"
+    fi
+done
+
+# Step 3: Check API health
+log "\nStep 3: Checking API health..."
+if curl -sf http://localhost:8080/v1/system/health > /tmp/health.json 2>/dev/null; then
+    echo -e "  ${GREEN}✓ API is responding${NC}"
+    if command -v jq >/dev/null 2>&1; then
+        echo "  Status: $(jq -r '.status' /tmp/health.json 2>/dev/null || echo 'parse error')"
+        echo "  Uptime: $(jq -r '.uptime' /tmp/health.json 2>/dev/null || echo 'parse error')"
+    fi
+else
+    error "  ✗ API health check failed"
+    echo "  Checking if port 8080 is listening..."
+    netstat -tlnp | grep :8080 || echo "  Port 8080 not listening"
+fi
+
+# Step 4: Check CIRISManager installation
+log "\nStep 4: Checking CIRISManager installation..."
+if command -v ciris-manager >/dev/null 2>&1; then
+    echo -e "  ${GREEN}✓ CIRISManager is installed${NC}"
+    echo "  Location: $(which ciris-manager)"
+else
+    error "  ✗ CIRISManager not found in PATH"
+    # Check if it's installed but not in PATH
+    if [ -f "/usr/local/bin/ciris-manager" ]; then
+        warn "  Found at /usr/local/bin/ciris-manager but not in PATH"
+    fi
+fi
+
+# Step 5: Check CIRISManager service
+log "\nStep 5: Checking CIRISManager systemd service..."
+if systemctl list-unit-files | grep -q "ciris-manager.service"; then
+    echo -e "  ${GREEN}✓ Service is installed${NC}"
+    STATUS=$(systemctl is-active ciris-manager.service || echo "inactive")
+    ENABLED=$(systemctl is-enabled ciris-manager.service || echo "disabled")
+    echo "  Status: $STATUS"
+    echo "  Enabled: $ENABLED"
+    
+    if [[ "$STATUS" != "active" ]]; then
+        warn "  Service is not active!"
+        echo "  Last 10 journal entries:"
+        journalctl -u ciris-manager.service -n 10 --no-pager | sed 's/^/    /'
+    fi
+else
+    error "  ✗ ciris-manager.service not found"
+fi
+
+# Step 6: Check CIRISManager config
+log "\nStep 6: Checking CIRISManager configuration..."
+if [ -f "/etc/ciris-manager/config.yml" ]; then
+    echo -e "  ${GREEN}✓ Config file exists${NC}"
+    echo "  Compose file path:"
+    grep "compose_file:" /etc/ciris-manager/config.yml | sed 's/^/    /'
+    
+    # Verify compose file exists
+    COMPOSE_FILE=$(grep "compose_file:" /etc/ciris-manager/config.yml | awk '{print $2}' | tr -d '"')
+    if [ -f "$COMPOSE_FILE" ]; then
+        echo -e "  ${GREEN}✓ Compose file exists${NC}"
+    else
+        error "  ✗ Compose file not found: $COMPOSE_FILE"
+    fi
+else
+    error "  ✗ Config file not found at /etc/ciris-manager/config.yml"
+fi
+
+# Step 7: Check Docker permissions
+log "\nStep 7: Checking Docker permissions..."
+if docker ps >/dev/null 2>&1; then
+    echo -e "  ${GREEN}✓ Docker accessible${NC}"
+else
+    error "  ✗ Cannot access Docker - permission issue?"
+fi
+
+# Step 8: Provide recommendations
+echo ""
+echo -e "${BLUE}=== Recommendations ===${NC}"
+echo ""
+
+ISSUES=0
+
+# Check if containers need to be started
+if ! docker ps --format "{{.Names}}" | grep -q "ciris-agent-datum"; then
+    ((ISSUES++))
+    echo "$ISSUES. Agent container is not running. Start it with:"
+    echo "   docker-compose -f /home/ciris/CIRISAgent/deployment/docker-compose.dev-prod.yml up -d"
+    echo ""
+fi
+
+# Check if CIRISManager needs installation
+if ! command -v ciris-manager >/dev/null 2>&1; then
+    ((ISSUES++))
+    echo "$ISSUES. CIRISManager needs to be installed:"
+    echo "   cd /home/ciris/CIRISAgent"
+    echo "   pip3 install -e ."
+    echo ""
+fi
+
+# Check if service needs to be started
+if systemctl list-unit-files | grep -q "ciris-manager.service"; then
+    if [[ "$(systemctl is-active ciris-manager.service)" != "active" ]]; then
+        ((ISSUES++))
+        echo "$ISSUES. CIRISManager service needs to be started:"
+        echo "   systemctl start ciris-manager"
+        echo "   systemctl enable ciris-manager"
+        echo ""
+    fi
+else
+    ((ISSUES++))
+    echo "$ISSUES. CIRISManager service needs to be installed:"
+    echo "   cp /home/ciris/CIRISAgent/deployment/ciris-manager.service /etc/systemd/system/"
+    echo "   systemctl daemon-reload"
+    echo "   systemctl enable ciris-manager"
+    echo "   systemctl start ciris-manager"
+    echo ""
+fi
+
+# Check if config needs to be created
+if [ ! -f "/etc/ciris-manager/config.yml" ]; then
+    ((ISSUES++))
+    echo "$ISSUES. CIRISManager config needs to be created:"
+    echo "   mkdir -p /etc/ciris-manager"
+    echo "   ciris-manager --generate-config --config /etc/ciris-manager/config.yml"
+    echo "   # Then update the compose_file path to:"
+    echo "   # /home/ciris/CIRISAgent/deployment/docker-compose.dev-prod.yml"
+    echo ""
+fi
+
+if [ $ISSUES -eq 0 ]; then
+    echo -e "${GREEN}No issues found! Everything appears to be configured correctly.${NC}"
+else
+    echo -e "${YELLOW}Found $ISSUES issue(s) that need attention.${NC}"
+fi
+
+echo ""
+echo -e "${BLUE}=== Quick Fix Script ===${NC}"
+echo ""
+echo "Run this to fix common issues:"
+echo ""
+echo "cd /home/ciris/CIRISAgent && \\"
+echo "docker-compose -f deployment/docker-compose.dev-prod.yml up -d && \\"
+echo "pip3 install -e . && \\"
+echo "mkdir -p /etc/ciris-manager && \\"
+echo "ciris-manager --generate-config --config /etc/ciris-manager/config.yml && \\"
+echo "sed -i 's|docker-compose.yml|docker-compose.dev-prod.yml|' /etc/ciris-manager/config.yml && \\"
+echo "cp deployment/ciris-manager.service /etc/systemd/system/ && \\"
+echo "systemctl daemon-reload && \\"
+echo "systemctl enable ciris-manager && \\"
+echo "systemctl start ciris-manager"

--- a/setup_manager.py
+++ b/setup_manager.py
@@ -1,34 +1,26 @@
+#!/usr/bin/env python3
 """
 Setup script for CIRISManager.
+This is a lightweight installation that only installs the manager component.
 """
+
 from setuptools import setup, find_packages
 
 setup(
     name="ciris-manager",
     version="0.1.0",
-    description="CIRIS Agent Lifecycle Management Service",
-    author="CIRIS Team",
-    packages=find_packages(),
-    include_package_data=True,
-    python_requires=">=3.8",
+    description="CIRIS Container Manager - Lightweight systemd service for agent lifecycle",
+    author="CIRIS AI",
+    packages=find_packages(include=["ciris_manager", "ciris_manager.*"]),
     install_requires=[
-        "pydantic>=2.0.0",
-        "PyYAML>=6.0",
-        "aiofiles>=23.0.0",
+        "pyyaml>=6.0",
+        "asyncio",
+        "aiofiles>=23.0",
     ],
     entry_points={
         "console_scripts": [
-            "ciris-manager=ciris_manager.__main__:main",
+            "ciris-manager=ciris_manager.cli:main",
         ],
     },
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-    ],
+    python_requires=">=3.8",
 )


### PR DESCRIPTION
## Summary
- Fix CIRISManager installation issues in production deployment
- Add manual intervention scripts for troubleshooting
- Provide comprehensive deployment and troubleshooting tools

## Changes
1. **Add CLI entry point** - Create `ciris_manager/cli.py` with proper argument parsing and config generation
2. **Fix installation** - Update CI/CD to use editable install correctly
3. **Add troubleshooting scripts**:
   - `production-troubleshoot.sh` - Comprehensive diagnostic tool
   - `manual-staged-deploy.sh` - Manual intervention for failed deployments
   - `deploy-ciris-manager.sh` - Dedicated CIRISManager deployment script

## Problem Solved
The previous deployment failed with a timeout during CIRISManager installation. This PR:
- Fixes the installation command
- Provides tools to diagnose and fix deployment issues
- Enables manual intervention when automated deployment fails

## Testing
- Scripts have been tested locally
- Installation process verified with proper Python path setup
- Manual intervention flow tested

## Deployment Instructions
After merging, if automated deployment fails:
1. SSH to server: `ssh -i ~/.ssh/ciris_deploy root@108.61.119.117`
2. Run troubleshooting: `cd /home/ciris/CIRISAgent && ./deployment/production-troubleshoot.sh`
3. If needed, deploy manually: `./deployment/deploy-ciris-manager.sh`