### PR TITLE
fix: Restore multi-agent routing for OAuth

### DIFF
--- a/CIRISGUI/apps/agui/contexts/AgentContextDynamic.tsx
+++ b/CIRISGUI/apps/agui/contexts/AgentContextDynamic.tsx
@@ -119,10 +119,15 @@ export function AgentProvider({ children }: { children: ReactNode }) {
     
     setCurrentAgent(agent);
     
-    // Update SDK to use the agent's API endpoint
-    if (agent.api_endpoint) {
-      cirisClient.setConfig({ baseURL: agent.api_endpoint });
-    }
+    // Update SDK to use multi-agent routing pattern
+    // For production, use /api/{agent}/v1 pattern
+    // For local development, use the agent's direct endpoint
+    const isProduction = window.location.hostname === 'agents.ciris.ai';
+    const baseURL = isProduction 
+      ? `${window.location.origin}/api/${agentId}`
+      : agent.api_endpoint;
+    
+    cirisClient.setConfig({ baseURL });
   };
 
   // Initial discovery


### PR DESCRIPTION
## Summary

This restores the multi-agent routing pattern that was accidentally removed, fixing the OAuth 404 errors.

## The Problem

- OAuth URLs like `/api/datum/v1/auth/oauth/google/login` were returning 404
- The GUI was trying to use direct endpoints instead of the multi-agent routes
- This broke existing OAuth integrations

## The Fix

Updated AgentContextDynamic to use the correct routing pattern:
- **Production**: `/api/{agent}/v1/*` for multi-agent support
- **Local dev**: Direct agent endpoints from CIRISManager

## Result

- OAuth URLs work again
- Multi-agent architecture is preserved
- Dynamic discovery still works
- Both single-agent and multi-agent deployments are supported

This maintains the flexibility of the original design while adding dynamic discovery.

🤖 Generated with [Claude Code](https://claude.ai/code)