### PR TITLE
fix: Remove duplicate /v1 prefix in nginx multi-agent proxy_pass

### DIFF
--- a/deployment/nginx/agents.ciris.ai.conf
+++ b/deployment/nginx/agents.ciris.ai.conf
@@ -95,7 +95,7 @@ server {
 
     # Datum API (port 8080)
     location ~ ^/api/datum/(.*)$ {
-        proxy_pass http://datum/v1/$1$is_args$args;
+        proxy_pass http://datum/$1$is_args$args;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -110,7 +110,7 @@ server {
 
     # Sage API (port 8081)
     location ~ ^/api/sage/(.*)$ {
-        proxy_pass http://sage/v1/$1$is_args$args;
+        proxy_pass http://sage/$1$is_args$args;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -125,7 +125,7 @@ server {
 
     # Scout API (port 8082)
     location ~ ^/api/scout/(.*)$ {
-        proxy_pass http://scout/v1/$1$is_args$args;
+        proxy_pass http://scout/$1$is_args$args;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -140,7 +140,7 @@ server {
 
     # Echo-Core API (port 8083)
     location ~ ^/api/echo-core/(.*)$ {
-        proxy_pass http://echo_core/v1/$1$is_args$args;
+        proxy_pass http://echo_core/$1$is_args$args;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -155,7 +155,7 @@ server {
 
     # Echo-Speculative API (port 8084)
     location ~ ^/api/echo-speculative/(.*)$ {
-        proxy_pass http://echo_speculative/v1/$1$is_args$args;
+        proxy_pass http://echo_speculative/$1$is_args$args;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
- Fixed nginx configuration that was duplicating the /v1 prefix in multi-agent routes
- The regex was capturing everything after /api/{agent}/ and then prepending /v1/
- This caused paths like /api/datum/v1/system/health to become /v1/v1/system/health

## Test plan
- [x] Test that /api/datum/v1/system/health returns 200 (not 404)
- [x] Test that OAuth login works: /api/datum/v1/auth/oauth/google/login
- [ ] Verify GUI can communicate with agents through multi-agent routes

🤖 Generated with [Claude Code](https://claude.ai/code)