### PR TITLE
fix: Add OAuth callback routes and update login page for dynamic agents

### DIFF
--- a/deployment/nginx/agents.ciris.ai.conf
+++ b/deployment/nginx/agents.ciris.ai.conf
@@ -189,9 +189,19 @@ server {
     }
 
     # OAuth Callback Routes - Per-agent callbacks
-    # Datum OAuth callbacks
+    # Datum OAuth callbacks (GUI pattern)
     location ~ ^/oauth/datum/callback$ {
         proxy_pass http://datum/v1/auth/oauth/callback$is_args$args;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    
+    # Datum OAuth callbacks (Direct API pattern)
+    location ~ ^/v1/auth/oauth/datum/(.+)/callback$ {
+        proxy_pass http://datum/v1/auth/oauth/$1/callback$is_args$args;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -232,6 +242,44 @@ server {
     # Echo-Speculative OAuth callbacks
     location ~ ^/oauth/echo-speculative/callback$ {
         proxy_pass http://echo_speculative/v1/auth/oauth/callback$is_args$args;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Direct API OAuth callbacks (when redirected from OAuth provider)
+    # These routes handle callbacks like /v1/auth/oauth/datum/google/callback
+    location ~ ^/v1/auth/oauth/sage/(.+)/callback$ {
+        proxy_pass http://sage/v1/auth/oauth/$1/callback$is_args$args;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    
+    location ~ ^/v1/auth/oauth/scout/(.+)/callback$ {
+        proxy_pass http://scout/v1/auth/oauth/$1/callback$is_args$args;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    
+    location ~ ^/v1/auth/oauth/echo-core/(.+)/callback$ {
+        proxy_pass http://echo_core/v1/auth/oauth/$1/callback$is_args$args;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    
+    location ~ ^/v1/auth/oauth/echo-speculative/(.+)/callback$ {
+        proxy_pass http://echo_speculative/v1/auth/oauth/$1/callback$is_args$args;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Summary
- Added nginx routes for OAuth callbacks in multi-agent pattern (/v1/auth/oauth/{agent}/{provider}/callback)
- Updated login page to use dynamic agent discovery from CIRISManager
- Fixed OAuth redirect URIs to use correct multi-agent routing

## Problem
Google OAuth was redirecting to /v1/auth/oauth/datum/google/callback but nginx only had routes for /oauth/datum/callback pattern, causing 404 errors.

## Test plan
- [x] OAuth login redirects to correct URL
- [ ] OAuth callback route works and returns user to GUI
- [ ] Login page shows dynamically discovered agents
- [ ] Agent selection updates OAuth URLs correctly

🤖 Generated with [Claude Code](https://claude.ai/code)