### PR TITLE
fix: Critical nginx OAuth route ordering

### DIFF
--- a/deployment/nginx/agents.ciris.ai.conf
+++ b/deployment/nginx/agents.ciris.ai.conf
@@ -78,7 +78,58 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # Default API endpoint (Datum at root /v1)
+    # OAuth Callback Routes - MUST come before general /v1/ route
+    # Datum OAuth callbacks (Direct API pattern)
+    location ~ ^/v1/auth/oauth/datum/(.+)/callback$ {
+        proxy_pass http://datum/v1/auth/oauth/$1/callback$is_args$args;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    
+    # Sage OAuth callbacks (Direct API pattern)
+    location ~ ^/v1/auth/oauth/sage/(.+)/callback$ {
+        proxy_pass http://sage/v1/auth/oauth/$1/callback$is_args$args;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    
+    # Scout OAuth callbacks (Direct API pattern)
+    location ~ ^/v1/auth/oauth/scout/(.+)/callback$ {
+        proxy_pass http://scout/v1/auth/oauth/$1/callback$is_args$args;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    
+    # Echo-Core OAuth callbacks (Direct API pattern)
+    location ~ ^/v1/auth/oauth/echo-core/(.+)/callback$ {
+        proxy_pass http://echo_core/v1/auth/oauth/$1/callback$is_args$args;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    
+    # Echo-Speculative OAuth callbacks (Direct API pattern)
+    location ~ ^/v1/auth/oauth/echo-speculative/(.+)/callback$ {
+        proxy_pass http://echo_speculative/v1/auth/oauth/$1/callback$is_args$args;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Default API endpoint (Datum at root /v1) - MUST come after specific routes
     location /v1/ {
         proxy_pass http://datum;
         proxy_http_version 1.1;
@@ -188,20 +239,10 @@ server {
         client_max_body_size 10M;
     }
 
-    # OAuth Callback Routes - Per-agent callbacks
+    # OAuth Callback Routes - Per-agent callbacks (GUI pattern)
     # Datum OAuth callbacks (GUI pattern)
     location ~ ^/oauth/datum/callback$ {
         proxy_pass http://datum/v1/auth/oauth/callback$is_args$args;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-    
-    # Datum OAuth callbacks (Direct API pattern)
-    location ~ ^/v1/auth/oauth/datum/(.+)/callback$ {
-        proxy_pass http://datum/v1/auth/oauth/$1/callback$is_args$args;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -249,43 +290,6 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    # Direct API OAuth callbacks (when redirected from OAuth provider)
-    # These routes handle callbacks like /v1/auth/oauth/datum/google/callback
-    location ~ ^/v1/auth/oauth/sage/(.+)/callback$ {
-        proxy_pass http://sage/v1/auth/oauth/$1/callback$is_args$args;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-    
-    location ~ ^/v1/auth/oauth/scout/(.+)/callback$ {
-        proxy_pass http://scout/v1/auth/oauth/$1/callback$is_args$args;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-    
-    location ~ ^/v1/auth/oauth/echo-core/(.+)/callback$ {
-        proxy_pass http://echo_core/v1/auth/oauth/$1/callback$is_args$args;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-    
-    location ~ ^/v1/auth/oauth/echo-speculative/(.+)/callback$ {
-        proxy_pass http://echo_speculative/v1/auth/oauth/$1/callback$is_args$args;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
 
     # Health check endpoint for nginx
     location /health {


### PR DESCRIPTION
## Critical Fix

The OAuth callback routes were returning 404 because nginx was matching the general /v1/ route before reaching the specific OAuth callback routes.

## Issue
- OAuth callbacks to /v1/auth/oauth/datum/google/callback were returning 404
- The general /v1/ location block was catching all requests before specific OAuth routes

## Solution
- Moved all OAuth callback routes BEFORE the general /v1/ route
- Nginx processes location blocks in order, so specific routes must come first
- Removed duplicate OAuth route definitions

## Testing
This fixes the OAuth flow in production where callbacks were failing with 404.