### PR TITLE
fix: Export AgentInfo type from SDK

### DIFF
--- a/CIRISGUI/apps/agui/lib/ciris-sdk/index.ts
+++ b/CIRISGUI/apps/agui/lib/ciris-sdk/index.ts
@@ -23,6 +23,7 @@ export { SystemResource } from './resources/system';
 export { MemoryResource } from './resources/memory';
 export { ConfigResource, unwrapConfigValue, wrapConfigValue } from './resources/config';
 export { UsersResource } from './resources/users';
+export { ManagerResource } from './resources/manager';
 
 // Export OAuth types
 export type {
@@ -46,3 +47,12 @@ export type {
   PermissionRequestResponse,
   PermissionGrantRequest
 } from './resources/users';
+
+// Export manager types
+export type {
+  AgentInfo,
+  AgentCreationRequest,
+  UpdateNotification,
+  DeploymentStatus,
+  ManagerHealth
+} from './resources/manager';

--- a/logs/.current_incident_log
+++ b/logs/.current_incident_log
@@ -1,1 +1,1 @@
-/app/logs/incidents_20250720_220257.log
+/app/logs/incidents_20250721_015133.log

--- a/logs/.current_log
+++ b/logs/.current_log
@@ -1,1 +1,1 @@
-/app/logs/ciris_agent_20250720_220257.log
+/app/logs/ciris_agent_20250721_015133.log

--- a/shared/oauth/oauth_config.json
+++ b/shared/oauth/oauth_config.json
@@ -1,0 +1,1 @@
+{"google":{"client_id":"test","client_secret":"test","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://oauth2.googleapis.com/token"}}


### PR DESCRIPTION
## Fix GUI Build Error

The GUI build was failing in CI/CD because the AgentInfo type was not exported from the SDK index.

## Error


## Solution
- Added ManagerResource export to SDK index
- Added manager types export section including AgentInfo

This fixes the TypeScript compilation error that was preventing GUI deployment.