### PR TITLE
Fix CI tests by adding PyNaCl dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ discord.py>=2.3.0,<3.0.0
 cryptography>=41.0.0,<46.0.0
 PyJWT[crypto]>=2.8.0,<3.0.0
 bcrypt>=4.0.0,<5.0.0
+PyNaCl>=1.5.0,<2.0.0
 
 # Web Framework (API/GUI)
 fastapi>=0.111.0,<1.0.0


### PR DESCRIPTION
## Summary
- Fixed CI test failures caused by missing PyNaCl module
- Added PyNaCl to requirements.txt for CIRISManager template verification

## Root Cause
The new CIRISManager template verification feature uses Ed25519 signatures via PyNaCl, but the dependency wasn't added to requirements.txt

## Test plan
- [x] CI tests should pass after this change
- [x] CIRISManager template verification works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)