### PR TITLE
Fix OAuth callback URLs to use dynamic agent ID

### DIFF
--- a/ciris_engine/logic/adapters/api/routes/auth.py
+++ b/ciris_engine/logic/adapters/api/routes/auth.py
@@ -34,7 +34,9 @@ from ciris_engine.schemas.runtime.api import APIRole
 OAUTH_CONFIG_DIR = ".ciris"
 OAUTH_CONFIG_FILE = "oauth.json"
 PROVIDER_NAME_DESC = "Provider name"
-OAUTH_CALLBACK_PATH = "/v1/auth/oauth/datum/{provider}/callback"
+# Get agent ID from environment, default to 'datum' if not set
+AGENT_ID = os.getenv("CIRIS_AGENT_ID", "datum")
+OAUTH_CALLBACK_PATH = f"/v1/auth/oauth/{AGENT_ID}/{{provider}}/callback"
 DEFAULT_OAUTH_BASE_URL = "https://agents.ciris.ai"
 
 from ..dependencies.auth import (
@@ -529,7 +531,7 @@ async def oauth_callback(
                         "code": code,
                         "client_id": client_id,
                         "client_secret": client_secret,
-                        "redirect_uri": os.getenv("OAUTH_CALLBACK_BASE_URL", "https://agents.ciris.ai") + "/oauth/datum/callback"
+                        "redirect_uri": os.getenv("OAUTH_CALLBACK_BASE_URL", DEFAULT_OAUTH_BASE_URL) + OAUTH_CALLBACK_PATH.replace('{provider}', provider)
                     }
                 )
                 
@@ -664,7 +666,7 @@ async def oauth_callback(
         
         # Redirect to GUI OAuth callback page with token info
         # The GUI will handle storing the token and redirecting to dashboard
-        gui_callback_url = f"/oauth/datum/{provider}/callback"
+        gui_callback_url = f"/oauth/{AGENT_ID}/{provider}/callback"
         redirect_params = {
             "access_token": api_key,
             "token_type": "Bearer",


### PR DESCRIPTION
## Summary
- Fixed OAuth redirect_uri_mismatch error in production
- OAuth callback URLs now dynamically use CIRIS_AGENT_ID from environment
- Format: `/v1/auth/oauth/{agent_id}/{provider}/callback`

## Root Cause
The OAuth callback path was hardcoded to use 'datum' instead of reading the agent ID from the environment. This broke multi-agent OAuth support.

## Changes
- Read CIRIS_AGENT_ID from environment (defaults to 'datum')
- Construct OAUTH_CALLBACK_PATH dynamically
- Fix GitHub OAuth redirect_uri to use dynamic path
- Fix GUI callback URL to use dynamic agent ID

## Test plan
- [x] OAuth login should work for Datum agent
- [ ] When Scout agent is created, its OAuth callback will be `/v1/auth/oauth/scout/google/callback`
- [ ] Each agent can have its own OAuth configuration

🤖 Generated with [Claude Code](https://claude.ai/code)