### PR TITLE
fix: Fix CIRISManager test failures in CI

### DIFF
--- a/ciris_manager/core/watchdog.py
+++ b/ciris_manager/core/watchdog.py
@@ -6,7 +6,7 @@ to prevent infinite restart loops.
 """
 import asyncio
 import logging
-from typing import Dict, List, Set
+from typing import Dict, List, Set, Any
 from datetime import datetime, timedelta
 from dataclasses import dataclass, field
 
@@ -210,21 +210,25 @@ class CrashLoopWatchdog:
         # TODO: Implement actual alerting mechanism
         logger.critical(f"ALERT: {message}")
         
-    def get_status(self) -> Dict[str, Dict]:
+    def get_status(self) -> Dict[str, Any]:
         """Get current watchdog status."""
-        status = {}
-        
-        for name, tracker in self._trackers.items():
-            status[name] = {
-                'crashes': len(tracker.crashes),
-                'stopped': tracker.stopped,
-                'recent_crashes': [
-                    {
-                        'timestamp': crash.timestamp.isoformat(),
-                        'exit_code': crash.exit_code
-                    }
-                    for crash in tracker.crashes[-5:]  # Last 5 crashes
-                ]
+        return {
+            'running': self._running,
+            'check_interval': self.check_interval,
+            'crash_threshold': self.crash_threshold,
+            'crash_window': self.crash_window.total_seconds(),
+            'containers': {
+                name: {
+                    'crashes': len(tracker.crashes),
+                    'stopped': tracker.stopped,
+                    'recent_crashes': [
+                        {
+                            'timestamp': crash.timestamp.isoformat(),
+                            'exit_code': crash.exit_code
+                        }
+                        for crash in tracker.crashes[-5:]  # Last 5 crashes
+                    ]
+                }
+                for name, tracker in self._trackers.items()
             }
-            
-        return status
+        }

--- a/tests/ciris_manager/test_cli.py
+++ b/tests/ciris_manager/test_cli.py
@@ -59,36 +59,16 @@ class TestCLI:
         # Should run manager
         mock_asyncio_run.assert_called_once()
     
-    @pytest.mark.skip(reason="Temporarily skip to deploy OAuth fix")
     @patch('ciris_manager.cli.print')
     def test_main_generate_config_and_exit(self, mock_print, tmp_path):
         """Test main with --generate-config flag."""
         config_path = tmp_path / "config.yml"
         
-        with patch('sys.argv', ['ciris-manager', '--generate-config']):
-            # Mock the default path to our temp path
-            with patch('ciris_manager.cli.Path') as mock_path_class:
-                # Create a proper mock that returns our temp path
-                def path_side_effect(arg):
-                    if "~/.config" in arg:
-                        return config_path
-                    return Path(arg)
-                
-                mock_path_class.side_effect = path_side_effect
-                
-                # Patch the default config path to use temp path
-                original_config = '/etc/ciris-manager/config.yml'
-                with patch('ciris_manager.cli.Path') as inner_path:
-                    def inner_path_effect(p):
-                        if p == original_config:
-                            return config_path
-                        return Path(p)
-                    inner_path.side_effect = inner_path_effect
-                    
-                    with pytest.raises(SystemExit) as exc:
-                        main()
-                    
-                    assert exc.value.code == 0
+        with patch('sys.argv', ['ciris-manager', '--generate-config', '--config', str(config_path)]):
+            with pytest.raises(SystemExit) as exc:
+                main()
+            
+            assert exc.value.code == 0
         
         # Config should be created
         assert config_path.exists()

--- a/tests/ciris_manager/test_manager.py
+++ b/tests/ciris_manager/test_manager.py
@@ -138,7 +138,6 @@ class TestCIRISManager:
         assert agent.name == "Scout"
         assert agent.port == 8081
     
-    @pytest.mark.skip(reason="Temporarily skip to deploy OAuth fix")
     @pytest.mark.asyncio
     async def test_create_agent_pre_approved(self, manager):
         """Test creating agent with pre-approved template."""
@@ -160,13 +159,13 @@ class TestCIRISManager:
             )
         
         # Verify result
-        assert result["agent_id"] == "agent-scout"
-        assert result["container"] == "ciris-agent-scout"
+        assert result["agent_id"] == "scout"
+        assert result["container"] == "ciris-scout"
         assert result["port"] == 8080  # First available
         assert result["status"] == "starting"
         
         # Verify agent registered
-        agent = manager.agent_registry.get_agent("agent-scout")
+        agent = manager.agent_registry.get_agent("scout")
         assert agent is not None
         assert agent.name == "Scout"
         
@@ -192,7 +191,6 @@ class TestCIRISManager:
                 name="Custom"
             )
     
-    @pytest.mark.skip(reason="Temporarily skip to deploy OAuth fix")
     @pytest.mark.asyncio
     async def test_create_agent_custom_template_with_signature(self, manager):
         """Test creating agent with custom template and signature."""
@@ -214,7 +212,7 @@ class TestCIRISManager:
             )
         
         # Should succeed
-        assert result["agent_id"] == "agent-custom"
+        assert result["agent_id"] == "custom"
         assert result["status"] == "starting"
     
     @pytest.mark.asyncio
@@ -328,7 +326,6 @@ class TestCIRISManager:
         status = manager.get_status()
         assert status['running']
     
-    @pytest.mark.skip(reason="Temporarily skip to deploy OAuth fix")
     @pytest.mark.asyncio
     async def test_port_allocation_persistence(self, manager):
         """Test port allocation persists across restarts."""
@@ -353,8 +350,8 @@ class TestCIRISManager:
             manager2 = CIRISManager(manager.config)
         
         # Ports should still be allocated
-        assert manager2.port_manager.get_port("agent-scout1") == 8080
-        assert manager2.port_manager.get_port("agent-scout2") == 8081
+        assert manager2.port_manager.get_port("scout1") == 8080
+        assert manager2.port_manager.get_port("scout2") == 8081
     
     @pytest.mark.asyncio
     async def test_concurrent_agent_creation(self, manager):

--- a/tests/ciris_manager/test_watchdog_simple.py
+++ b/tests/ciris_manager/test_watchdog_simple.py
@@ -6,7 +6,7 @@ import pytest
 from unittest.mock import Mock
 from ciris_manager.core.watchdog import CrashLoopWatchdog, ContainerTracker, CrashEvent
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timedelta
 
 
 class TestWatchdogSimple:
@@ -22,7 +22,7 @@ class TestWatchdogSimple:
         
         assert watchdog.check_interval == 30
         assert watchdog.crash_threshold == 3
-        assert watchdog.crash_window == 300
+        assert watchdog.crash_window == timedelta(seconds=300)
         assert not watchdog._running
     
     def test_get_status(self):


### PR DESCRIPTION
## Summary
- Fixed all failing CIRISManager tests
- Removed pytest.skip decorators 
- Fixed uvicorn mock to avoid port binding issues
- Updated agent ID assertions to match new format without 'agent-' prefix
- Fixed watchdog get_status() format

## Changes
- Fixed test_start_api_server_import_error by properly mocking uvicorn
- Updated CLI test to use --config flag
- Fixed watchdog get_status() to return expected format with config details
- All 102 CIRISManager tests now pass locally

## Test Results
All CIRISManager tests passing:
```
====================== 102 passed, 74 warnings in 21.78s =======================
```

This should fix the CI/CD pipeline that's been failing on the main branch.