### PR TITLE
fix: OAuth callback URL for multi-agent deployment

### DIFF
--- a/ciris_engine/logic/adapters/api/routes/auth.py
+++ b/ciris_engine/logic/adapters/api/routes/auth.py
@@ -257,7 +257,7 @@ async def list_oauth_providers(
                 provider=provider,
                 client_id=settings.get("client_id", ""),
                 created=settings.get("created"),
-                callback_url=f"{request.url.scheme}://{request.headers.get('host', 'localhost')}{OAUTH_CALLBACK_PATH}",
+                callback_url=f"{request.headers.get('x-forwarded-proto', request.url.scheme)}://{request.headers.get('host', 'localhost')}{OAUTH_CALLBACK_PATH}",
                 metadata=settings.get("metadata", {})
             ))
         
@@ -327,7 +327,7 @@ async def configure_oauth_provider(
         
         return ConfigureOAuthProviderResponse(
             provider=body.provider,
-            callback_url=f"{request.url.scheme}://{request.headers.get('host', 'localhost')}{OAUTH_CALLBACK_PATH}",
+            callback_url=f"{request.headers.get('x-forwarded-proto', request.url.scheme)}://{request.headers.get('host', 'localhost')}{OAUTH_CALLBACK_PATH}",
             message="OAuth provider configured successfully"
         )
     except Exception as e:
@@ -387,7 +387,7 @@ async def oauth_login(
         base_url = os.getenv("OAUTH_CALLBACK_BASE_URL")
         if not base_url:
             # Construct from request headers
-            base_url = f"{request.url.scheme}://{request.headers.get('host', 'localhost')}"
+            base_url = f"{request.headers.get('x-forwarded-proto', request.url.scheme)}://{request.headers.get('host', 'localhost')}"
         
         # Always use API callback URL for OAuth providers (this is what's registered in Google Console)
         callback_url = f"{base_url}{OAUTH_CALLBACK_PATH.replace('{provider}', provider)}"

--- a/deployment/docker-compose.dev-prod.yml
+++ b/deployment/docker-compose.dev-prod.yml
@@ -30,6 +30,7 @@ services:
       - CIRIS_PORT=8080
       - CIRIS_ADAPTER=api
       - CIRIS_ADAPTER_DISCORD=discord
+      - OAUTH_CALLBACK_BASE_URL=https://agents.ciris.ai
       - CIRIS_MOCK_LLM=true  # Enable mock LLM for Phase 1
       # Discord configuration loaded from .env.datum file
       # API configuration


### PR DESCRIPTION
## Description

This PR fixes OAuth authentication when CIRIS is deployed behind an nginx reverse proxy (as in production).

## Problem

When deployed behind nginx, the API was generating OAuth callback URLs with `http://` instead of `https://` because nginx proxies internally via HTTP. This caused redirect_uri_mismatch errors with OAuth providers.

## Solution

1. **Add X-Forwarded-Proto support**: The API now checks the `X-Forwarded-Proto` header (set by nginx) to determine the correct scheme
2. **Add OAUTH_CALLBACK_BASE_URL environment variable**: Added to the deployment config to ensure consistent callback URLs

## Changes

- Modified `auth.py` to use `request.headers.get('x-forwarded-proto', request.url.scheme)` instead of just `request.url.scheme`
- Added `OAUTH_CALLBACK_BASE_URL=https://agents.ciris.ai` to `docker-compose.dev-prod.yml`

## Testing

Tested in production - OAuth login now works correctly with Google.

## Impact

This change ensures OAuth will continue to work after CD deployments without manual intervention.