### PR TITLE
fix: Use full registry paths for Docker images

### DIFF
--- a/deployment/docker-compose.dev-prod.yml
+++ b/deployment/docker-compose.dev-prod.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   # Nginx reverse proxy - containerized to replace standalone service
   nginx:
-    image: ciris-nginx:latest  # Will be pulled from ghcr.io and tagged locally
+    image: ghcr.io/cirisai/ciris-nginx:latest
     container_name: ciris-nginx
     network_mode: host  # Use host network to access containers on bridge
     volumes:
@@ -18,7 +18,7 @@ services:
     restart: unless-stopped
   # Development: Single Datum agent with Mock LLM for testing
   agent-datum:
-    image: ciris-agent:latest  # Will be pulled from ghcr.io and tagged locally
+    image: ghcr.io/cirisai/ciris-agent:latest
     container_name: ciris-agent-datum
     ports:
       - "127.0.0.1:8080:8080"  # Expose to localhost only for nginx
@@ -58,7 +58,7 @@ services:
 
   # GUI Application
   ciris-gui:
-    image: ciris-gui:latest  # Will be pulled from ghcr.io and tagged locally
+    image: ghcr.io/cirisai/ciris-gui:latest
     container_name: ciris-gui
     ports:
       - "127.0.0.1:3000:3000"  # Expose to localhost only for nginx


### PR DESCRIPTION
## Problem

The deployment failed with:
```
Error response from daemon: pull access denied for ciris-gui, 
repository does not exist or may require 'docker login'
```

## Root Cause

The `docker-compose.dev-prod.yml` file was using short image names without the registry prefix:
- ❌ `ciris-nginx:latest`
- ❌ `ciris-agent:latest`
- ❌ `ciris-gui:latest`

Docker Compose doesn't know these are in GitHub Container Registry - it tries Docker Hub by default.

## Solution

Use full registry paths:
- ✅ `ghcr.io/cirisai/ciris-nginx:latest`
- ✅ `ghcr.io/cirisai/ciris-agent:latest`
- ✅ `ghcr.io/cirisai/ciris-gui:latest`

## Impact

This fixes the deployment failure and ensures `docker-compose pull` can correctly fetch images from GitHub Container Registry.

## Testing

Verified that these are the correct image paths by checking existing containers on production server.