### PR TITLE
fix: Test suite updates for type safety improvements

### DIFF
--- a/tests/adapters/api/test_api_adapter.py
+++ b/tests/adapters/api/test_api_adapter.py
@@ -314,10 +314,10 @@ class TestAPIChannelManagement:
             channels = api_platform.get_channel_list()
             
             assert len(channels) == 2
-            assert any(c["channel_id"] == "api_127.0.0.1_8888" for c in channels)
-            assert any(c["channel_id"] == "api_192.168.1.1_8080" for c in channels)
-            assert all(c["channel_type"] == "api" for c in channels)
-            assert all(c["is_active"] for c in channels)
+            assert any(c.channel_id == "api_127.0.0.1_8888" for c in channels)
+            assert any(c.channel_id == "api_192.168.1.1_8080" for c in channels)
+            assert all(c.channel_type == "api" for c in channels)
+            assert all(c.is_active for c in channels)
 
 
 class TestAPIErrorHandling:

--- a/tests/adapters/api/test_api_communication.py
+++ b/tests/adapters/api/test_api_communication.py
@@ -203,16 +203,16 @@ class TestAPICommunicationMessageFetching:
             assert len(messages) == 2
             
             # Check observe message
-            assert messages[0]["content"] == "User message 1"
-            assert messages[0]["author_id"] == "user1"
-            assert messages[0]["author_name"] == "User One"
-            assert messages[0]["is_agent_message"] is False
+            assert messages[0].content == "User message 1"
+            assert messages[0].author_id == "user1"
+            assert messages[0].author_name == "User One"
+            assert messages[0].is_bot is False
             
             # Check speak message
-            assert messages[1]["content"] == "Bot response 1"
-            assert messages[1]["author_id"] == "ciris"
-            assert messages[1]["author_name"] == "CIRIS"
-            assert messages[1]["is_agent_message"] is True
+            assert messages[1].content == "Bot response 1"
+            assert messages[1].author_id == "ciris"
+            assert messages[1].author_name == "CIRIS"
+            assert messages[1].is_bot is True
     
     @pytest.mark.asyncio
     async def test_fetch_messages_with_before_timestamp(self, communication_service):

--- a/tests/adapters/cli/test_cli_implementation.py
+++ b/tests/adapters/cli/test_cli_implementation.py
@@ -300,9 +300,9 @@ class TestCLIAdapterChannelManagement:
             
             # Check that we have channels
             channel = channels[0]
-            assert "channel_id" in channel
-            assert "channel_name" in channel
-            assert "channel_type" in channel
+            assert hasattr(channel, 'channel_id')
+            assert hasattr(channel, 'channel_name')
+            assert hasattr(channel, 'channel_type')
     
     @pytest.mark.asyncio
     async def test_channel_activity_update(self, cli_adapter):
@@ -323,7 +323,7 @@ class TestCLIAdapterChannelManagement:
             
             # Get initial activity
             initial_channels = cli_adapter.get_channel_list()
-            initial_activity = initial_channels[0]["last_activity"]
+            initial_activity = initial_channels[0].last_activity
             
             # Wait a bit
             await asyncio.sleep(0.01)
@@ -337,7 +337,7 @@ class TestCLIAdapterChannelManagement:
             
             # Check updated activity
             updated_channels = cli_adapter.get_channel_list()
-            updated_activity = updated_channels[0]["last_activity"]
+            updated_activity = updated_channels[0].last_activity
         
         # Activity should be updated
         assert updated_activity >= initial_activity


### PR DESCRIPTION
## Summary
Fixed 4 failing tests related to type safety improvements where Dict[str, Any] was replaced with typed objects.

## Changes
- Fixed CLI adapter tests to use ChannelContext attributes instead of dict access
- Fixed API adapter tests to use ChannelContext attributes instead of dict access  
- Fixed API communication tests to use FetchedMessage attributes instead of dict access
- Changed from is_agent_message to is_bot field name

## Context
These tests were failing after our type safety improvements in PR #301. This completes the migration from untyped dictionaries to proper Pydantic models.

🤖 Generated with [Claude Code](https://claude.ai/code)