### PR TITLE
Fix: Mount manager-generated nginx config for dynamic agent routes

### DIFF
--- a/deployment/docker-compose.dev-prod.yml
+++ b/deployment/docker-compose.dev-prod.yml
@@ -10,8 +10,10 @@ services:
       # SSL certificates from host
       - /etc/letsencrypt:/etc/letsencrypt:ro
       - ./nginx/logs:/var/log/nginx
-      # Mount nginx config
-      - /home/ciris/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      # Mount nginx config directory
+      - ./nginx/agents.ciris.ai-dev.conf:/etc/nginx/conf.d/default.conf:ro
+      # Mount manager-generated agent routes
+      - /opt/ciris-manager/nginx/agents.conf:/etc/nginx/conf.d/agents.conf:ro
     depends_on:
       - ciris-gui
       - agent-datum


### PR DESCRIPTION
## Problem
New agents created by CIRISManager don't appear in the GUI because nginx routes aren't updated.

## Root Cause
- CIRISManager couldn't write nginx config due to permissions
- Manager runs as ciris-manager user, can't write to /home/ciris/
- Falls back to NoOpNginxManager (silent failure)

## Solution
Mount manager's nginx config directory into nginx container:
- Manager writes to /opt/ciris-manager/nginx/agents.conf (has permissions)
- Nginx reads from mounted volume
- Dynamic route updates work properly

## Testing
1. Deploy updated docker-compose
2. CIRISManager regenerates nginx config
3. New agents appear in GUI login dropdown

Coordinates with CIRISManager PR for the manager-side changes.