### PR TITLE
fix: Set loadingAgents to false after loading from CIRISManager

### DIFF
--- a/CIRISGUI/apps/agui/app/login/page.tsx
+++ b/CIRISGUI/apps/agui/app/login/page.tsx
@@ -57,6 +57,7 @@ export default function LoginPage() {
             const healthyAgent = agentsList.find(a => a.health === 'healthy') || agentsList[0];
             setSelectedAgent(healthyAgent.agent_id);
           }
+          setLoadingAgents(false); // Important: set loading to false!
           return; // Exit early for managed mode
         }
       } catch (error) {


### PR DESCRIPTION
The login page was successfully detecting CIRISManager and loading agents, but the UI remained stuck showing 'Loading agents...' because we forgot to call setLoadingAgents(false) in the managed mode code path.

This one-line fix ensures the loading state is properly cleared after agents are loaded.