### PR TITLE
fix: Remove /v1 from managed mode - nginx already adds it

### DIFF
--- a/CIRISGUI/apps/agui/lib/sdk-config-manager.ts
+++ b/CIRISGUI/apps/agui/lib/sdk-config-manager.ts
@@ -34,8 +34,8 @@ class SDKConfigManager {
     // Determine the correct base URL
     let baseURL: string;
     if (mode === 'managed') {
-      // In managed mode, use /api/{agent_id}/v1 path
-      baseURL = `${window.location.origin}/api/${agentId}/v1`;
+      // In managed mode, use /api/{agent_id} path (nginx adds /v1)
+      baseURL = `${window.location.origin}/api/${agentId}`;
     } else {
       // In standalone mode, check if we have a stored API URL
       const storedApiUrl = localStorage.getItem(`agent_${agentId}_api_url`);
@@ -76,8 +76,8 @@ class SDKConfigManager {
     // During OAuth callback, we need to be extra careful about the base URL
     let baseURL: string;
     if (mode === 'managed') {
-      // Always use the proxied path in managed mode with /v1
-      baseURL = `${window.location.origin}/api/${agentId}/v1`;
+      // Always use the proxied path in managed mode (nginx adds /v1)
+      baseURL = `${window.location.origin}/api/${agentId}`;
     } else {
       // In standalone, use the origin
       baseURL = window.location.origin;


### PR DESCRIPTION
## The Real Fix

I was adding /v1 to the SDK base URL, but nginx already adds it!

## Nginx routing
-  → 

## What was happening
- SDK base URL: 
- API call: 
- Nginx routes to:  ❌ 404

## Now
- SDK base URL: 
- API call:   
- Nginx routes to:  ✅

This should finally fix the OAuth dashboard!