### PR TITLE
fix: Remove /v1 from OAuth URLs in login page - nginx adds it automatically

### DIFF
--- a/CIRISGUI/apps/agui/app/login/page.tsx
+++ b/CIRISGUI/apps/agui/app/login/page.tsx
@@ -165,7 +165,7 @@ export default function LoginPage() {
       if (agents.length > 1 || agent.container_name !== 'standalone') {
         // Managed mode: use agent-specific paths
         redirectUri = encodeURIComponent(`${window.location.origin}/oauth/${selectedAgent}/callback`);
-        oauthUrl = `${window.location.origin}/api/${agent.agent_id}/v1/auth/oauth/${provider}/login`;
+        oauthUrl = `${window.location.origin}/api/${agent.agent_id}/auth/oauth/${provider}/login`;
       } else {
         // Standalone mode: direct OAuth
         redirectUri = encodeURIComponent(`${window.location.origin}/oauth/callback`);


### PR DESCRIPTION
## Problem
OAuth authentication was failing with 404 errors because the login page was constructing URLs with /v1/ hardcoded, but nginx already adds /v1/ when proxying requests.

## Solution
Remove /v1/ from the OAuth URL construction in managed mode. This aligns with how the SDK works and prevents the double /v1/v1/ path issue.

## Changes
- Line 168: Changed from `/api/${agent.agent_id}/v1/auth/oauth/${provider}/login` to `/api/${agent.agent_id}/auth/oauth/${provider}/login`
- Standalone mode remains unchanged (correctly uses /v1/ directly)

## Testing
- This fixes the production OAuth issue at agents.ciris.ai
- Simple string change that won't affect any tests