### PR TITLE
fix: Strip /v1 from SDK paths in managed mode since nginx adds it

### DIFF
--- a/CIRISGUI/apps/agui/lib/ciris-sdk/transport.ts
+++ b/CIRISGUI/apps/agui/lib/ciris-sdk/transport.ts
@@ -261,6 +261,11 @@ export class Transport {
       url = new URL(path);
     } else {
       // Path is relative, combine with baseURL
+      // In managed mode (when baseURL contains /api/), nginx adds /v1
+      // so we need to strip it from SDK paths
+      if (this.baseURL.includes('/api/') && path.startsWith('/v1/')) {
+        path = path.substring(3); // Remove '/v1' prefix
+      }
       url = new URL(path, this.baseURL);
     }
 


### PR DESCRIPTION
## Problem
After OAuth login, the dashboard shows 404 errors because the SDK is adding /v1/ to paths, but nginx is already adding /v1/ when proxying requests.

## Root Cause
- Nginx rewrites `/api/datum/foo` → `http://agent_datum/v1/foo`
- SDK adds `/v1/` to all paths
- Result: `/api/datum/v1/system/health` → `/v1/v1/system/health` (double v1)

## Solution
Detect managed mode in the transport layer (when baseURL contains '/api/') and strip '/v1/' prefix from paths before making requests.

## Why this approach?
- Minimal change - just 5 lines in transport.ts
- Doesn't break OAuth (constructed manually)
- Doesn't break standalone mode (no /api/ in URL)
- Avoids changing 50+ resource files
- Future-proof: works with any nginx routing