### PR TITLE
fix: Properly handle URL construction when stripping /v1 prefix

### DIFF
--- a/CIRISGUI/apps/agui/app/dashboard/page.tsx
+++ b/CIRISGUI/apps/agui/app/dashboard/page.tsx
@@ -213,12 +213,19 @@ export default function DashboardPage() {
                     <br />
                     - Auth Token: {AuthStore.getAccessToken() ? 'Present' : 'Missing'}
                     <br />
-                    - Expected URL: {window.location.origin}/api/{currentAgent?.agent_id}/v1/*
+                    - Agent ID: {currentAgent?.agent_id || 'Not set'}
+                    <br />
+                    - SDK Transport Base: {(cirisClient as any).transport?.getBaseURL?.() || 'Unknown'}
                   </p>
                   {healthError && (
-                    <p className="mt-2 font-mono text-xs">
-                      Error: {healthError.message}
-                    </p>
+                    <div className="mt-2">
+                      <p className="font-mono text-xs">
+                        Error: {healthError.message}
+                      </p>
+                      <p className="font-mono text-xs text-red-600">
+                        Check Network Tab: The failing URL will show what's actually being called
+                      </p>
+                    </div>
                   )}
                 </div>
               </div>

--- a/CIRISGUI/apps/agui/lib/ciris-sdk/transport.ts
+++ b/CIRISGUI/apps/agui/lib/ciris-sdk/transport.ts
@@ -264,9 +264,13 @@ export class Transport {
       // In managed mode (when baseURL contains /api/), nginx adds /v1
       // so we need to strip it from SDK paths
       if (this.baseURL.includes('/api/') && path.startsWith('/v1/')) {
-        path = path.substring(3); // Remove '/v1' prefix
+        // Remove '/v1' prefix and ensure path doesn't start with /
+        path = path.substring(4); // This gives us 'auth/me' instead of '/auth/me'
       }
-      url = new URL(path, this.baseURL);
+      
+      // Ensure baseURL ends with / for proper URL construction
+      const base = this.baseURL.endsWith('/') ? this.baseURL : this.baseURL + '/';
+      url = new URL(path, base);
     }
 
     if (params) {
@@ -277,9 +281,14 @@ export class Transport {
       });
     }
 
-    // Debug logging in development
-    if (process.env.NODE_ENV === 'development') {
-      console.log('[CIRIS SDK] Request URL:', url.toString());
+    // Debug logging
+    if (process.env.NODE_ENV === 'development' || this.baseURL.includes('/api/')) {
+      console.log('[CIRIS SDK] Transport debug:', {
+        baseURL: this.baseURL,
+        originalPath: path,
+        strippedV1: this.baseURL.includes('/api/') && path.startsWith('/v1/'),
+        finalURL: url.toString()
+      });
     }
 
     return url.toString();


### PR DESCRIPTION
## The Real Issue
When stripping '/v1/' from paths like '/v1/auth/me', we were getting '/auth/me' with a leading slash. The JavaScript URL constructor treats paths starting with '/' as absolute from the origin, completely ignoring the base path\!

Example:
```javascript
new URL('/auth/me', 'https://agents.ciris.ai/api/datum')
// Results in: https://agents.ciris.ai/auth/me (WRONG - lost /api/datum)

new URL('auth/me', 'https://agents.ciris.ai/api/datum/')  
// Results in: https://agents.ciris.ai/api/datum/auth/me (CORRECT)
```

## Fix
1. Changed substring from 3 to 4 chars to remove '/v1/' completely
2. Ensure baseURL ends with '/' for proper relative URL construction
3. Added debug logging to help diagnose issues
4. Enhanced dashboard error display

This should finally fix the OAuth + API access issue in production.