### PR TITLE
SECURITY: Fix timing attack vulnerability in password verification

### DIFF
--- a/ciris_engine/logic/services/infrastructure/authentication.py
+++ b/ciris_engine/logic/services/infrastructure/authentication.py
@@ -855,7 +855,9 @@ class AuthenticationService(BaseInfrastructureService, AuthenticationServiceProt
                 iterations=100000,
             )
             key = kdf.derive(password.encode())
-            return key == stored_key
+            # Use constant-time comparison to prevent timing attacks
+            import hmac
+            return hmac.compare_digest(key, stored_key)
         except Exception:
             return False
 


### PR DESCRIPTION
## Security Issue Found
The failing CI test revealed a real security vulnerability - password verification was not using constant-time comparison.

## The Problem
Using Python's `==` operator for comparing password hashes can leak timing information because it returns early on the first mismatch. Attackers can use this timing difference to guess passwords byte by byte.

## The Fix
1. **Use `hmac.compare_digest()`** - This performs constant-time comparison
2. **Improve the test**:
   - More iterations (50 instead of 10)
   - Use `time.perf_counter()` for precision
   - Remove outliers for stability
   - Better error messages

## Impact
This vulnerability could allow timing attacks against password verification. While PBKDF2 with 100k iterations provides some protection, constant-time comparison is a security best practice.

Thanks to the flaky test for catching this\!