### PR TITLE
fix: Add missing /oauth segment to Manager callback URL

### DIFF
--- a/CIRISGUI/apps/agui/app/login/page.tsx
+++ b/CIRISGUI/apps/agui/app/login/page.tsx
@@ -215,7 +215,7 @@ export default function LoginPage() {
   const handleManagerGoogleLogin = async () => {
     try {
       // Redirect to Manager OAuth endpoint through nginx proxy
-      const redirectUri = encodeURIComponent(`${window.location.origin}/manager/callback`);
+      const redirectUri = encodeURIComponent(`${window.location.origin}/manager/oauth/callback`);
       // Always use the nginx proxy path
       const managerUrl = `${window.location.origin}/manager/v1/oauth/login`;
       window.location.href = `${managerUrl}?redirect_uri=${redirectUri}`;


### PR DESCRIPTION
## Summary
- Fixed Manager OAuth login callback path mismatch
- Frontend was sending to `/manager/callback` but backend expects `/manager/oauth/callback`
- Added missing `/oauth` segment to align with CIRISManager's compatibility redirect

## The Fix
Changed line 218 in `app/login/page.tsx`:
```typescript
// Before:
const redirectUri = encodeURIComponent(`${window.location.origin}/manager/callback`);

// After:
const redirectUri = encodeURIComponent(`${window.location.origin}/manager/oauth/callback`);
```

## Test Plan
- [ ] Click "Manager Access" button on login page
- [ ] Verify redirect URL contains `/manager/oauth/callback`
- [ ] Confirm successful authentication and landing on Manager dashboard
- [ ] Check for `manager_token` cookie after successful auth

🤖 Generated with [Claude Code](https://claude.ai/code)