### PR TITLE
fix: Fix CIRISRuntime test initialization errors

### DIFF
--- a/tests/adapters/api/test_oauth_permissions.py
+++ b/tests/adapters/api/test_oauth_permissions.py
@@ -18,12 +18,16 @@ from fastapi import status
 from ciris_engine.logic.adapters.api.app import create_app
 from ciris_engine.logic.adapters.api.services.auth_service import APIAuthService, OAuthUser, UserRole
 from ciris_engine.logic.runtime.ciris_runtime import CIRISRuntime
+from ciris_engine.logic.runtime.prevent_sideeffects import allow_runtime_creation
 from ciris_engine.schemas.config.essential import EssentialConfig
 
 
 @pytest_asyncio.fixture
 async def test_runtime():
     """Create a test runtime for OAuth testing."""
+    # Allow runtime creation in tests
+    allow_runtime_creation()
+    
     config = EssentialConfig()
     config.services.llm_endpoint = "mock://localhost"
     config.services.llm_model = "mock"

--- a/tests/api/test_system_extensions_integration.py
+++ b/tests/api/test_system_extensions_integration.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock
 
 from ciris_engine.logic.adapters.api.app import create_app
 from ciris_engine.logic.runtime.ciris_runtime import CIRISRuntime
+from ciris_engine.logic.runtime.prevent_sideeffects import allow_runtime_creation
 from ciris_engine.logic.services.runtime.control_service import RuntimeControlService
 from ciris_engine.schemas.config.essential import EssentialConfig
 from ciris_engine.schemas.adapters import AdapterServiceRegistration
@@ -22,6 +23,9 @@ from ciris_engine.logic.registries.base import Priority, SelectionStrategy
 @pytest_asyncio.fixture
 async def test_runtime():
     """Create a test runtime with mock services."""
+    # Allow runtime creation in tests
+    allow_runtime_creation()
+    
     # Create proper EssentialConfig with nested configs
     from ciris_engine.schemas.config.essential import ServiceEndpointsConfig
     


### PR DESCRIPTION
## Summary
Fix the `TypeError: object.__new__() takes exactly one argument` error that was causing test failures and stopping test runs early.

## Root Cause
The CIRISRuntime constructor checks the `CIRIS_IMPORT_MODE` environment variable and prevents runtime creation during imports to avoid side effects. The tests set this env var in conftest.py but didn't call `allow_runtime_creation()` before creating runtime instances.

## Changes
- Add `allow_runtime_creation()` call to test fixtures that create CIRISRuntime
- Fixed in:
  - `tests/adapters/api/test_oauth_permissions.py`
  - `tests/api/test_system_extensions_integration.py`

## Impact
- Tests will now run to completion instead of stopping at test 314
- Full test coverage will be calculated
- CI builds will pass

🤖 Generated with [Claude Code](https://claude.ai/code)