### PR TITLE
fix: Robust OAuth permission test runtime creation

### DIFF
--- a/logs/.current_incident_log
+++ b/logs/.current_incident_log
@@ -1,1 +1,1 @@
-/app/logs/incidents_20250804_000839.log
+/home/emoore/CIRISAgent/logs/incidents_20250804_011135.log

--- a/logs/.current_log
+++ b/logs/.current_log
@@ -1,1 +1,1 @@
-/app/logs/ciris_agent_20250804_000839.log
+/home/emoore/CIRISAgent/logs/ciris_agent_20250804_011135.log

--- a/tests/adapters/api/test_oauth_permissions.py
+++ b/tests/adapters/api/test_oauth_permissions.py
@@ -25,25 +25,29 @@ from ciris_engine.schemas.config.essential import EssentialConfig
 @pytest_asyncio.fixture
 async def test_runtime():
     """Create a test runtime for OAuth testing."""
-    # Allow runtime creation in tests
-    import os
-    os.environ.pop('CIRIS_IMPORT_MODE', None)  # Force allow runtime creation
-    allow_runtime_creation()  # Call the function to allow runtime creation
+    # Allow runtime creation for this test
+    allow_runtime_creation()
     
-    config = EssentialConfig()
-    config.services.llm_endpoint = "mock://localhost"
-    config.services.llm_model = "mock"
-    
-    runtime = CIRISRuntime(
-        adapter_types=["api"],
-        essential_config=config,
-        startup_channel_id="test_oauth",
-        mock_llm=True
-    )
-    
-    await runtime.initialize()
-    yield runtime
-    await runtime.shutdown()
+    try:
+        config = EssentialConfig()
+        config.services.llm_endpoint = "mock://localhost"
+        config.services.llm_model = "mock"
+        
+        runtime = CIRISRuntime(
+            adapter_types=["api"],
+            essential_config=config,
+            startup_channel_id="test_oauth",
+            mock_llm=True
+        )
+        
+        await runtime.initialize()
+        yield runtime
+        await runtime.shutdown()
+    finally:
+        # Restore original state to avoid affecting other tests
+        import os
+        if os.environ.get('CIRIS_IMPORT_MODE') is None:
+            os.environ['CIRIS_IMPORT_MODE'] = 'true'
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- Remove os.environ manipulation that interfered with allow_runtime_creation()
- Follow the proven pattern from test_ciris_runtime.py
- Use try/finally to restore CIRIS_IMPORT_MODE after test

## Why This Fix Works
The previous approach was calling  before , which interfered with the runtime creation mechanism. 

The robust pattern (used successfully in other tests):
1. Call  without any environment manipulation
2. Use try/finally to restore the original state after the test

## Testing
- Test passes locally
- Matches pattern used in test_ciris_runtime.py and other working tests