### PR TITLE
fix: Exclude tools directory from SonarCloud coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -16,7 +16,7 @@ sonar.sources=.
 sonar.python.coverage.reportPaths=coverage.xml
 
 # Exclude everything except ciris_engine
-sonar.exclusions=CIRISGUI/**/*,CIRISVoice/**/*,FSD/**/*,ciris_adk/**/*,ciris_mypy_toolkit/**/*,ciris_profiles/**/*,ciris_sdk/**/*,config/**/*,data_archive/**/*,docker/**/*,docs/**/*,htmlcov/**/*,logs/**/*,scripts/**/*,tests/**/*,ciris_engine/persistence/migrations/*.sql,*.md,*.txt,*.yaml,*.yml,*.json,*.ini,*.sh,*.lock,*.toml,Dockerfile,docker-compose.yml
+sonar.exclusions=CIRISGUI/**/*,CIRISVoice/**/*,FSD/**/*,ciris_adk/**/*,ciris_mypy_toolkit/**/*,ciris_profiles/**/*,ciris_sdk/**/*,config/**/*,data_archive/**/*,docker/**/*,docs/**/*,htmlcov/**/*,logs/**/*,scripts/**/*,tests/**/*,tools/**/*,ciris_engine/persistence/migrations/*.sql,*.md,*.txt,*.yaml,*.yml,*.json,*.ini,*.sh,*.lock,*.toml,Dockerfile,docker-compose.yml
 
 # Include all Python files
 sonar.inclusions=**/*.py

--- a/tools/test_tool/log_parser.py
+++ b/tools/test_tool/log_parser.py
@@ -33,7 +33,7 @@ class LogParser:
     )
     ERROR_HEADER_PATTERN = re.compile(
         r'^_{5,}\s+(ERROR|FAILED|FAILURE)\s+.+\s+_{5,}$'
-    )
+    )  # sonar-hotspot: safe - regex is simple with no nested quantifiers or complex backtracking
     TEST_STATS_PATTERN = re.compile(
         r'^=+\s*(\d+)\s+passed(?:,\s*(\d+)\s+skipped)?(?:,\s*(\d+)\s+warnings)?(?:,\s*(\d+)\s+error)?(?:,\s*(\d+)\s+failed)?'
     )

--- a/tools/test_tool/runner.py
+++ b/tools/test_tool/runner.py
@@ -114,7 +114,7 @@ class TestRunner:
             if pid:
                 # Check if process is still running
                 try:
-                    os.kill(pid, 0)
+                    os.kill(pid, 0)  # sonar-hotspot: safe - signal 0 only checks if process exists, doesn't terminate
                     return True
                 except ProcessLookupError:
                     return False


### PR DESCRIPTION
## Summary
- Add tools/**/* to sonar.exclusions in sonar-project.properties
- Also added sonar-hotspot comments to the 2 flagged lines (though they'll be excluded anyway)

## Benefits
1. **Removes 2 security hotspots** from tools/test_tool/
2. **Improves coverage percentage** by excluding non-production code
3. **Follows best practices** - dev tools shouldn't count against coverage
4. **Better reflects actual code quality** of the production ciris_engine

## Why This Makes Sense
- Tools are development utilities, not production code
- Industry standard is to exclude build tools, scripts, and dev utilities
- Coverage should focus on the actual application code that runs in production