### PR TITLE
fix: Exclude non-core directories from SonarCloud coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -16,7 +16,7 @@ sonar.sources=.
 sonar.python.coverage.reportPaths=coverage.xml
 
 # Exclude everything except ciris_engine
-sonar.exclusions=CIRISGUI/**/*,CIRISVoice/**/*,FSD/**/*,ciris_adk/**/*,ciris_mypy_toolkit/**/*,ciris_profiles/**/*,ciris_sdk/**/*,config/**/*,data_archive/**/*,docker/**/*,docs/**/*,htmlcov/**/*,logs/**/*,scripts/**/*,tests/**/*,tools/**/*,ciris_engine/persistence/migrations/*.sql,*.md,*.txt,*.yaml,*.yml,*.json,*.ini,*.sh,*.lock,*.toml,Dockerfile,docker-compose.yml
+sonar.exclusions=CIRISGUI/**/*,CIRISVoice/**/*,FSD/**/*,ciris_adk/**/*,ciris_mypy_toolkit/**/*,ciris_profiles/**/*,ciris_sdk/**/*,config/**/*,data_archive/**/*,docker/**/*,docs/**/*,htmlcov/**/*,logs/**/*,scripts/**/*,tests/**/*,tools/**/*,ciris_modular_services/**/*,deployment/**/*,wyoming/**/*,ciris_engine/persistence/migrations/*.sql,*.md,*.txt,*.yaml,*.yml,*.json,*.ini,*.sh,*.lock,*.toml,Dockerfile,docker-compose.yml
 
 # Include all Python files
 sonar.inclusions=**/*.py


### PR DESCRIPTION
## Summary
Exclude additional non-core directories from SonarCloud coverage analysis:
- **ciris_modular_services/**: Mock LLM and other modular service implementations
- **deployment/**: Deployment scripts, Docker configs, and infrastructure code
- **wyoming/**: Voice/Wyoming protocol components

## Rationale
These directories contain:
- Development/testing utilities (mock LLM)
- Infrastructure/deployment code (not application logic)
- Optional voice components (Wyoming protocol)

Coverage should focus on the core ciris_engine production code that runs the agent's logic.

## Expected Impact
- Further improved coverage percentage
- More accurate representation of core code quality
- Removes noise from auxiliary components