### PR TITLE
fix: Add OAuth config path fallback for managed/standalone modes

### DIFF
--- a/ciris_engine/logic/adapters/api/routes/auth.py
+++ b/ciris_engine/logic/adapters/api/routes/auth.py
@@ -237,7 +237,13 @@ async def list_oauth_providers(
     import json
     from pathlib import Path
     
-    oauth_config_file = Path.home() / OAUTH_CONFIG_DIR / OAUTH_CONFIG_FILE
+    # Check shared volume first (managed mode), then fall back to local (standalone)
+    oauth_config_file = Path("/home/ciris/shared/oauth/oauth.json")
+    if not oauth_config_file.exists():
+        oauth_config_file = Path.home() / OAUTH_CONFIG_DIR / OAUTH_CONFIG_FILE
+        logger.debug(f"Using local OAuth config: {oauth_config_file}")
+    else:
+        logger.debug(f"Using shared OAuth config: {oauth_config_file}")
     
     if not oauth_config_file.exists():
         return OAuthProvidersResponse(providers=[])
@@ -292,7 +298,13 @@ async def configure_oauth_provider(
     import json
     from pathlib import Path
     
-    oauth_config_file = Path.home() / OAUTH_CONFIG_DIR / OAUTH_CONFIG_FILE
+    # Check shared volume first (managed mode), then fall back to local (standalone)
+    oauth_config_file = Path("/home/ciris/shared/oauth/oauth.json")
+    if not oauth_config_file.exists():
+        oauth_config_file = Path.home() / OAUTH_CONFIG_DIR / OAUTH_CONFIG_FILE
+        logger.debug(f"Using local OAuth config: {oauth_config_file}")
+    else:
+        logger.debug(f"Using shared OAuth config: {oauth_config_file}")
     oauth_config_file.parent.mkdir(exist_ok=True, mode=0o700)
     
     # Load existing config
@@ -352,7 +364,13 @@ async def oauth_login(
     from pathlib import Path
     import urllib.parse
     
-    oauth_config_file = Path.home() / OAUTH_CONFIG_DIR / OAUTH_CONFIG_FILE
+    # Check shared volume first (managed mode), then fall back to local (standalone)
+    oauth_config_file = Path("/home/ciris/shared/oauth/oauth.json")
+    if not oauth_config_file.exists():
+        oauth_config_file = Path.home() / OAUTH_CONFIG_DIR / OAUTH_CONFIG_FILE
+        logger.debug(f"Using local OAuth config: {oauth_config_file}")
+    else:
+        logger.debug(f"Using shared OAuth config: {oauth_config_file}")
     
     if not oauth_config_file.exists():
         raise HTTPException(
@@ -452,7 +470,13 @@ async def oauth_callback(
     from pathlib import Path
     
     # Load OAuth configuration
-    oauth_config_file = Path.home() / OAUTH_CONFIG_DIR / OAUTH_CONFIG_FILE
+    # Check shared volume first (managed mode), then fall back to local (standalone)
+    oauth_config_file = Path("/home/ciris/shared/oauth/oauth.json")
+    if not oauth_config_file.exists():
+        oauth_config_file = Path.home() / OAUTH_CONFIG_DIR / OAUTH_CONFIG_FILE
+        logger.debug(f"Using local OAuth config: {oauth_config_file}")
+    else:
+        logger.debug(f"Using shared OAuth config: {oauth_config_file}")
     
     if not oauth_config_file.exists():
         raise HTTPException(

--- a/ciris_engine/logic/infrastructure/sub_services/wa_cli_oauth.py
+++ b/ciris_engine/logic/infrastructure/sub_services/wa_cli_oauth.py
@@ -38,9 +38,11 @@ class WACLIOAuthService:
         self.time_service = time_service
         self.console = Console()
 
-        # OAuth configuration
-        self.oauth_config_file = Path.home() / ".ciris" / "oauth.json"
-        self.oauth_config_file.parent.mkdir(exist_ok=True, mode=0o700)
+        # OAuth configuration - check shared volume first (managed mode), then local
+        self.oauth_config_file = Path("/home/ciris/shared/oauth/oauth.json")
+        if not self.oauth_config_file.exists():
+            self.oauth_config_file = Path.home() / ".ciris" / "oauth.json"
+            self.oauth_config_file.parent.mkdir(exist_ok=True, mode=0o700)
 
         # OAuth callback data storage
         self._oauth_callback_data: Optional[OAuthCallbackData] = None


### PR DESCRIPTION
## Summary
Simple, robust fix to support OAuth configuration in both managed (CIRISManager) and standalone deployments.

## Problem
Agents need to access OAuth configuration from different paths depending on deployment mode:
- **Managed mode**: `/home/ciris/shared/oauth/oauth.json` (shared volume)
- **Standalone mode**: `~/.ciris/oauth.json` (local)

## Solution
Check shared path first, fall back to local if not found. Simple as that.

```python
# Check shared volume first (managed mode), then fall back to local (standalone)
oauth_config_file = Path("/home/ciris/shared/oauth/oauth.json")
if not oauth_config_file.exists():
    oauth_config_file = Path.home() / OAUTH_CONFIG_DIR / OAUTH_CONFIG_FILE
```

## Changes
- Updated `auth.py` - 4 locations where OAuth config is accessed
- Updated `wa_cli_oauth.py` - 1 location in constructor
- Added debug logging to show which path is being used
- No breaking changes - fully backwards compatible

## Benefits
- ✅ Zero coordination required between containers
- ✅ Works for both deployment modes seamlessly
- ✅ Clear precedence: shared > local
- ✅ Simple, maintainable code
- ✅ Self-documenting with debug logs

## Testing
All OAuth tests pass - no functionality changes, just path resolution.

🤖 Generated with [Claude Code](https://claude.ai/code)