### PR TITLE
fix: Make version test resilient to version changes

### DIFF
--- a/tests/ciris_engine/logic/context/test_system_snapshot.py
+++ b/tests/ciris_engine/logic/context/test_system_snapshot.py
@@ -270,7 +270,15 @@ async def test_build_system_snapshot_with_version_info():
     snapshot = await build_system_snapshot(task=None, thought=None, resource_monitor=resource_monitor)
 
     assert isinstance(snapshot, SystemSnapshot)
-    # Version info should be present
-    assert snapshot.agent_version == "1.1.2-beta"
+    # Version info should be present and valid
+    assert snapshot.agent_version is not None
+    assert isinstance(snapshot.agent_version, str)
+    assert len(snapshot.agent_version) > 0
+    # Check it matches semantic versioning pattern (e.g., "1.1.2-beta")
+    import re
+
+    assert re.match(
+        r"^\d+\.\d+\.\d+(-\w+)?$", snapshot.agent_version
+    ), f"Invalid version format: {snapshot.agent_version}"
     assert snapshot.agent_codename == "Graceful Guardian"
     # code_hash might be None in tests

--- a/tools/install_smart_commit.sh
+++ b/tools/install_smart_commit.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Install smart commit functionality
+# This makes pre-commit hooks automatically re-stage formatted files
+
+set -e
+
+echo "Installing smart commit functionality..."
+
+# Create a simple wrapper that handles file modifications
+cat > .git/hooks/pre-commit << 'EOF'
+#!/bin/bash
+# Auto-restage files modified by pre-commit hooks
+# Simple and robust - just run pre-commit twice if needed
+
+# First run
+pre-commit run
+EXIT_CODE=$?
+
+# If it failed, check if files were modified
+if [ $EXIT_CODE -ne 0 ]; then
+    # Check for any unstaged changes
+    if ! git diff --quiet; then
+        echo ""
+        echo "Re-staging files modified by hooks..."
+        git add -u  # Stage all modified files that were already tracked
+
+        echo "Running hooks again..."
+        pre-commit run
+        EXIT_CODE=$?
+    fi
+fi
+
+exit $EXIT_CODE
+EOF
+
+chmod +x .git/hooks/pre-commit
+
+echo "✅ Smart commit installed!"
+echo ""
+echo "How it works:"
+echo "  1. Runs pre-commit hooks"
+echo "  2. If files are modified by hooks (formatting, etc), stages them"
+echo "  3. Runs hooks again to verify"
+echo ""
+echo "Just use 'git commit' normally - it will handle the rest!"


### PR DESCRIPTION
The test was checking for a specific version (1.1.0-beta) which broke when we bumped to 1.1.2-beta.

Now the test:
- Validates version exists and is a string
- Checks it matches semantic versioning pattern (X.Y.Z or X.Y.Z-suffix)
- Doesn't care about the actual version number

This prevents CI/CD failures when we bump versions.

Also improved the git hook to automatically re-stage files modified by pre-commit hooks (black, etc).