### PR TITLE
Critical fix: SDK URL building causing 404s after OAuth login

### DIFF
--- a/CIRISGUI/apps/agui/lib/ciris-sdk/transport.ts
+++ b/CIRISGUI/apps/agui/lib/ciris-sdk/transport.ts
@@ -261,9 +261,11 @@ export class Transport {
       url = new URL(path);
     } else {
       // Path is relative, combine with baseURL
+      // Remove leading slash from path to ensure proper concatenation
+      const cleanPath = path.startsWith('/') ? path.slice(1) : path;
       // Ensure baseURL ends with / for proper URL construction
       const base = this.baseURL.endsWith('/') ? this.baseURL : this.baseURL + '/';
-      url = new URL(path, base);
+      url = new URL(cleanPath, base);
     }
 
     if (params) {

--- a/CIRISGUI/apps/agui/lib/ciris-sdk/version.ts
+++ b/CIRISGUI/apps/agui/lib/ciris-sdk/version.ts
@@ -2,7 +2,7 @@
 // This file is auto-updated during build
 
 export const SDK_VERSION = {
-  version: '1.1.3-beta',
+  version: '1.1.4-beta',
   buildDate: new Date().toISOString(),
   gitHash: process.env.NEXT_PUBLIC_GIT_HASH || 'development',
   gitBranch: process.env.NEXT_PUBLIC_GIT_BRANCH || 'main',

--- a/CIRISGUI/apps/agui/package.json
+++ b/CIRISGUI/apps/agui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agui",
-  "version": "1.1.3-beta",
+  "version": "1.1.4-beta",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Fixed critical bug where SDK was building incorrect URLs in production
- OAuth login worked but all API calls returned 404

## Root Cause
The URL constructor in transport.ts was treating paths starting with '/' as absolute, causing:
- Base URL: `https://agents.ciris.ai/api/datum/`
- Path: `/v1/system/health`
- Result: `https://agents.ciris.ai/v1/system/health` (WRONG - missing /api/datum)

## Fix
Strip leading slash from paths before URL construction:
- Base URL: `https://agents.ciris.ai/api/datum/`
- Path: `v1/system/health` (slash removed)
- Result: `https://agents.ciris.ai/api/datum/v1/system/health` (CORRECT)

## Testing
- Version bumped to 1.1.4-beta for production verification
- Grace tool will monitor deployment

This fixes the production issue where users could log in via OAuth but got API configuration errors.