### PR TITLE
Critical Fix: TSDB None handling causing production failures

### DIFF
--- a/ciris_engine/__init__.py
+++ b/ciris_engine/__init__.py
@@ -1,6 +1,8 @@
 """CIRIS Engine - Core Agent Runtime and Services"""
 
-__version__ = "1.0.0-beta.1"
+from .constants import CIRIS_VERSION
+
+__version__ = CIRIS_VERSION
 
 # Import key runtime components for easy access
 from .logic.runtime.ciris_runtime import CIRISRuntime

--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -3,10 +3,10 @@
 from pathlib import Path
 
 # Version information
-CIRIS_VERSION = "1.1.3-beta"
+CIRIS_VERSION = "1.1.4-beta"
 CIRIS_VERSION_MAJOR = 1
 CIRIS_VERSION_MINOR = 1
-CIRIS_VERSION_PATCH = 3
+CIRIS_VERSION_PATCH = 4
 CIRIS_VERSION_BUILD = 0  # Build number for incremental improvements
 CIRIS_VERSION_STAGE = "beta"
 CIRIS_CODENAME = "Graceful Guardian"  # Codename for this release

--- a/ciris_engine/logic/services/graph/tsdb_consolidation/data_converter.py
+++ b/ciris_engine/logic/services/graph/tsdb_consolidation/data_converter.py
@@ -270,6 +270,14 @@ class TSDBDataConverter:
         try:
             # Convert dict to typed model if needed
             if isinstance(raw_task, dict):
+                # Clean thoughts list before creating RawTaskData
+                if "thoughts" in raw_task and raw_task["thoughts"]:
+                    cleaned_thoughts = []
+                    for thought in raw_task["thoughts"]:
+                        # Remove None values from thought dicts
+                        cleaned_thought = {k: v for k, v in thought.items() if v is not None}
+                        cleaned_thoughts.append(cleaned_thought)
+                    raw_task["thoughts"] = cleaned_thoughts
                 raw_task = RawTaskData(**raw_task)
             # Extract handlers from thoughts
             handlers_used = []
@@ -338,7 +346,9 @@ class TSDBDataConverter:
         try:
             # Convert dict to typed model if needed
             if isinstance(raw_thought, dict):
-                raw_thought = RawThoughtData(**raw_thought)
+                # Filter out None values that cause validation issues
+                cleaned_thought = {k: v for k, v in raw_thought.items() if v is not None}
+                raw_thought = RawThoughtData(**cleaned_thought)
             final_action = None
             handler = None
 

--- a/ciris_sdk/__init__.py
+++ b/ciris_sdk/__init__.py
@@ -94,4 +94,6 @@ __all__ = [
 ]
 
 # Version indicator for v1 API
-__version__ = "1.0.0-pre-beta"
+from ciris_engine.constants import CIRIS_VERSION
+
+__version__ = CIRIS_VERSION

--- a/tests/ciris_engine/logic/services/graph/test_tsdb_data_converter_none_handling.py
+++ b/tests/ciris_engine/logic/services/graph/test_tsdb_data_converter_none_handling.py
@@ -1,0 +1,105 @@
+"""Test that TSDBDataConverter properly handles None values from database.
+
+This test ensures that the converter can handle NULL database values
+that become None in Python dicts, which was causing validation errors
+in production.
+"""
+
+from ciris_engine.logic.services.graph.tsdb_consolidation.data_converter import RawThoughtData, TSDBDataConverter
+
+
+def test_thought_with_none_final_action():
+    """Test that thoughts with None final_action are handled correctly."""
+    # This simulates what comes from the database when final_action_json is NULL
+    raw_thought_dict = {
+        "thought_id": "test_thought_1",
+        "thought_type": "standard",
+        "status": "completed",
+        "created_at": "2025-08-07T00:00:00",
+        "final_action": None,  # This is what causes the issue in production
+        "content": "Test thought content",
+    }
+
+    # This should not raise a validation error
+    result = TSDBDataConverter._convert_thought(raw_thought_dict)
+
+    assert result is not None
+    assert result.thought_id == "test_thought_1"
+    assert result.final_action is None
+    assert result.handler is None
+
+
+def test_task_with_thoughts_containing_none():
+    """Test that tasks with thoughts containing None values are handled."""
+    raw_task_dict = {
+        "task_id": "test_task_1",
+        "status": "completed",
+        "created_at": "2025-08-07T00:00:00",
+        "updated_at": "2025-08-07T00:01:00",
+        "thoughts": [
+            {
+                "thought_id": "thought_1",
+                "thought_type": "standard",
+                "status": "completed",
+                "created_at": "2025-08-07T00:00:00",
+                "final_action": None,  # NULL from database
+            },
+            {
+                "thought_id": "thought_2",
+                "thought_type": "standard",
+                "status": "completed",
+                "created_at": "2025-08-07T00:00:30",
+                "final_action": '{"action": "SPEAK"}',  # Valid JSON string
+            },
+        ],
+    }
+
+    # This should not raise a validation error
+    result = TSDBDataConverter.convert_task(raw_task_dict)
+
+    assert result is not None
+    assert result.task_id == "test_task_1"
+    assert len(result.thoughts) == 2
+    assert result.thoughts[0].final_action is None
+    assert result.thoughts[1].final_action is not None
+
+
+def test_raw_thought_data_with_none_directly():
+    """Test that RawThoughtData can be created when None values are filtered."""
+    # This would fail without the fix
+    raw_dict_with_none = {
+        "thought_id": "test",
+        "thought_type": "standard",
+        "status": "completed",
+        "created_at": "2025-08-07T00:00:00",
+        "final_action": None,
+    }
+
+    # Filter None values as the fix does
+    cleaned_dict = {k: v for k, v in raw_dict_with_none.items() if v is not None}
+
+    # This should work
+    thought = RawThoughtData(**cleaned_dict)
+    assert thought.thought_id == "test"
+    assert thought.final_action is None  # Optional field defaults to None
+
+
+def test_multiple_none_fields():
+    """Test handling of multiple None fields in thought data."""
+    raw_thought_dict = {
+        "thought_id": "test_thought",
+        "thought_type": "standard",
+        "status": "completed",
+        "created_at": "2025-08-07T00:00:00",
+        "final_action": None,
+        "content": None,
+        "round_number": None,  # These would all come as None from NULL database values
+        "depth": None,
+    }
+
+    result = TSDBDataConverter._convert_thought(raw_thought_dict)
+
+    assert result is not None
+    assert result.thought_id == "test_thought"
+    assert result.final_action is None
+    assert result.handler is None


### PR DESCRIPTION
## Critical Production Fix

**Issue**: datum agent stuck in SHUTDOWN state due to TSDB consolidation failures

## Root Cause Analysis
- Database column `final_action_json` can be NULL
- When fetched, becomes Python None in dict
- RawThoughtData validation fails because None doesn't match Union[str, Dict[...]]
- Error: `Input should be a valid string/int/float/bool [type=*_type, input_value=None]`

## Why Tests Didn't Catch This
- Tests DO create thoughts with `final_action_json = None`
- But test never ran the actual conversion that production does
- Added comprehensive test coverage that reproduces and verifies the fix

## Fix
1. Filter out None values before creating RawThoughtData/RawTaskData
2. Added proper test coverage for None handling
3. Consolidated version to single source in constants.py (v1.1.4-beta)

## Changes
- Fixed data_converter.py to handle None values from database
- Added test_tsdb_data_converter_none_handling.py
- Version consolidation: all versions now reference constants.py

This is a critical fix for production stability.