### PR TITLE
Fix: MemoryQuery import location

### DIFF
--- a/ciris_engine/logic/services/graph/audit_service.py
+++ b/ciris_engine/logic/services/graph/audit_service.py
@@ -46,13 +46,12 @@ from ciris_engine.schemas.runtime.audit import AuditActionContext, AuditRequest
 from ciris_engine.schemas.runtime.enums import HandlerActionType, ServiceType
 from ciris_engine.schemas.runtime.memory import TimeSeriesDataPoint
 from ciris_engine.schemas.services.graph.audit import AuditEventData, AuditQuery, VerificationReport
-from ciris_engine.schemas.services.graph.memory import MemoryQuery
 
 # TSDB functionality integrated into graph nodes
 from ciris_engine.schemas.services.graph_core import GraphNode, GraphScope, NodeType
 from ciris_engine.schemas.services.nodes import AuditEntry as AuditEntryNode
 from ciris_engine.schemas.services.nodes import AuditEntryContext
-from ciris_engine.schemas.services.operations import MemoryOpStatus
+from ciris_engine.schemas.services.operations import MemoryOpStatus, MemoryQuery
 
 # Type alias for protocol compatibility
 AuditEntry = AuditEntryNode


### PR DESCRIPTION
Fixes CI/CD test failure by importing MemoryQuery from correct location.

MemoryQuery is in `schemas.services.operations`, not `schemas.services.graph.memory`.

Tests now passing locally (49/49 passed).