### PR TITLE
fix: Test serialization for Discord context persistence

### DIFF
--- a/tests/test_discord_context_persistence.py
+++ b/tests/test_discord_context_persistence.py
@@ -288,8 +288,16 @@ class TestDiscordContextPersistence:
                         corr.service_type,
                         corr.handler_name,
                         corr.action_type,
-                        json.dumps(corr.request_data),
-                        json.dumps(corr.response_data),
+                        (
+                            corr.request_data.model_dump_json()
+                            if hasattr(corr.request_data, "model_dump_json")
+                            else json.dumps(corr.request_data)
+                        ),
+                        (
+                            corr.response_data.model_dump_json()
+                            if hasattr(corr.response_data, "model_dump_json")
+                            else json.dumps(corr.response_data)
+                        ),
                         corr.status.value if hasattr(corr.status, "value") else corr.status,
                         corr.created_at.isoformat() if hasattr(corr.created_at, "isoformat") else str(corr.created_at),
                         corr.updated_at.isoformat() if hasattr(corr.updated_at, "isoformat") else str(corr.updated_at),


### PR DESCRIPTION
Fixed test that was failing in CI due to ServiceRequestData serialization issue.