### PR TITLE
fix: Critical - Guidance thoughts must be created with PENDING status

### DIFF
--- a/ciris_engine/logic/adapters/discord/discord_observer.py
+++ b/ciris_engine/logic/adapters/discord/discord_observer.py
@@ -357,7 +357,7 @@ class DiscordObserver(BaseObserver[DiscordMessage]):
                             source_task_id=original_task.task_id,
                             parent_thought_id=referenced_thought_id,
                             thought_type=ThoughtType.GUIDANCE,
-                            status=ThoughtStatus.PROCESSING,  # Set to PROCESSING status
+                            status=ThoughtStatus.PENDING,  # Must be PENDING to enter processing queue!
                             created_at=(
                                 self.time_service.now_iso()
                                 if self.time_service

--- a/tests/test_guidance_thought_processing.py
+++ b/tests/test_guidance_thought_processing.py
@@ -1,0 +1,327 @@
+"""
+Test guidance thought processing, especially edge cases like round_number=0.
+
+This test ensures that guidance thoughts created in response to deferrals
+are properly processed even when they have round_number=0.
+"""
+
+import asyncio
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ciris_engine.logic import persistence
+from ciris_engine.logic.processors.support.processing_queue import ProcessingQueueItem
+from ciris_engine.logic.processors.support.thought_manager import ThoughtManager
+from ciris_engine.schemas.runtime.enums import TaskStatus, ThoughtStatus, ThoughtType
+from ciris_engine.schemas.runtime.models import FinalAction, Task, TaskContext, Thought, ThoughtContext
+
+
+class TestGuidanceThoughtProcessing:
+    """Test suite for guidance thought processing edge cases."""
+
+    @pytest.fixture
+    def time_service(self):
+        """Mock time service."""
+        service = MagicMock()
+        service.now.return_value = datetime.now(timezone.utc)
+        service.now_iso.return_value = datetime.now(timezone.utc).isoformat()
+        return service
+
+    @pytest.fixture
+    def thought_manager(self, time_service):
+        """Create a ThoughtManager instance."""
+        return ThoughtManager(time_service=time_service, max_active_thoughts=50)
+
+    @pytest.fixture
+    def shutdown_task(self, time_service):
+        """Create a mock shutdown task."""
+        return Task(
+            task_id=f"shutdown_{uuid.uuid4().hex[:8]}",
+            channel_id="discord_1234_5678",
+            description="System shutdown requested: CD deployment",
+            priority=10,
+            status=TaskStatus.ACTIVE,
+            created_at=time_service.now_iso(),
+            updated_at=time_service.now_iso(),
+            context=TaskContext(
+                channel_id="discord_1234_5678",
+                user_id="system",
+                correlation_id=f"shutdown_{uuid.uuid4().hex[:8]}",
+                parent_task_id=None,
+            ),
+        )
+
+    @pytest.fixture
+    def deferral_thought(self, shutdown_task, time_service):
+        """Create a deferral thought."""
+        return Thought(
+            thought_id=f"thought_{uuid.uuid4().hex[:8]}",
+            source_task_id=shutdown_task.task_id,
+            channel_id=shutdown_task.channel_id,
+            thought_type=ThoughtType.STANDARD,
+            status=ThoughtStatus.COMPLETED,
+            created_at=time_service.now_iso(),
+            updated_at=time_service.now_iso(),
+            round_number=1,
+            content="Should I shutdown for deployment?",
+            thought_depth=0,
+            final_action=FinalAction(
+                action_type="DEFER",
+                action_params={
+                    "task_id": shutdown_task.task_id,
+                    "channel_id": shutdown_task.channel_id,
+                    "reason": "Need clarification on deployment impact",
+                },
+                reasoning="Need more information about deployment impact before proceeding",
+            ),
+            context=ThoughtContext(
+                task_id=shutdown_task.task_id,
+                channel_id=shutdown_task.channel_id,
+                round_number=1,
+                depth=0,
+                parent_thought_id=None,
+                correlation_id=shutdown_task.context.correlation_id,
+            ),
+        )
+
+    @pytest.fixture
+    def guidance_thought(self, shutdown_task, deferral_thought, time_service):
+        """Create a guidance thought with round_number=0."""
+        return Thought(
+            thought_id=f"guidance_{uuid.uuid4().hex[:8]}",
+            source_task_id=shutdown_task.task_id,
+            channel_id=shutdown_task.channel_id,
+            thought_type=ThoughtType.GUIDANCE,
+            status=ThoughtStatus.PENDING,  # Start as PENDING
+            created_at=time_service.now_iso(),
+            updated_at=time_service.now_iso(),
+            round_number=0,  # CRITICAL: Guidance thoughts often have round_number=0
+            content="Guidance: This is to improve your handling of message history. Please proceed with shutdown.",
+            thought_depth=1,
+            parent_thought_id=deferral_thought.thought_id,
+            final_action=None,
+            context=ThoughtContext(
+                task_id=shutdown_task.task_id,
+                channel_id=shutdown_task.channel_id,
+                round_number=0,  # CRITICAL: Must be 0 to test the edge case
+                depth=1,
+                parent_thought_id=deferral_thought.thought_id,
+                correlation_id=shutdown_task.context.correlation_id,
+            ),
+        )
+
+    @pytest.mark.asyncio
+    async def test_guidance_thought_with_round_zero_gets_processed(
+        self, thought_manager, guidance_thought, shutdown_task
+    ):
+        """Test that guidance thoughts with round_number=0 are added to processing queue."""
+        with patch("ciris_engine.logic.persistence.get_thoughts_by_task_id") as mock_get_thoughts:
+            with patch("ciris_engine.logic.persistence.add_thought") as mock_add_thought:
+                # Setup: Return the guidance thought as pending
+                mock_get_thoughts.return_value = [guidance_thought]
+
+                # Add to processing queue (simulate what populate_processing_queue does)
+                queue_item = ProcessingQueueItem.from_thought(guidance_thought)
+                thought_manager.processing_queue.append(queue_item)
+
+                # Verify it was added
+                assert len(thought_manager.processing_queue) == 1
+                item = thought_manager.processing_queue[0]
+                assert item.thought_id == guidance_thought.thought_id
+                # Round number is in the context
+                assert item.initial_context.round_number == 0  # Should preserve round_number=0
+
+    @pytest.mark.asyncio
+    async def test_guidance_thought_transitions_to_processing(self, guidance_thought):
+        """Test that guidance thoughts transition from PENDING to PROCESSING correctly."""
+        with patch("ciris_engine.logic.persistence.update_thought_status") as mock_update_status:
+            # Simulate the transition
+            persistence.update_thought_status(thought_id=guidance_thought.thought_id, status=ThoughtStatus.PROCESSING)
+
+            # Verify the update was called
+            mock_update_status.assert_called_once_with(
+                thought_id=guidance_thought.thought_id, status=ThoughtStatus.PROCESSING
+            )
+
+    @pytest.mark.asyncio
+    async def test_shutdown_processor_processes_guidance_thoughts(self):
+        """Test that ShutdownProcessor properly processes guidance thoughts."""
+        from ciris_engine.logic.processors.states.shutdown_processor import ShutdownProcessor
+
+        # Create mock services
+        config_accessor = MagicMock()
+        thought_processor = AsyncMock()
+        action_dispatcher = AsyncMock()
+        time_service = MagicMock()
+        time_service.now.return_value = datetime.now(timezone.utc)
+        time_service.now_iso.return_value = datetime.now(timezone.utc).isoformat()
+        services = {"communication_bus": AsyncMock(), "time_service": time_service, "resource_monitor": MagicMock()}
+
+        # Create processor
+        processor = ShutdownProcessor(
+            config_accessor=config_accessor,
+            thought_processor=thought_processor,
+            action_dispatcher=action_dispatcher,
+            services=services,
+            time_service=time_service,
+        )
+
+        # Create shutdown task and guidance thought
+        shutdown_task = Task(
+            task_id="shutdown_test",
+            channel_id="test_channel",
+            description="Test shutdown",
+            priority=10,
+            status=TaskStatus.ACTIVE,
+            created_at=time_service.now_iso(),
+            updated_at=time_service.now_iso(),
+            context=TaskContext(
+                channel_id="test_channel",
+                user_id="system",
+                correlation_id="test_corr",
+                parent_task_id=None,
+            ),
+        )
+
+        guidance_thought = Thought(
+            thought_id="guidance_test",
+            source_task_id=shutdown_task.task_id,
+            channel_id=shutdown_task.channel_id,
+            thought_type=ThoughtType.GUIDANCE,
+            status=ThoughtStatus.PENDING,
+            created_at=time_service.now_iso(),
+            updated_at=time_service.now_iso(),
+            round_number=0,  # Key test case
+            content="Guidance: Proceed with shutdown",
+            thought_depth=1,
+            parent_thought_id="parent_thought",
+            final_action=None,
+            context=ThoughtContext(
+                task_id=shutdown_task.task_id,
+                channel_id=shutdown_task.channel_id,
+                round_number=0,
+                depth=1,
+                parent_thought_id="parent_thought",
+                correlation_id="test_corr",
+            ),
+        )
+
+        # Mock persistence methods
+        with patch("ciris_engine.logic.persistence.get_task_by_id") as mock_get_task:
+            with patch("ciris_engine.logic.persistence.get_thoughts_by_task_id") as mock_get_thoughts:
+                with patch("ciris_engine.logic.persistence.update_thought_status") as mock_update_status:
+                    with patch.object(processor, "process_thought_item") as mock_process_thought:
+                        # Setup mocks
+                        processor.shutdown_task = shutdown_task
+                        mock_get_task.return_value = shutdown_task
+                        mock_get_thoughts.return_value = [guidance_thought]
+                        mock_process_thought.return_value = MagicMock(selected_action="TASK_COMPLETE")
+
+                        # Process shutdown thoughts
+                        await processor._process_shutdown_thoughts()
+
+                        # Verify the guidance thought was processed
+                        mock_update_status.assert_called()
+                        mock_process_thought.assert_called_once()
+
+                        # Check that the thought was passed to process_thought_item
+                        call_args = mock_process_thought.call_args
+                        processed_item = call_args[0][0]
+                        assert processed_item.thought_id == guidance_thought.thought_id
+                        # Round number should be preserved in context
+                        assert processed_item.initial_context is not None
+                        if hasattr(processed_item.initial_context, "round_number"):
+                            assert processed_item.initial_context.round_number == 0
+
+    @pytest.mark.asyncio
+    async def test_processing_queue_item_preserves_round_zero(self, guidance_thought):
+        """Test that ProcessingQueueItem correctly handles round_number=0."""
+        # Create queue item from thought
+        queue_item = ProcessingQueueItem.from_thought(guidance_thought)
+
+        # Verify round_number is preserved in context
+        assert queue_item.initial_context.round_number == 0
+        assert queue_item.thought_id == guidance_thought.thought_id
+        assert queue_item.thought_type == ThoughtType.GUIDANCE
+
+    @pytest.mark.asyncio
+    async def test_guidance_thought_not_filtered_by_round_number(self):
+        """Test that guidance thoughts aren't filtered out due to round_number=0."""
+        from ciris_engine.logic.processors.support.thought_manager import ThoughtManager
+
+        time_service = MagicMock()
+        time_service.now.return_value = datetime.now(timezone.utc)
+        manager = ThoughtManager(time_service=time_service)
+
+        # Create a guidance thought with round_number=0
+        thought = Thought(
+            thought_id="test_guidance",
+            source_task_id="task_123",
+            channel_id="channel_123",
+            thought_type=ThoughtType.GUIDANCE,
+            status=ThoughtStatus.PENDING,
+            created_at=time_service.now().isoformat(),
+            updated_at=time_service.now().isoformat(),
+            round_number=0,
+            content="Test guidance",
+            thought_depth=1,
+            context=ThoughtContext(
+                task_id="task_123",
+                channel_id="channel_123",
+                round_number=0,
+                depth=1,
+                parent_thought_id="parent_123",
+                correlation_id="corr_123",
+            ),
+        )
+
+        # Add to queue (simulate what populate_processing_queue does)
+        queue_item = ProcessingQueueItem.from_thought(thought)
+        manager.processing_queue.append(queue_item)
+
+        # Should be in queue
+        assert len(manager.processing_queue) == 1
+        # Round number is in the context
+        assert manager.processing_queue[0].initial_context.round_number == 0
+
+    @pytest.mark.asyncio
+    async def test_guidance_thought_completion_flow(self, guidance_thought, shutdown_task):
+        """Test the complete flow of a guidance thought from creation to completion."""
+        with patch("ciris_engine.logic.persistence.get_task_by_id") as mock_get_task:
+            with patch("ciris_engine.logic.persistence.update_thought_status") as mock_update_status:
+                with patch("ciris_engine.logic.persistence.update_task_status") as mock_update_task:
+                    # Initial state
+                    mock_get_task.return_value = shutdown_task
+
+                    # 1. Guidance thought starts as PENDING
+                    assert guidance_thought.status == ThoughtStatus.PENDING
+
+                    # 2. Transitions to PROCESSING
+                    persistence.update_thought_status(
+                        thought_id=guidance_thought.thought_id, status=ThoughtStatus.PROCESSING
+                    )
+                    mock_update_status.assert_called_with(
+                        thought_id=guidance_thought.thought_id, status=ThoughtStatus.PROCESSING
+                    )
+
+                    # 3. Completes with TASK_COMPLETE action
+                    persistence.update_thought_status(
+                        thought_id=guidance_thought.thought_id,
+                        status=ThoughtStatus.COMPLETED,
+                        final_action=FinalAction(
+                            action_type="TASK_COMPLETE",
+                            action_params={},
+                            reasoning="Shutdown approved based on guidance",
+                        ),
+                    )
+
+                    # 4. Task should be marked complete
+                    persistence.update_task_status(shutdown_task.task_id, TaskStatus.COMPLETED, None)  # time_service
+                    mock_update_task.assert_called_with(shutdown_task.task_id, TaskStatus.COMPLETED, None)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_guidance_thought_status_bug.py
+++ b/tests/test_guidance_thought_status_bug.py
@@ -1,0 +1,332 @@
+"""
+Test to validate the guidance thought status bug and fix.
+
+BUG: Guidance thoughts were being created with status=PROCESSING instead of PENDING,
+causing them to never enter the processing queue and get stuck forever.
+
+FIX: Guidance thoughts must be created with status=PENDING so they can be picked up
+by the normal thought processing pipeline.
+"""
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ciris_engine.logic.adapters.discord.discord_observer import DiscordObserver
+from ciris_engine.logic.persistence import add_thought, get_thought_by_id
+from ciris_engine.schemas.runtime.enums import TaskStatus, ThoughtStatus, ThoughtType
+from ciris_engine.schemas.runtime.messages import DiscordMessage
+from ciris_engine.schemas.runtime.models import Task, TaskContext, Thought
+
+
+class TestGuidanceThoughtStatusBug:
+    """Test suite to validate the guidance thought status bug is fixed."""
+
+    @pytest.fixture
+    def mock_services(self):
+        """Create mock services for the observer."""
+        return {
+            "memory_service": AsyncMock(),
+            "bus_manager": MagicMock(),
+            "filter_service": AsyncMock(),
+            "secrets_service": AsyncMock(),
+            "communication_service": AsyncMock(),
+            "time_service": MagicMock(
+                now=lambda: datetime.now(timezone.utc), now_iso=lambda: datetime.now(timezone.utc).isoformat()
+            ),
+            "auth_service": AsyncMock(),
+        }
+
+    @pytest.fixture
+    def discord_observer(self, mock_services):
+        """Create a DiscordObserver instance."""
+        return DiscordObserver(
+            monitored_channel_ids=["1234567890"],
+            deferral_channel_id="1234567890",
+            wa_user_ids=["537080239679864862"],
+            memory_service=mock_services["memory_service"],
+            agent_id="test_agent",
+            bus_manager=mock_services["bus_manager"],
+            filter_service=mock_services["filter_service"],
+            secrets_service=mock_services["secrets_service"],
+            communication_service=mock_services["communication_service"],
+            time_service=mock_services["time_service"],
+            auth_service=mock_services["auth_service"],
+        )
+
+    @pytest.fixture
+    def deferred_task(self):
+        """Create a task that has been deferred."""
+        return Task(
+            task_id="task_123",
+            channel_id="discord_1234_5678",
+            description="Test task for shutdown",
+            priority=10,
+            status=TaskStatus.ACTIVE,
+            created_at=datetime.now(timezone.utc).isoformat(),
+            updated_at=datetime.now(timezone.utc).isoformat(),
+            context=TaskContext(
+                channel_id="discord_1234_5678",
+                user_id="system",
+                correlation_id="test_corr",
+                parent_task_id=None,
+            ),
+        )
+
+    @pytest.fixture
+    def deferred_thought(self, deferred_task):
+        """Create a thought that resulted in deferral."""
+        return Thought(
+            thought_id="thought_defer_123",
+            source_task_id=deferred_task.task_id,
+            channel_id=deferred_task.channel_id,
+            thought_type=ThoughtType.FOLLOW_UP,
+            status=ThoughtStatus.DEFERRED,
+            created_at=datetime.now(timezone.utc).isoformat(),
+            updated_at=datetime.now(timezone.utc).isoformat(),
+            round_number=1,
+            content="Should I proceed with shutdown?",
+            thought_depth=1,
+        )
+
+    @pytest.mark.asyncio
+    async def test_guidance_thought_created_with_pending_status(
+        self, discord_observer, deferred_task, deferred_thought
+    ):
+        """Test that guidance thoughts are created with PENDING status, not PROCESSING."""
+        # Create a WA guidance message
+        guidance_message = DiscordMessage(
+            message_id="msg_456",
+            content="GUIDANCE: DEFER:thought_defer_123: Proceed with the shutdown, this is a routine update.",
+            author_id="537080239679864862",  # WA user
+            author_name="WiseAuthority",
+            channel_id="1234567890",  # Deferral channel
+            is_bot=False,
+            is_dm=False,
+            raw_message=None,
+        )
+
+        # Mock the persistence methods
+        with patch("ciris_engine.logic.persistence.get_thought_by_id") as mock_get_thought:
+            with patch("ciris_engine.logic.persistence.get_task_by_id") as mock_get_task:
+                with patch("ciris_engine.logic.persistence.add_thought") as mock_add_thought:
+                    # Setup mocks
+                    mock_get_thought.return_value = deferred_thought
+                    mock_get_task.return_value = deferred_task
+
+                    # Process the guidance message
+                    await discord_observer._handle_wa_guidance(guidance_message)
+
+                    # Verify a thought was added
+                    mock_add_thought.assert_called_once()
+
+                    # Get the created thought
+                    created_thought = mock_add_thought.call_args[0][0]
+
+                    # CRITICAL ASSERTION: Guidance thought must be PENDING, not PROCESSING
+                    assert created_thought.status == ThoughtStatus.PENDING, (
+                        f"Guidance thought created with status {created_thought.status}, "
+                        f"but must be PENDING to enter processing queue!"
+                    )
+
+                    # Verify other properties
+                    assert created_thought.thought_type == ThoughtType.GUIDANCE
+                    assert created_thought.parent_thought_id == deferred_thought.thought_id
+                    assert created_thought.source_task_id == deferred_task.task_id
+                    assert created_thought.round_number == 0  # Guidance thoughts start at round 0
+                    assert "GUIDANCE:" in created_thought.content
+                    assert guidance_message.content in created_thought.content
+
+    @pytest.mark.asyncio
+    async def test_guidance_thought_enters_processing_queue(self):
+        """Test that PENDING guidance thoughts can enter the processing queue."""
+        from ciris_engine.logic.processors.support.processing_queue import ProcessingQueueItem
+        from ciris_engine.logic.processors.support.thought_manager import ThoughtManager
+
+        # Create a guidance thought with PENDING status
+        guidance_thought = Thought(
+            thought_id="guidance_test_123",
+            source_task_id="task_123",
+            channel_id="discord_1234_5678",
+            thought_type=ThoughtType.GUIDANCE,
+            status=ThoughtStatus.PENDING,  # Correct status
+            created_at=datetime.now(timezone.utc).isoformat(),
+            updated_at=datetime.now(timezone.utc).isoformat(),
+            round_number=0,
+            content="GUIDANCE: Proceed with shutdown",
+            thought_depth=1,
+            parent_thought_id="parent_thought_123",
+        )
+
+        # Create thought manager
+        time_service = MagicMock()
+        time_service.now.return_value = datetime.now(timezone.utc)
+        manager = ThoughtManager(time_service=time_service)
+
+        # Mock persistence to return our guidance thought
+        with patch("ciris_engine.logic.persistence.get_thoughts_by_task_id") as mock_get_thoughts:
+            mock_get_thoughts.return_value = [guidance_thought]
+
+            # Populate the processing queue
+            tasks = [MagicMock(task_id="task_123")]
+            added = manager.populate_processing_queue(tasks, round_number=1)
+
+            # Verify the guidance thought was added to the queue
+            assert added == 1, "Guidance thought should be added to processing queue"
+            assert len(manager.processing_queue) == 1
+
+            queue_item = manager.processing_queue[0]
+            assert queue_item.thought_id == guidance_thought.thought_id
+            assert queue_item.thought_type == ThoughtType.GUIDANCE
+
+    @pytest.mark.asyncio
+    async def test_processing_status_thoughts_not_added_to_queue(self):
+        """Test that thoughts already in PROCESSING status are NOT added to queue."""
+        from ciris_engine.logic.processors.support.thought_manager import ThoughtManager
+
+        # Create a thought incorrectly stuck in PROCESSING status (the bug)
+        stuck_thought = Thought(
+            thought_id="stuck_guidance_123",
+            source_task_id="task_123",
+            channel_id="discord_1234_5678",
+            thought_type=ThoughtType.GUIDANCE,
+            status=ThoughtStatus.PROCESSING,  # Wrong status - causes the bug!
+            created_at=datetime.now(timezone.utc).isoformat(),
+            updated_at=datetime.now(timezone.utc).isoformat(),
+            round_number=0,
+            content="GUIDANCE: This will be stuck forever",
+            thought_depth=1,
+        )
+
+        # Create thought manager
+        time_service = MagicMock()
+        time_service.now.return_value = datetime.now(timezone.utc)
+        manager = ThoughtManager(time_service=time_service)
+
+        # Mock persistence to return the stuck thought
+        with patch("ciris_engine.logic.persistence.get_thoughts_by_task_id") as mock_get_thoughts:
+            mock_get_thoughts.return_value = [stuck_thought]
+
+            # Try to populate the processing queue
+            tasks = [MagicMock(task_id="task_123")]
+            added = manager.populate_processing_queue(tasks, round_number=1)
+
+            # Verify the stuck thought was NOT added (because it's already PROCESSING)
+            assert added == 0, "PROCESSING status thoughts should not be added to queue"
+            assert len(manager.processing_queue) == 0
+
+    @pytest.mark.asyncio
+    async def test_shutdown_processor_handles_pending_guidance_thoughts(self):
+        """Test that ShutdownProcessor can process PENDING guidance thoughts."""
+        from ciris_engine.logic.processors.states.shutdown_processor import ShutdownProcessor
+
+        # Create mock services
+        config_accessor = MagicMock()
+        thought_processor = AsyncMock()
+        action_dispatcher = AsyncMock()
+        time_service = MagicMock()
+        time_service.now.return_value = datetime.now(timezone.utc)
+        time_service.now_iso.return_value = datetime.now(timezone.utc).isoformat()
+        services = {"communication_bus": AsyncMock(), "time_service": time_service, "resource_monitor": MagicMock()}
+
+        processor = ShutdownProcessor(
+            config_accessor=config_accessor,
+            thought_processor=thought_processor,
+            action_dispatcher=action_dispatcher,
+            services=services,
+            time_service=time_service,
+        )
+
+        # Create shutdown task
+        shutdown_task = Task(
+            task_id="shutdown_test",
+            channel_id="test_channel",
+            description="Test shutdown",
+            priority=10,
+            status=TaskStatus.ACTIVE,
+            created_at=time_service.now_iso(),
+            updated_at=time_service.now_iso(),
+            context=TaskContext(
+                channel_id="test_channel",
+                user_id="system",
+                correlation_id="test_corr",
+                parent_task_id=None,
+            ),
+        )
+
+        # Create PENDING guidance thought (correct status)
+        guidance_thought = Thought(
+            thought_id="guidance_pending",
+            source_task_id=shutdown_task.task_id,
+            channel_id=shutdown_task.channel_id,
+            thought_type=ThoughtType.GUIDANCE,
+            status=ThoughtStatus.PENDING,  # Correct status!
+            created_at=time_service.now_iso(),
+            updated_at=time_service.now_iso(),
+            round_number=0,
+            content="GUIDANCE: Proceed with shutdown",
+            thought_depth=1,
+            parent_thought_id="parent_thought",
+        )
+
+        # Mock persistence
+        with patch("ciris_engine.logic.persistence.get_task_by_id") as mock_get_task:
+            with patch("ciris_engine.logic.persistence.get_thoughts_by_task_id") as mock_get_thoughts:
+                with patch("ciris_engine.logic.persistence.update_thought_status") as mock_update_status:
+                    with patch.object(processor, "process_thought_item") as mock_process:
+                        # Setup
+                        processor.shutdown_task = shutdown_task
+                        mock_get_task.return_value = shutdown_task
+                        mock_get_thoughts.return_value = [guidance_thought]
+                        mock_process.return_value = MagicMock(selected_action="TASK_COMPLETE")
+
+                        # Process shutdown thoughts
+                        await processor._process_shutdown_thoughts()
+
+                        # Verify the PENDING thought was picked up and processed
+                        mock_update_status.assert_called_with(
+                            thought_id=guidance_thought.thought_id, status=ThoughtStatus.PROCESSING
+                        )
+                        mock_process.assert_called_once()
+
+    def test_regression_guidance_thoughts_never_created_as_processing(self):
+        """Regression test to ensure guidance thoughts are never created with PROCESSING status."""
+        # This is a static code analysis test
+        # Read the discord_observer.py file and check for the bug
+        import ast
+        from pathlib import Path
+
+        observer_path = Path(__file__).parent.parent / "ciris_engine/logic/adapters/discord/discord_observer.py"
+        if not observer_path.exists():
+            pytest.skip("Discord observer file not found")
+
+        with open(observer_path, "r") as f:
+            tree = ast.parse(f.read())
+
+        # Find all Thought() instantiations
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                if isinstance(node.func, ast.Name) and node.func.id == "Thought":
+                    # Check if this is a guidance thought
+                    is_guidance = False
+                    has_processing_status = False
+
+                    for keyword in node.keywords:
+                        if keyword.arg == "thought_type":
+                            if isinstance(keyword.value, ast.Attribute) and keyword.value.attr == "GUIDANCE":
+                                is_guidance = True
+                        elif keyword.arg == "status":
+                            if isinstance(keyword.value, ast.Attribute) and keyword.value.attr == "PROCESSING":
+                                has_processing_status = True
+
+                    # If it's a guidance thought with PROCESSING status, fail the test
+                    assert not (is_guidance and has_processing_status), (
+                        "Found guidance thought being created with PROCESSING status! "
+                        "This is the bug that causes guidance thoughts to get stuck."
+                    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tools/investigate_guidance_bug.py
+++ b/tools/investigate_guidance_bug.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""
+Investigate the guidance thought bug more thoroughly.
+This script will help us understand:
+1. What status the thought was created with
+2. Whether it ever entered any processing queue
+3. Why it's stuck
+"""
+
+import sqlite3
+import sys
+from datetime import datetime
+from pathlib import Path
+
+# Add the project root to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from ciris_engine.logic.persistence.db.core import get_db_connection
+
+
+def investigate_guidance_processing():
+    """Deep dive into guidance thought processing."""
+    conn = get_db_connection()
+
+    print("\n" + "=" * 100)
+    print("GUIDANCE THOUGHT PROCESSING INVESTIGATION")
+    print("=" * 100)
+
+    # 1. Find all guidance thoughts
+    cursor = conn.execute(
+        """
+        SELECT thought_id, source_task_id, status, round_number,
+               created_at, updated_at, parent_thought_id, content
+        FROM thoughts
+        WHERE thought_type = 'guidance'
+        ORDER BY created_at DESC
+    """
+    )
+
+    guidance_thoughts = cursor.fetchall()
+    print(f"\n1. GUIDANCE THOUGHTS FOUND: {len(guidance_thoughts)}")
+
+    for thought in guidance_thoughts:
+        thought_id = thought[0]
+        status = thought[2]
+        created = thought[4]
+        updated = thought[5]
+
+        print(f"\n  Thought: {thought_id}")
+        print(f"  Status: {status}")
+        print(f"  Created: {created}")
+        print(f"  Updated: {updated}")
+
+        # Check if created == updated (never processed)
+        if created == updated:
+            print(f"  ⚠️  NEVER UPDATED - created and updated timestamps are identical!")
+
+        # 2. Check if this thought ever appeared in correlations
+        cursor2 = conn.execute(
+            """
+            SELECT COUNT(*) as correlation_count
+            FROM service_correlations
+            WHERE request_data LIKE ? OR response_data LIKE ?
+        """,
+            (f"%{thought_id}%", f"%{thought_id}%"),
+        )
+
+        corr_count = cursor2.fetchone()[0]
+        print(f"  Correlations: {corr_count}")
+
+        if corr_count == 0:
+            print(f"  ❌ NEVER PROCESSED - No correlations found!")
+        else:
+            # Show the correlations
+            cursor3 = conn.execute(
+                """
+                SELECT handler_name, action_type, status, created_at
+                FROM service_correlations
+                WHERE request_data LIKE ? OR response_data LIKE ?
+                ORDER BY created_at
+            """,
+                (f"%{thought_id}%", f"%{thought_id}%"),
+            )
+
+            for corr in cursor3.fetchall():
+                print(f"    - {corr[3]}: {corr[0]} -> {corr[1]} ({corr[2]})")
+
+    # 3. Check what statuses thoughts are created with in the code
+    print("\n2. CHECKING THOUGHT CREATION PATTERNS")
+    print("-" * 50)
+
+    # Look for thoughts created in last hour with their initial status
+    cursor = conn.execute(
+        """
+        SELECT thought_type, status, COUNT(*) as count
+        FROM thoughts
+        WHERE datetime(created_at) > datetime('now', '-1 hour')
+        GROUP BY thought_type, status
+        ORDER BY thought_type, status
+    """
+    )
+
+    print("\nThoughts created in last hour by type and status:")
+    for row in cursor.fetchall():
+        print(f"  {row[0]:15} | {row[1]:12} | Count: {row[2]}")
+
+    # 4. Check if there are other PROCESSING thoughts that are stuck
+    print("\n3. OTHER STUCK THOUGHTS IN PROCESSING STATUS")
+    print("-" * 50)
+
+    cursor = conn.execute(
+        """
+        SELECT thought_id, thought_type, source_task_id,
+               created_at, updated_at
+        FROM thoughts
+        WHERE status = 'processing'
+          AND datetime(created_at) < datetime('now', '-5 minutes')
+        ORDER BY created_at DESC
+        LIMIT 10
+    """
+    )
+
+    stuck_thoughts = cursor.fetchall()
+    print(f"\nFound {len(stuck_thoughts)} thoughts stuck in PROCESSING for >5 minutes:")
+
+    for thought in stuck_thoughts:
+        thought_id = thought[0]
+        thought_type = thought[1]
+        created = thought[3]
+        updated = thought[4]
+
+        # Calculate time stuck
+        try:
+            created_dt = datetime.fromisoformat(created.replace("Z", "+00:00"))
+            now_dt = datetime.utcnow()
+            stuck_minutes = (now_dt - created_dt).total_seconds() / 60
+
+            print(f"  {thought_id[:8]}... | {thought_type:12} | Stuck for {stuck_minutes:.0f} minutes")
+
+            if created == updated:
+                print(f"    ⚠️  Never updated since creation!")
+        except:
+            print(f"  {thought_id[:8]}... | {thought_type:12} | Unable to calculate time")
+
+    # 5. Check the shutdown task specifically
+    print("\n4. SHUTDOWN TASK INVESTIGATION")
+    print("-" * 50)
+
+    cursor = conn.execute(
+        """
+        SELECT task_id, description, status, priority, created_at
+        FROM tasks
+        WHERE task_id LIKE 'shutdown%'
+        ORDER BY created_at DESC
+        LIMIT 5
+    """
+    )
+
+    for task in cursor.fetchall():
+        task_id = task[0]
+        desc = task[1][:50]
+        status = task[2]
+        priority = task[3]
+
+        print(f"\nTask: {task_id}")
+        print(f"  Description: {desc}...")
+        print(f"  Status: {status}")
+        print(f"  Priority: {priority}")
+
+        # Get all thoughts for this task
+        cursor2 = conn.execute(
+            """
+            SELECT thought_id, thought_type, status, round_number, created_at
+            FROM thoughts
+            WHERE source_task_id = ?
+            ORDER BY created_at
+        """,
+            (task_id,),
+        )
+
+        thoughts = cursor2.fetchall()
+        print(f"  Thoughts ({len(thoughts)}):")
+
+        for t in thoughts:
+            marker = ""
+            if t[2] == "processing":
+                marker = " ⚠️ STUCK"
+            elif t[2] == "deferred":
+                marker = " 🔄 DEFERRED"
+            print(f"    {t[4]} | {t[0][:8]}... | {t[1]:12} | {t[2]:12} | Round {t[3]}{marker}")
+
+    # 6. Check if thoughts with round_number=0 are being processed
+    print("\n5. ROUND NUMBER 0 THOUGHTS")
+    print("-" * 50)
+
+    cursor = conn.execute(
+        """
+        SELECT thought_type, status, COUNT(*) as count
+        FROM thoughts
+        WHERE round_number = 0
+        GROUP BY thought_type, status
+        ORDER BY thought_type, status
+    """
+    )
+
+    print("\nThoughts with round_number=0 by type and status:")
+    for row in cursor.fetchall():
+        print(f"  {row[0]:15} | {row[1]:12} | Count: {row[2]}")
+
+    # 7. Check if there's a pattern with parent thoughts
+    print("\n6. PARENT THOUGHT ANALYSIS")
+    print("-" * 50)
+
+    cursor = conn.execute(
+        """
+        SELECT t.thought_id, t.thought_type, t.status,
+               p.thought_type as parent_type, p.status as parent_status
+        FROM thoughts t
+        LEFT JOIN thoughts p ON t.parent_thought_id = p.thought_id
+        WHERE t.status = 'processing'
+          AND t.parent_thought_id IS NOT NULL
+        LIMIT 10
+    """
+    )
+
+    print("\nThoughts stuck in PROCESSING with parent thoughts:")
+    for row in cursor.fetchall():
+        print(f"  Child:  {row[0][:8]}... | {row[1]:12} | {row[2]}")
+        print(f"  Parent: {row[3]:12} | {row[4]}")
+        print()
+
+
+if __name__ == "__main__":
+    investigate_guidance_processing()


### PR DESCRIPTION
## Summary
- Fixed critical bug where guidance thoughts were created with `status=PROCESSING` instead of `PENDING`
- This caused guidance thoughts to never enter the processing queue and get stuck forever
- The production agent was stuck in SHUTDOWN state due to this bug

## The Bug
When WA provides guidance on a deferred decision, the DiscordObserver creates a guidance thought. This thought was incorrectly created with `status=ThoughtStatus.PROCESSING` (line 360 in discord_observer.py), which meant it would never be picked up by the ThoughtManager's `populate_queue()` method that only fetches `PENDING` thoughts.

## The Fix
Changed line 360 in discord_observer.py from:
```python
status=ThoughtStatus.PROCESSING,  # Wrong - causes the bug\!
```
to:
```python
status=ThoughtStatus.PENDING,  # Must be PENDING to enter processing queue\!
```

## Test Coverage
- Added comprehensive test suite in `test_guidance_thought_status_bug.py`
- Added edge case tests in `test_guidance_thought_processing.py`
- Added investigation script `investigate_guidance_bug.py` for debugging
- Enhanced debug tools with `investigate_stuck_thought()` and `show_guidance_thoughts()` functions

## Production Impact
This fix will allow the stuck production agent to resume normal operation once deployed.

🤖 Generated with [Claude Code](https://claude.ai/code)