### PR TITLE
fix: Add get_incident_count method to fix telemetry API error

### DIFF
--- a/ciris_engine/logic/adapters/api/routes/telemetry.py
+++ b/ciris_engine/logic/adapters/api/routes/telemetry.py
@@ -356,9 +356,8 @@ async def _get_system_overview(request: Request) -> SystemOverview:
     # Get incident count
     if incident_service:
         try:
-            one_hour_ago = datetime.now(timezone.utc) - timedelta(hours=1)
-            incidents = await incident_service.get_incidents(start_time=one_hour_ago)
-            overview.recent_incidents = len(incidents) if incidents else 0
+            # Get count of incidents from the last hour
+            overview.recent_incidents = await incident_service.get_incident_count(hours=1)
         except Exception as e:
             logger.warning(
                 f"Telemetry metric retrieval failed for incident count: {type(e).__name__}: {str(e)} - Returning default/empty value"

--- a/ciris_engine/logic/services/graph/incident_service.py
+++ b/ciris_engine/logic/services/graph/incident_service.py
@@ -527,6 +527,25 @@ class IncidentManagementService(BaseGraphService):
             updated_at=current_time,
         )
 
+    async def get_incident_count(self, hours: int = 1) -> int:
+        """Get count of incidents in the specified time window.
+
+        Args:
+            hours: Number of hours to look back
+
+        Returns:
+            Count of incidents
+        """
+        try:
+            time_service = self._get_time_service()
+            current_time = time_service.now()
+            cutoff_time = current_time - timedelta(hours=hours)
+            incidents = await self._get_recent_incidents(cutoff_time)
+            return len(incidents)
+        except Exception as e:
+            logger.warning(f"Failed to get incident count: {e}")
+            return 0
+
     async def _mark_incidents_analyzed(self, incidents: List[IncidentNode]) -> None:
         """Mark incidents as analyzed."""
         for incident in incidents:

--- a/tests/test_incident_telemetry_fix.py
+++ b/tests/test_incident_telemetry_fix.py
@@ -1,0 +1,100 @@
+"""
+Test to verify the incident telemetry fix.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ciris_engine.logic.services.graph.incident_service import IncidentManagementService
+from ciris_engine.schemas.services.graph.incident import IncidentNode, IncidentSeverity, IncidentStatus
+
+
+@pytest.mark.asyncio
+async def test_get_incident_count():
+    """Test that get_incident_count method works correctly."""
+    # Create mock services
+    memory_bus = AsyncMock()
+    time_service = MagicMock()
+    time_service.now.return_value = datetime.now(timezone.utc)
+
+    # Create service
+    service = IncidentManagementService(memory_bus=memory_bus, time_service=time_service)
+
+    # Mock _get_recent_incidents to return some test incidents
+    test_incidents = [
+        IncidentNode(
+            id=f"incident_{i}",
+            type="AUDIT_ENTRY",
+            scope="LOCAL",
+            attributes={},
+            incident_type="ERROR",
+            severity=IncidentSeverity.MEDIUM,
+            status=IncidentStatus.OPEN,
+            description=f"Test incident {i}",
+            component="test_component",
+            impact="Low",
+            detection_time=datetime.now(timezone.utc) - timedelta(minutes=30),
+            updated_by="test",
+            updated_at=datetime.now(timezone.utc),
+        )
+        for i in range(5)
+    ]
+
+    with patch.object(service, "_get_recent_incidents", return_value=test_incidents):
+        # Test getting incident count
+        count = await service.get_incident_count(hours=1)
+
+        # Verify
+        assert count == 5, f"Expected 5 incidents, got {count}"
+
+        # Verify the method was called with correct cutoff time
+        service._get_recent_incidents.assert_called_once()
+        call_args = service._get_recent_incidents.call_args[0]
+        cutoff_time = call_args[0]
+
+        # Check that cutoff time is approximately 1 hour ago
+        expected_cutoff = time_service.now.return_value - timedelta(hours=1)
+        time_diff = abs((cutoff_time - expected_cutoff).total_seconds())
+        assert time_diff < 1, f"Cutoff time not correct, diff: {time_diff} seconds"
+
+
+@pytest.mark.asyncio
+async def test_get_incident_count_with_error():
+    """Test that get_incident_count handles errors gracefully."""
+    # Create mock services
+    memory_bus = AsyncMock()
+    time_service = MagicMock()
+    time_service.now.return_value = datetime.now(timezone.utc)
+
+    # Create service
+    service = IncidentManagementService(memory_bus=memory_bus, time_service=time_service)
+
+    # Mock _get_recent_incidents to raise an error
+    with patch.object(service, "_get_recent_incidents", side_effect=Exception("Database error")):
+        # Test getting incident count
+        count = await service.get_incident_count(hours=1)
+
+        # Should return 0 on error
+        assert count == 0, f"Expected 0 on error, got {count}"
+
+
+@pytest.mark.asyncio
+async def test_incident_service_has_get_incident_count():
+    """Test that the incident service has the get_incident_count method."""
+    # Create mock services
+    memory_bus = AsyncMock()
+    time_service = MagicMock()
+    time_service.now.return_value = datetime.now(timezone.utc)
+
+    # Create service
+    service = IncidentManagementService(memory_bus=memory_bus, time_service=time_service)
+
+    # Check the method exists
+    assert hasattr(service, "get_incident_count"), "IncidentManagementService should have get_incident_count method"
+    assert callable(getattr(service, "get_incident_count")), "get_incident_count should be callable"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Fixed AttributeError in telemetry API that was preventing UI from displaying incident counts
- Added `get_incident_count` method to IncidentManagementService
- Updated telemetry route to use the new method

## The Problem
The telemetry route was calling `incident_service.get_incidents()` which doesn't exist.
This caused AttributeError warnings in production logs and prevented the UI from showing incident counts.

## The Fix
- Added a simple `get_incident_count(hours=1)` method to IncidentManagementService
- This method internally calls `_get_recent_incidents` and returns the count
- Updated telemetry route to use this new method

## Testing
- Added unit tests to verify the method works correctly
- Tests handle both success and error cases

This fix allows the UI to properly display incident counts from the telemetry API.

🤖 Generated with [Claude Code](https://claude.ai/code)