### PR TITLE
fix: Set agent identity version to actual CIRIS version

### DIFF
--- a/ciris_engine/logic/runtime/identity_manager.py
+++ b/ciris_engine/logic/runtime/identity_manager.py
@@ -9,6 +9,7 @@ import logging
 from pathlib import Path
 from typing import Optional
 
+from ciris_engine.constants import CIRIS_VERSION
 from ciris_engine.protocols.services.lifecycle.time import TimeServiceProtocol
 from ciris_engine.schemas.config.agent import AgentTemplate
 from ciris_engine.schemas.config.essential import EssentialConfig
@@ -156,6 +157,7 @@ class IdentityManager:
                 approval_required=True,
                 approved_by=None,
                 approval_timestamp=None,
+                version=CIRIS_VERSION,  # Use actual CIRIS version
             ),
             permitted_actions=[
                 HandlerActionType.OBSERVE,

--- a/ciris_engine/schemas/services/nodes.py
+++ b/ciris_engine/schemas/services/nodes.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field
 
+from ciris_engine.constants import CIRIS_VERSION
 from ciris_engine.schemas.services.graph_core import GraphNode, GraphNodeAttributes, GraphScope, NodeType
 from ciris_engine.schemas.services.graph_typed_nodes import TypedGraphNode, register_node_type
 
@@ -689,7 +690,7 @@ class IdentityNode(TypedGraphNode):
                 approval_required=self.approval_required,
                 approved_by=self.approved_by,
                 approval_timestamp=self.approval_timestamp,
-                version="1.0.0",
+                version=CIRIS_VERSION,
                 previous_versions=[],
             ),
             permitted_actions=self.permitted_actions,

--- a/dict_any_audit_results.json
+++ b/dict_any_audit_results.json
@@ -1013,7 +1013,7 @@
       },
       {
         "file": "ciris_engine/schemas/services/nodes.py",
-        "line": 275,
+        "line": 276,
         "class": "IdentitySnapshot",
         "function": null,
         "context": "other",
@@ -1021,7 +1021,7 @@
       },
       {
         "file": "ciris_engine/schemas/services/nodes.py",
-        "line": 529,
+        "line": 530,
         "class": "IdentityNode",
         "function": null,
         "context": "other",


### PR DESCRIPTION
## Summary
Fixes the issue where Datum reports version 1.0 instead of 1.3.4-beta.

## Problem
Datum was reporting `version: 1.0` when asked about their version, despite the system being at version 1.3.4-beta.

## Root Cause
The `IdentityMetadata` schema had a hardcoded default version of "1.0.0" instead of using the actual CIRIS_VERSION constant.

## Solution
- Import `CIRIS_VERSION` from constants.py in both identity_manager.py and nodes.py
- Use `CIRIS_VERSION` when creating IdentityMetadata instances
- This ensures agents report their actual version correctly

## Test
After deployment, Datum should respond with version 1.3.4-beta when asked.

🤖 Generated with [Claude Code](https://claude.ai/code)