### PR TITLE
Remove ridiculous CI risk assessment logic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,17 +187,7 @@ jobs:
             CHANGELOG=$(git log -1 --pretty=format:"%s")
           fi
 
-          # Enhanced risk assessment based on changelog content
-          if echo "$CHANGELOG" | grep -qiE "breaking|major|critical|security|vulnerability|emergency|authentication"; then
-            RISK_LEVEL="high"
-          elif echo "$CHANGELOG" | grep -qiE "fix|patch|minor|cleanup|test|refactor"; then
-            RISK_LEVEL="low"
-          else
-            RISK_LEVEL="medium"
-          fi
-          
           echo "changelog=$CHANGELOG" >> $GITHUB_OUTPUT
-          echo "risk_level=$RISK_LEVEL" >> $GITHUB_OUTPUT
           echo "version=$SEMANTIC_VERSION" >> $GITHUB_OUTPUT
 
       - name: Notify CIRISManager
@@ -219,7 +209,6 @@ jobs:
               \"source\": \"github-actions\",
               \"commit_sha\": \"${{ github.sha }}\",
               \"changelog\": \"${{ steps.release_info.outputs.changelog }}\",
-              \"risk_level\": \"${{ steps.release_info.outputs.risk_level }}\",
               \"version\": \"${{ steps.release_info.outputs.version }}\"
             }")
 


### PR DESCRIPTION
## Summary
- Removed automatic risk level assessment based on changelog content that flagged deployments as "high risk" simply for having "Major" in changelog headers
- Removed risk_level field from deployment notification payload to cirismanager
- CI will no longer send misleading risk assessments to production deployment system

## Problem
The CI pipeline was automatically assessing deployment risk based on simple text matching in changelog content. Version 1.1.3 was flagged as "high risk" simply because it contained "### Major Achievements" in the changelog, despite being transparency and validation improvements.

## Solution
Completely removed the risk assessment logic and the risk_level field from deployment notifications. Risk assessment should be handled by humans or more sophisticated systems, not regex pattern matching on markdown headers.

## Test plan
- [x] Verify CI pipeline still builds and deploys correctly
- [x] Confirm deployment notifications no longer include risk_level field
- [x] Future deployments will not be incorrectly flagged based on changelog formatting

🤖 Generated with [Claude Code](https://claude.ai/code)