### PR TITLE
1.5.0 Release: P0 Fixes for PostgreSQL and Shutdown Loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Solution**: Use proper helper functions `get_secrets_db_full_path()` and `get_audit_db_full_path()` which preserve query parameters
   - **Files**: `ciris_engine/logic/runtime/service_initializer.py:257-262, 390-397`
   - **Root Cause**: Scout-003 (scout-remote-test-dahrb9) first occurrence with Reddit adapter on main server exposed the bug
+- **P0: Missing Environment Variable Loading in Database Init** - Fixed `CIRIS_DB_URL` not being loaded during fallback config creation
+  - **Problem**: Line 619 in `ciris_runtime.py` creates `EssentialConfig()` without calling `.load_env_vars()`
+  - **Impact**: PostgreSQL deployments silently fall back to SQLite when no config provided, ignoring `CIRIS_DB_URL` environment variable
+  - **Symptom**: Agent logs "Using SQLite database: data/ciris_engine.db" despite `CIRIS_DB_URL` being set to PostgreSQL
+  - **Solution**: Added `.load_env_vars()` call immediately after `EssentialConfig()` creation at line 620
+  - **Files**: `ciris_engine/logic/runtime/ciris_runtime.py:620`
+  - **Production Evidence**: Scout-003 startup logs showed SQLite fallback with PostgreSQL URL configured
 - **P1: Dialect Initialization Timing Bug** - Fixed `get_task_by_correlation_id()` to initialize dialect before building SQL
   - **Problem**: Called `get_adapter()` BEFORE establishing database connection, causing SQLite syntax to be used with PostgreSQL
   - **Impact**: PostgreSQL deployments failed correlation ID lookups with syntax errors (json_extract not supported)

--- a/ciris_engine/logic/runtime/ciris_runtime.py
+++ b/ciris_engine/logic/runtime/ciris_runtime.py
@@ -617,6 +617,7 @@ class CIRISRuntime:
         if not self.essential_config:
             # Use default essential config if none provided
             self.essential_config = EssentialConfig()
+            self.essential_config.load_env_vars()  # Load CIRIS_DB_URL and other env vars
             logger.warning("No config provided, using defaults")
 
     async def _verify_database_integrity(self) -> bool:


### PR DESCRIPTION
## Summary

This PR merges the 1.5.0 release branch containing three P0 production bug fixes discovered during Scout deployment:

### P0 Fixes

1. **Single-Occurrence Shutdown Loop** (Sage 7-hour freeze)
   - Single-occurrence agents entering monitoring mode for existing tasks
   - Fixed claiming logic to always claim for `occurrence_id="default"`
   - Added comprehensive deployment scenario tests

2. **PostgreSQL Environment Variable Loading** (Scout-003 startup failure)
   - `CIRIS_DB_URL` not loaded when creating fallback `EssentialConfig()`
   - Agents silently fell back to SQLite despite PostgreSQL configuration
   - Added `.load_env_vars()` call at ciris_runtime.py:620

3. **PostgreSQL URL Corruption** (Previously fixed)
   - Derivative database URL generation using proper helper functions
   - Preserves query parameters like `?sslmode=require`

### Additional Changes

- Reddit observer runtime injection and production readiness
- Comprehensive unit tests (15 new tests, 100% pass rate)
- Deployment scenario test coverage (51 total shutdown processor tests)
- Python 3.11 compatibility improvements
- Type safety enhancements

### Production Evidence

- Sage: 7-hour shutdown loop (25,200+ iterations)
- Scout-003: "invalid sslmode value: require_secrets" startup crash
- Both issues resolved and verified

### Test Results

- ✅ All unit tests passing
- ✅ 15 new Reddit observer tests (100% pass rate)
- ✅ Mypy type checking passes
- ✅ Python 3.11 and 3.12 compatibility verified

## Files Changed

**Core Fixes:**
- `ciris_engine/logic/processors/states/shutdown_processor.py` - Single-occurrence claiming
- `ciris_engine/logic/runtime/ciris_runtime.py` - Environment variable loading
- `ciris_engine/logic/runtime/service_initializer.py` - PostgreSQL URL handling

**Tests:**
- `tests/ciris_engine/logic/processors/states/test_shutdown_processor.py` - Deployment scenarios
- Additional test coverage for Reddit observer fixes

**Documentation:**
- `CHANGELOG.md` - Complete release notes with production evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)