### PR TITLE
fix(P0): Clean up stale SHUTDOWN_ tasks to prevent infinite loop on restart

### DIFF
--- a/tests/fixtures/database_maintenance.py
+++ b/tests/fixtures/database_maintenance.py
@@ -165,6 +165,32 @@ def stale_thought_data():
 
 
 @pytest.fixture
+def old_shutdown_task_data():
+    """
+    Provide sample old shutdown task data for cleanup testing.
+
+    Tests uppercase SHUTDOWN_ pattern (shared shutdown tasks use uppercase).
+
+    Returns:
+        Dict: Old shutdown task with stale timestamp
+    """
+    now = datetime.now(timezone.utc)
+    old_time = now - timedelta(minutes=10)  # 10 minutes old
+
+    return {
+        "task_id": "SHUTDOWN_SHARED_20251027",
+        "description": "System shutdown requested (shared across all occurrences)",
+        "status": "active",
+        "agent_occurrence_id": "__shared__",
+        "parent_task_id": None,
+        "created_at": old_time.isoformat(),
+        "updated_at": old_time.isoformat(),
+        "channel_id": "api",
+        "priority": 10,
+    }
+
+
+@pytest.fixture
 def multi_occurrence_cleanup_scenario():
     """
     Provide a complete multi-occurrence cleanup scenario.


### PR DESCRIPTION
## Problem

Datum was stuck in an infinite shutdown loop for 26+ minutes (18,700+ rounds) when attempting to deploy v1.5.4. The agent was reusing an old `SHUTDOWN_SHARED_20251031` task from a previous container run, causing it to wait forever for an LLM response that would never come.

## Root Cause

**Database maintenance cleanup bug**: The `_cleanup_stale_wakeup_tasks()` method only checked for `"shutdown_"` (lowercase) but shared shutdown tasks use `"SHUTDOWN_"` (uppercase) format via `try_claim_shared_task()`.

When Datum restarted:
1. Old `SHUTDOWN_SHARED_20251031` task (PENDING/ACTIVE) persisted in database
2. Seed thought `th_seed_SHUTDOWN_09c0ea32-98b` was marked "completed" from previous run
3. Shutdown processor claimed the stale task thinking it could process normally
4. Processor looped forever "Waiting for agent response" (thought already completed, no new LLM call)

## Solution

Added check for uppercase `"SHUTDOWN_"` pattern in maintenance cleanup:

```python
or task.task_id.startswith("SHUTDOWN_")  # Also match uppercase SHUTDOWN_ tasks
```

Now stale shutdown tasks >5 minutes old are cleaned up on startup, preventing reuse.

## Changes

- **Fixed**: `ciris_engine/logic/services/infrastructure/database_maintenance/service.py:432`
  - Added uppercase SHUTDOWN_ pattern check
  - Enhanced docstring to explain infinite loop prevention

- **Tests**: `tests/test_services/test_database_maintenance_multi_occurrence.py`
  - New test: `test_cleanup_removes_stale_uppercase_shutdown_tasks`
  - Verifies old SHUTDOWN_SHARED_* tasks are deleted on startup

- **Fixtures**: `tests/fixtures/database_maintenance.py`
  - Added `old_shutdown_task_data` fixture for testing

## Testing

✅ New test passing: `test_cleanup_removes_stale_uppercase_shutdown_tasks`  
✅ All 8 maintenance tests passing  
✅ Mypy clean  
✅ All previous Reddit fixes included (1.5.4 commits)

## Production Impact

**Immediate**: Fixes Datum deployment blockage (stuck since 18:33 UTC Oct 31)  
**Long-term**: Prevents shutdown loop bugs on any future container restarts

## Deployment Notes

After merge, Datum should restart cleanly and accept new shutdown requests without getting stuck in infinite loops.

## Related Issues

- Discovered during 1.5.4 deployment attempt to production Datum
- Affects single-occurrence agents that reuse persisted shared shutdown tasks
- Bug present in 1.5.3, fixed in 1.5.4

---

**Commits in this PR:**
- fix: Reddit observer now only responds to replies to Scout's own content
- fix: Prevent duplicate Reddit replies with correlation_id unique constraint  
- fix: Replace self._logger with module logger in RedditAPIClient
- test: Update test to reflect unique constraint on correlation_id
- refactor: Reduce cognitive complexity of add_task from 18 to 15
- fix(P0): Clean up stale SHUTDOWN_ tasks to prevent infinite loop on restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)