### PR TITLE
fix(P0-CRITICAL): PostgreSQL placeholder bugs + Datum shutdown loop fix

### DIFF
--- a/BUILD_INFO.txt
+++ b/BUILD_INFO.txt
@@ -1,7 +1,7 @@
 # Build Information
-Code Hash: 671738603ba5
-Build Time: 2025-11-01T12:15:18.586316
-Git Commit: 45a81729b09603b5ba4c9a8f840ed3cc2f3578e1
+Code Hash: 33929d1f225f
+Build Time: 2025-11-01T18:49:59.557403
+Git Commit: e0e9abd97f9448e738fa6b01daee3d72db417ed0
 Git Branch: 1.5.6
 
 This hash is a SHA-256 of all Python source files in the repository.

--- a/tests/test_services/test_database_maintenance_multi_occurrence.py
+++ b/tests/test_services/test_database_maintenance_multi_occurrence.py
@@ -449,12 +449,10 @@ class TestInsertRawThoughtHelper:
 
         # Verify thought exists with empty context
         from ciris_engine.logic.persistence import get_db_connection
+
         with get_db_connection(db_path=clean_db) as conn:
             cursor = conn.cursor()
-            cursor.execute(
-                "SELECT context_json FROM thoughts WHERE thought_id = ?",
-                ("helper_test_002",)
-            )
+            cursor.execute("SELECT context_json FROM thoughts WHERE thought_id = ?", ("helper_test_002",))
             row = cursor.fetchone()
             assert row is not None
             assert row["context_json"] == "{}"
@@ -584,6 +582,7 @@ class TestInvalidThoughtCleanup:
         WHEN cleanup runs
         THEN exception is caught and logged, no crash
         """
+
         # Mock get_db_connection to raise exception
         def mock_get_db_connection(*args, **kwargs):
             raise Exception("Database connection failed")


### PR DESCRIPTION
## Summary

Fixes 4 P0-CRITICAL bugs in v1.5.6:

1. **PostgreSQL Temporal Edge Creation Bug** - Hardcoded `?` placeholders in edge deletion
2. **Memory Visualization Missing Edges** - `get_edges_for_node()` returned 0 edges on PostgreSQL
3. **Multi-Occurrence Wakeup Loop** - Scout stuck for 14+ hours due to placeholder bug
4. **Datum Shutdown Loop** - 20-hour-old stale task reuse causing infinite loop

## Root Cause

All bugs stem from hardcoded SQLite `?` placeholders in PostgreSQL queries:
- PostgreSQL requires `%s` placeholders
- PostgreSQLCursorWrapper automatically translates `?` → `%s`
- Some code bypassed the wrapper or wasn't documented

## Bug Details

### Bug 1: Temporal Edge Creation (b703f2cf)
**File**: `ciris_engine/logic/services/memory/edge_manager.py:200-202`  
**Impact**: DELETE failed, duplicates accumulated  
**Fix**: Changed to `adapter.placeholder()`

### Bug 2: Memory Visualization (3c122bb8 + 8eeb8685)
**File**: `ciris_engine/logic/persistence/models/graph.py:241-271`  
**Impact**: Visualization showed isolated nodes  
**Fix**: Documented PostgreSQLCursorWrapper translation  
**Tests**: Added 7 comprehensive tests for `get_edges_for_node()`

### Bug 3: Multi-Occurrence Wakeup Loop (45a81729)
**File**: `ciris_engine/logic/persistence/models/tasks.py:617`  
**Impact**: Scout stuck at round 22,000+ for 14+ hours  
**Fix**: Documented PostgreSQLCursorWrapper translation

### Bug 4: Datum Shutdown Loop (b5c47018)
**File**: `ciris_engine/logic/persistence/models/tasks.py:700-733`  
**Impact**: Datum stuck at round 28,845+ reusing 20-hour-old task  
**Fix**: Added stale task detection:
- Check task status (must be PENDING or ACTIVE)
- Check task age (must be <10 minutes)
- Delete stale tasks instead of reusing

## Test Coverage

**Bug 2 Tests** (`tests/ciris_engine/logic/persistence/models/test_graph.py`):
- SQLite/PostgreSQL placeholder compatibility
- Incoming/outgoing edge filtering
- Scope isolation
- Empty result handling
- Attribute parsing
- Error handling

**Bug 4 Tests** (`tests/ciris_engine/logic/persistence/test_shared_tasks.py`):
- Fresh active/pending task reuse (happy path)
- Completed stale task deletion
- Failed stale task deletion
- Old active task deletion (>10 min)
- 10-minute boundary edge case
- Exact Datum bug scenario (20-hour-old task)

**Total**: 14 new tests, all passing

## QA Results

Ran QA tests with both SQLite and PostgreSQL backends:
- **SQLite**: 117/118 tests passed (99.2%)
- **PostgreSQL**: 117/118 tests passed (99.2%)
- Single failing test unrelated to fixes (streaming issue)

## Version Bump

**New Version**: 1.5.6  
**Previous**: 1.5.5

## Changelog

Full details in CHANGELOG.md (lines 10-70)

## Verification

```bash
# Run comprehensive tests
pytest -n 16 tests/ --timeout=300

# Run QA with both backends
python -m tools.qa_runner --database-backends sqlite postgres --parallel-backends
```

## Deployment Impact

**Critical**: This fixes production issues on:
- Scout (stuck in wakeup loop)
- Datum (stuck in shutdown loop)

**Recommended**: Deploy immediately to production instances.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>