### PR TITLE
Fix DSAR multi-source routing and import-mode CLI path

### DIFF
--- a/ciris_engine/logic/adapters/api/routes/dsar_multi_source.py
+++ b/ciris_engine/logic/adapters/api/routes/dsar_multi_source.py
@@ -145,7 +145,10 @@ def _initialize_orchestrator(req: Request) -> DSAROrchestrator:
     )
 
 
-@router.post("", response_model=StandardResponse)
+# Explicit trailing slash support for TestClient (httpx follow_redirects=True still returns
+# 405 for POST when only the non-slash variant exists). Defining the route with an explicit
+# slash ensures both "/dsar/multi-source" and "/dsar/multi-source/" resolve correctly.
+@router.post("/", response_model=StandardResponse)
 async def submit_multi_source_dsar(
     request: MultiSourceDSARRequest,
     req: Request,

--- a/main.py
+++ b/main.py
@@ -271,6 +271,10 @@ def main(
             sys.exit(1)
 
         first_run = is_first_run()
+        # When running in import/CI mode, bypass interactive first-run gating so
+        # CLI smoke tests can execute without configuration prompts or exits.
+        if os.environ.get("CIRIS_IMPORT_MODE") == "true":
+            first_run = False
         if first_run and not adapter_types_list:
             # First run detected and no adapter explicitly specified via CLI
 


### PR DESCRIPTION
## Summary
- allow trailing slash posts for multi-source DSAR endpoint to avoid 405 responses
- skip first-run exit flow when CIRIS_IMPORT_MODE=true to support CLI smoke tests

## Testing
- `pytest tests/adapters/api/test_dsar_multi_source.py tests/adapters/api/test_dsar_endpoint.py::TestDSARAutomation::test_dsar_automation_graceful_degradation tests/test_discord_cli_failover.py::test_run_discord_uses_env -q` *(fails: pytest addopts require pytest-timeout plugin in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e65dca09c832b99d3a05e1f96d544)