### PR TITLE
Fix multi-source DSAR route and import-mode CLI behavior

### DIFF
--- a/ciris_engine/logic/adapters/api/routes/dsar_multi_source.py
+++ b/ciris_engine/logic/adapters/api/routes/dsar_multi_source.py
@@ -146,6 +146,7 @@ def _initialize_orchestrator(req: Request) -> DSAROrchestrator:
 
 
 @router.post("", response_model=StandardResponse)
+@router.post("/", response_model=StandardResponse, include_in_schema=False)
 async def submit_multi_source_dsar(
     request: MultiSourceDSARRequest,
     req: Request,


### PR DESCRIPTION
## Summary
- accept trailing slash submissions for the multi-source DSAR endpoint so tests hit the route
- honor CIRIS_IMPORT_MODE by bypassing first-run gating and defaulting to mock LLM during import-only execution

## Testing
- pytest tests/adapters/api/test_dsar_multi_source.py -q
- pytest tests/test_discord_cli_failover.py::test_run_discord_uses_env -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e65dca09c832b99d3a05e1f96d544)