### PR TITLE
fix: PostgreSQL dialect extract_scalar odict_keys subscript error

### DIFF
--- a/BUILD_INFO.txt
+++ b/BUILD_INFO.txt
@@ -1,8 +1,8 @@
 # Build Information
-Code Hash: 39d5fa3029ce
-Build Time: 2025-11-23T20:28:47.366020
-Git Commit: 98aed22eba81664cadd2d0b27cec747f9e119b90
-Git Branch: release/1.6.5.1
+Code Hash: 06a3abce3c1e
+Build Time: 2025-11-25T11:45:24.008123
+Git Commit: 6d39f8e0b2730c902e173ccbc133555def4465dc
+Git Branch: bugfix/issue-521-postgres-dialect
 
 This hash is a SHA-256 of all Python source files in the repository.
 It provides a deterministic version identifier based on the actual code content.

--- a/ciris_engine/logic/persistence/db/dialect.py
+++ b/ciris_engine/logic/persistence/db/dialect.py
@@ -310,7 +310,8 @@ DO UPDATE SET {updates}
             if hasattr(row, "keys"):
                 keys = row.keys()
                 if keys:
-                    return row[keys[0]]
+                    # Convert keys to list since dict_keys/odict_keys don't support indexing
+                    return row[list(keys)[0]]
             return None
 
     def get_query_builder(self) -> "QueryBuilder":


### PR DESCRIPTION
## Summary
- Fixes TypeError when `extract_scalar` is called on PostgreSQL rows
- `row.keys()` returns `odict_keys` which doesn't support `[0]` indexing
- Convert to list before indexing: `list(keys)[0]`

## Impact
This bug was causing massive log spam (~60MB incident logs) on PostgreSQL deployments because `count_tasks` and other frequent DB operations were continuously throwing errors.

## Test plan
- [ ] Verify existing SQLite tests still pass
- [ ] Deploy to PostgreSQL-backed scout agents
- [ ] Confirm log spam stops

Fixes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)