### PR TITLE
fix: Bump version to 1.7.2 to fix PyPI publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 **A type-safe, auditable AI agent framework with built-in ethical reasoning**
 
-**BETA RELEASE 1.7.1-stable** | [Release Notes](CHANGELOG.md) | [Documentation Hub](docs/README.md)
+**BETA RELEASE 1.7.2-stable** | [Release Notes](CHANGELOG.md) | [Documentation Hub](docs/README.md)
 
 Academic paper https://zenodo.org/records/17195221
 Philosophical foundation https://ciris.ai/ciris_covenant.pdf

--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -3,10 +3,10 @@
 from pathlib import Path
 
 # Version information
-CIRIS_VERSION = "1.7.1-stable"
+CIRIS_VERSION = "1.7.2-stable"
 CIRIS_VERSION_MAJOR = 1
 CIRIS_VERSION_MINOR = 7
-CIRIS_VERSION_PATCH = 1
+CIRIS_VERSION_PATCH = 2
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Stable Foundation"  # Codename for this release


### PR DESCRIPTION
## Summary
- Bumps version from 1.7.1 to 1.7.2

## Problem
The CD workflow failed because version 1.7.1 was already published to PyPI:
```
ERROR   HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
        File already exists ('ciris_agent-1.7.1-py3-none-any.whl')
```

## Solution
Bump to 1.7.2 so the next publish succeeds.

## Test plan
- [ ] Verify version is 1.7.2 in constants.py
- [ ] Verify CD workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)