### PR TITLE
Release 2.4.2: Context enrichment cache auto-population

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to CIRIS Agent will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.2] - 2026-04-10
+
+### Added
+
+- **Context Enrichment Cache Auto-Population** - Enrichment cache now auto-populates at startup and when adapters load dynamically, eliminating first-thought latency
+- **Unit Tests for Enrichment Cache** - Added comprehensive tests for startup cache population and adapter cache refresh
+
+### Fixed
+
+- **Context Enrichment Route** - Fixed 404 on `/adapters/context-enrichment` endpoint by moving it before wildcard route
+
+## [2.4.1] - 2026-04-09
+
+### Added
+
+- **WA Key Auto-Rotation** - User Wise Authority keys now auto-rotate with unit test coverage
+- **WA Signing via CIRISVerify** - Named key signing capability through CIRISVerify integration
+- **Play Integrity Reporting** - CIRISVerify v1.5.3 with Play Integrity failure reporting
+
+### Fixed
+
+- **Wallet Badge Display** - Fixed trust badge and wallet race conditions at startup
+- **Attestation Lights** - Parse CIRISVerify v1.5.x unified attestation format correctly
+- **Domain Filtering** - Fixed domain filtering and deterministic trace IDs
+
 ## [2.4.0] - 2026-04-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 **A type-safe, auditable AI agent framework with built-in ethical reasoning**
 
-**BETA RELEASE 2.4.1-stable** | [Release Notes](CHANGELOG.md) | [Documentation Hub](docs/README.md)
+**BETA RELEASE 2.4.2-stable** | [Release Notes](CHANGELOG.md) | [Documentation Hub](docs/README.md)
 
 CIRIS lets you run AI agents that explain their decisions, defer to humans when uncertain, and maintain complete audit trails. Currently powering Discord community moderation, designed to scale to healthcare and education.
 

--- a/android/app/src/main/python/version.py
+++ b/android/app/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.4.1"
+__version__ = "android-2.4.2"
 
 
 def get_version() -> str:

--- a/ciris_adapters/home_assistant/adapter.py
+++ b/ciris_adapters/home_assistant/adapter.py
@@ -140,6 +140,10 @@ class HomeAssistantAdapter(Service):
                         f"[HA DISCOVERY] Found {len(entities)} entities across {len(domains)} domains: "
                         + ", ".join(f"{d}={c}" for d, c in sorted(domains.items(), key=lambda x: -x[1])[:15])
                     )
+                    # Notify tool service that HA is now initialized so it can detect Music Assistant
+                    # This is critical - without this, MA tools won't appear if tool discovery
+                    # happened before HA finished loading entities
+                    await self.tool_service.notify_ha_initialized()
                 except Exception as e:
                     logger.warning(f"[HA DISCOVERY] Entity discovery failed: {e}")
             else:

--- a/ciris_adapters/home_assistant/tool_service.py
+++ b/ciris_adapters/home_assistant/tool_service.py
@@ -1298,6 +1298,20 @@ MA supports synchronized multi-room audio. If players are grouped:
         """Return service metadata for DSAR and data source discovery."""
         return {"data_source": False, "service_type": "device_control"}
 
+    async def notify_ha_initialized(self) -> None:
+        """Called after HA background initialization completes.
+
+        This triggers Music Assistant detection now that entities are available.
+        Without this, MA tools might not appear if tool discovery happened
+        before HA finished loading entities.
+        """
+        logger.info("[HA TOOLS] HA initialized - checking for Music Assistant")
+        ma_detected = await self._check_ma_available()
+        if ma_detected:
+            logger.info("[HA TOOLS] Music Assistant tools now available")
+        else:
+            logger.debug("[HA TOOLS] Music Assistant not detected after HA init")
+
     async def get_available_tools(self) -> List[str]:
         """Get available tool names. Used by system snapshot tool collection."""
         tools = list(self.TOOL_DEFINITIONS.keys())

--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -3,11 +3,11 @@
 from pathlib import Path
 
 # Version information
-CIRIS_VERSION = "2.4.1-stable"
+CIRIS_VERSION = "2.4.2-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
 CIRIS_VERSION_MINOR = 4
-CIRIS_VERSION_PATCH = 1
+CIRIS_VERSION_PATCH = 2
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/ciris_engine/logic/adapters/api/routes/memory.py
+++ b/ciris_engine/logic/adapters/api/routes/memory.py
@@ -435,6 +435,7 @@ async def forget_memory(
     auth: AuthAdminDep,
     memory_service: MemoryServiceDep,
     node_id: str = Path(..., description="Node ID to forget"),
+    scope: Optional[str] = Query(None, description="Graph scope (local, environment, community)"),
 ) -> SuccessResponse[MemoryOpResult[GraphNode]]:
     """
     Forget a specific memory node (FORGET).
@@ -447,10 +448,19 @@ async def forget_memory(
         # The forget method will look up the full node internally
         from ciris_engine.schemas.services.graph_core import GraphNode, GraphScope, NodeType
 
+        # Parse scope from query param, default to LOCAL for backwards compatibility
+        graph_scope = GraphScope.LOCAL
+        if scope:
+            scope_lower = scope.lower()
+            if scope_lower == "environment":
+                graph_scope = GraphScope.ENVIRONMENT
+            elif scope_lower == "community":
+                graph_scope = GraphScope.COMMUNITY
+
         node_to_forget = GraphNode(
             id=node_id,
             type=NodeType.CONCEPT,  # Default type, will be looked up by forget method
-            scope=GraphScope.LOCAL,  # Default scope
+            scope=graph_scope,
             attributes={},
         )
 

--- a/ciris_engine/logic/adapters/api/routes/memory.py
+++ b/ciris_engine/logic/adapters/api/routes/memory.py
@@ -434,8 +434,8 @@ async def forget_memory(
     request: Request,
     auth: AuthAdminDep,
     memory_service: MemoryServiceDep,
-    node_id: str = Path(..., description="Node ID to forget"),
-    scope: Optional[str] = Query(None, description="Graph scope (local, environment, community)"),
+    node_id: Annotated[str, Path(description="Node ID to forget")],
+    scope: Annotated[Optional[str], Query(description="Graph scope (local, environment, community)")] = None,
 ) -> SuccessResponse[MemoryOpResult[GraphNode]]:
     """
     Forget a specific memory node (FORGET).

--- a/ciris_engine/logic/adapters/api/routes/setup/config.py
+++ b/ciris_engine/logic/adapters/api/routes/setup/config.py
@@ -264,6 +264,47 @@ def _detect_api_key_set(provider: str) -> bool:
 router = APIRouter()
 
 
+async def _require_auth_if_configured(request: Request) -> None:
+    """Require authentication if setup is already completed."""
+    if _is_setup_allowed_without_auth():
+        return
+
+    from ...dependencies.auth import get_auth_context, get_auth_service
+
+    try:
+        authorization = request.headers.get("Authorization")
+        auth_service = get_auth_service(request)
+        auth = await get_auth_context(request, authorization, auth_service)
+        if auth is None:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.warning(f"Authentication failed for /setup/config: {e}")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
+
+
+def _get_template_id(request: Request) -> str:
+    """Get template ID from CLI flag or environment variable."""
+    template_id = os.getenv("CIRIS_TEMPLATE")
+    if not template_id:
+        runtime = getattr(request.app.state, "runtime", None)
+        if runtime and hasattr(runtime, "essential_config") and runtime.essential_config:
+            template_id = getattr(runtime.essential_config, "default_template", None)
+    return template_id or "default"
+
+
+def _parse_float_env(env_var: str) -> Optional[float]:
+    """Parse a float from environment variable, returning None if invalid."""
+    value = os.getenv(env_var)
+    if not value:
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
 @router.get("/config", responses=RESPONSES_401_500)
 async def get_current_config(request: Request) -> SuccessResponse[SetupConfigResponse]:
     """Get current configuration.
@@ -271,52 +312,12 @@ async def get_current_config(request: Request) -> SuccessResponse[SetupConfigRes
     Returns current setup configuration for editing.
     Requires authentication if setup is already completed.
     """
-    # If not first-run, require authentication
-    if not _is_setup_allowed_without_auth():
-        # Manually get auth context from request
-        try:
-            from ...dependencies.auth import get_auth_context, get_auth_service
+    await _require_auth_if_configured(request)
 
-            # Extract authorization header and auth service manually since we're not using Depends()
-            authorization = request.headers.get("Authorization")
-            auth_service = get_auth_service(request)
-            auth = await get_auth_context(request, authorization, auth_service)
-            if auth is None:
-                raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
-        except HTTPException:
-            raise
-        except Exception as e:
-            logger.warning(f"Authentication failed for /setup/config: {e}")
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication required")
-
-    # Get template from CLI flag (via runtime config) or environment variable
-    # CLI --template flag takes precedence on first-run before .env exists
-    template_id = os.getenv("CIRIS_TEMPLATE")
-    if not template_id:
-        runtime = getattr(request.app.state, "runtime", None)
-        if runtime and hasattr(runtime, "essential_config") and runtime.essential_config:
-            template_id = getattr(runtime.essential_config, "default_template", None)
-    if not template_id:
-        template_id = "default"
-
-    # Detect LLM provider using same logic as LLM service
+    template_id = _get_template_id(request)
     llm_provider = _detect_llm_provider(request)
-
-    # Get user location from environment (safely handle invalid values)
-    latitude_str = os.getenv("CIRIS_USER_LATITUDE")
-    longitude_str = os.getenv("CIRIS_USER_LONGITUDE")
-    latitude: Optional[float] = None
-    longitude: Optional[float] = None
-    if latitude_str:
-        try:
-            latitude = float(latitude_str)
-        except ValueError:
-            pass  # Invalid format, fall back to None
-    if longitude_str:
-        try:
-            longitude = float(longitude_str)
-        except ValueError:
-            pass  # Invalid format, fall back to None
+    latitude = _parse_float_env("CIRIS_USER_LATITUDE")
+    longitude = _parse_float_env("CIRIS_USER_LONGITUDE")
 
     config = SetupConfigResponse(
         llm_provider=llm_provider,

--- a/ciris_engine/logic/adapters/api/routes/setup/config.py
+++ b/ciris_engine/logic/adapters/api/routes/setup/config.py
@@ -302,11 +302,21 @@ async def get_current_config(request: Request) -> SuccessResponse[SetupConfigRes
     # Detect LLM provider using same logic as LLM service
     llm_provider = _detect_llm_provider(request)
 
-    # Get user location from environment
+    # Get user location from environment (safely handle invalid values)
     latitude_str = os.getenv("CIRIS_USER_LATITUDE")
     longitude_str = os.getenv("CIRIS_USER_LONGITUDE")
-    latitude = float(latitude_str) if latitude_str else None
-    longitude = float(longitude_str) if longitude_str else None
+    latitude: Optional[float] = None
+    longitude: Optional[float] = None
+    if latitude_str:
+        try:
+            latitude = float(latitude_str)
+        except ValueError:
+            pass  # Invalid format, fall back to None
+    if longitude_str:
+        try:
+            longitude = float(longitude_str)
+        except ValueError:
+            pass  # Invalid format, fall back to None
 
     config = SetupConfigResponse(
         llm_provider=llm_provider,

--- a/ciris_engine/logic/adapters/api/routes/setup/config.py
+++ b/ciris_engine/logic/adapters/api/routes/setup/config.py
@@ -302,6 +302,12 @@ async def get_current_config(request: Request) -> SuccessResponse[SetupConfigRes
     # Detect LLM provider using same logic as LLM service
     llm_provider = _detect_llm_provider(request)
 
+    # Get user location from environment
+    latitude_str = os.getenv("CIRIS_USER_LATITUDE")
+    longitude_str = os.getenv("CIRIS_USER_LONGITUDE")
+    latitude = float(latitude_str) if latitude_str else None
+    longitude = float(longitude_str) if longitude_str else None
+
     config = SetupConfigResponse(
         llm_provider=llm_provider,
         llm_base_url=os.getenv("OPENAI_API_BASE"),
@@ -313,6 +319,13 @@ async def get_current_config(request: Request) -> SuccessResponse[SetupConfigRes
         template_id=template_id,
         enabled_adapters=os.getenv("CIRIS_ADAPTER", "api").split(","),
         agent_port=int(os.getenv("CIRIS_API_PORT", "8080")),
+        location_country=os.getenv("CIRIS_USER_COUNTRY"),
+        location_region=os.getenv("CIRIS_USER_REGION"),
+        location_city=os.getenv("CIRIS_USER_CITY"),
+        location_latitude=latitude,
+        location_longitude=longitude,
+        timezone=os.getenv("CIRIS_USER_TIMEZONE"),
+        has_coordinates=latitude is not None and longitude is not None,
     )
 
     return SuccessResponse(data=config)

--- a/ciris_engine/logic/adapters/api/routes/setup/models.py
+++ b/ciris_engine/logic/adapters/api/routes/setup/models.py
@@ -378,6 +378,15 @@ class SetupConfigResponse(BaseModel):
     # Application
     agent_port: int = Field(default=8080, description="Current agent port")
 
+    # User Location (from setup)
+    location_country: Optional[str] = Field(None, description="User's country")
+    location_region: Optional[str] = Field(None, description="User's region/state")
+    location_city: Optional[str] = Field(None, description="User's city")
+    location_latitude: Optional[float] = Field(None, description="Latitude in decimal degrees")
+    location_longitude: Optional[float] = Field(None, description="Longitude in decimal degrees")
+    timezone: Optional[str] = Field(None, description="IANA timezone")
+    has_coordinates: bool = Field(False, description="Whether lat/long are available")
+
 
 class CreateUserRequest(BaseModel):
     """Request to create initial admin user."""

--- a/ciris_engine/logic/adapters/api/routes/system/adapters.py
+++ b/ciris_engine/logic/adapters/api/routes/system/adapters.py
@@ -964,3 +964,47 @@ async def reload_adapter(
     except Exception as e:
         logger.error(f"Error reloading adapter: {e}")
         raise HTTPException(status_code=500, detail=str(e))
+
+
+# ============================================================================
+# Context Enrichment Cache
+# ============================================================================
+
+
+@router.get(
+    "/adapters/context-enrichment",
+    responses={500: {"description": "Failed to get context enrichment data"}},
+)
+async def get_context_enrichment_cache(
+    request: Request,
+    auth: Annotated[AuthContext, Depends(require_observer)],
+) -> SuccessResponse[Dict[str, Any]]:
+    """
+    Get context enrichment cache data from adapters.
+
+    Returns cached results from adapter tools that have context_enrichment=True,
+    along with cache statistics. This data is ephemeral and refreshed periodically.
+    """
+    from ciris_engine.logic.context.system_snapshot_helpers import get_enrichment_cache
+
+    try:
+        cache = get_enrichment_cache()
+        enrichment_data = cache.get_all_entries()
+        cache_stats = cache.stats
+
+        return SuccessResponse(
+            data={
+                "entries": enrichment_data,
+                "stats": {
+                    "entry_count": cache_stats.get("entries", 0),
+                    "hits": cache_stats.get("hits", 0),
+                    "misses": cache_stats.get("misses", 0),
+                    "hit_rate_pct": cache_stats.get("hit_rate_pct", 0.0),
+                    "startup_populated": cache_stats.get("startup_populated", False),
+                },
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"Error getting context enrichment cache: {e}")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/ciris_engine/logic/adapters/api/routes/system/adapters.py
+++ b/ciris_engine/logic/adapters/api/routes/system/adapters.py
@@ -713,6 +713,45 @@ async def list_loadable_adapters(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@router.get(
+    "/adapters/context-enrichment",
+    responses={500: {"description": "Failed to get context enrichment data"}},
+)
+async def get_context_enrichment_cache(
+    request: Request,
+    auth: Annotated[AuthContext, Depends(require_observer)],
+) -> SuccessResponse[Dict[str, Any]]:
+    """
+    Get context enrichment cache data from adapters.
+
+    Returns cached results from adapter tools that have context_enrichment=True,
+    along with cache statistics. This data is ephemeral and refreshed periodically.
+    """
+    from ciris_engine.logic.context.system_snapshot_helpers import get_enrichment_cache
+
+    try:
+        cache = get_enrichment_cache()
+        enrichment_data = cache.get_all_entries()
+        cache_stats = cache.stats
+
+        return SuccessResponse(
+            data={
+                "entries": enrichment_data,
+                "stats": {
+                    "entry_count": cache_stats.get("entries", 0),
+                    "hits": cache_stats.get("hits", 0),
+                    "misses": cache_stats.get("misses", 0),
+                    "hit_rate_pct": cache_stats.get("hit_rate_pct", 0.0),
+                    "startup_populated": cache_stats.get("startup_populated", False),
+                },
+            }
+        )
+
+    except Exception as e:
+        logger.error(f"Error getting context enrichment cache: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
 @router.get("/adapters/{adapter_id}", responses=RESPONSES_ADAPTER_STATUS)
 async def get_adapter_status(
     adapter_id: str,
@@ -966,45 +1005,3 @@ async def reload_adapter(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-# ============================================================================
-# Context Enrichment Cache
-# ============================================================================
-
-
-@router.get(
-    "/adapters/context-enrichment",
-    responses={500: {"description": "Failed to get context enrichment data"}},
-)
-async def get_context_enrichment_cache(
-    request: Request,
-    auth: Annotated[AuthContext, Depends(require_observer)],
-) -> SuccessResponse[Dict[str, Any]]:
-    """
-    Get context enrichment cache data from adapters.
-
-    Returns cached results from adapter tools that have context_enrichment=True,
-    along with cache statistics. This data is ephemeral and refreshed periodically.
-    """
-    from ciris_engine.logic.context.system_snapshot_helpers import get_enrichment_cache
-
-    try:
-        cache = get_enrichment_cache()
-        enrichment_data = cache.get_all_entries()
-        cache_stats = cache.stats
-
-        return SuccessResponse(
-            data={
-                "entries": enrichment_data,
-                "stats": {
-                    "entry_count": cache_stats.get("entries", 0),
-                    "hits": cache_stats.get("hits", 0),
-                    "misses": cache_stats.get("misses", 0),
-                    "hit_rate_pct": cache_stats.get("hit_rate_pct", 0.0),
-                    "startup_populated": cache_stats.get("startup_populated", False),
-                },
-            }
-        )
-
-    except Exception as e:
-        logger.error(f"Error getting context enrichment cache: {e}")
-        raise HTTPException(status_code=500, detail=str(e))

--- a/ciris_engine/logic/adapters/api/routes/system/services.py
+++ b/ciris_engine/logic/adapters/api/routes/system/services.py
@@ -1,18 +1,15 @@
 """
 Services and resources endpoints.
 
-Provides resource usage information, service status monitoring, and environment context.
+Provides resource usage information and service status monitoring.
 """
 
 import logging
 from datetime import datetime, timezone
-from typing import Annotated, Any, Dict, Optional
+from typing import Annotated, Dict
 
 from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel, Field
 
-from ciris_engine.logic.context.system_snapshot_helpers import get_enrichment_cache
-from ciris_engine.logic.utils.location_utils import get_user_location
 from ciris_engine.schemas.api.responses import SuccessResponse
 
 from ...constants import ERROR_RESOURCE_MONITOR_NOT_AVAILABLE
@@ -128,101 +125,3 @@ async def get_services_status(
                 services=[], total_services=0, healthy_services=0, timestamp=datetime.now(timezone.utc)
             )
         )
-
-
-# ============================================================================
-# Environment Information Endpoint
-# ============================================================================
-
-
-class LocationInfo(BaseModel):
-    """User location information from setup."""
-
-    location: Optional[str] = Field(None, description="Human-readable location string")
-    latitude: Optional[float] = Field(None, description="Latitude in decimal degrees")
-    longitude: Optional[float] = Field(None, description="Longitude in decimal degrees")
-    timezone: Optional[str] = Field(None, description="IANA timezone")
-    country: Optional[str] = Field(None, description="Country name")
-    region: Optional[str] = Field(None, description="Region/state name")
-    city: Optional[str] = Field(None, description="City name")
-    iso6709: Optional[str] = Field(None, description="ISO 6709 coordinates string")
-    has_coordinates: bool = Field(False, description="Whether lat/long are available")
-
-
-class EnrichmentCacheStats(BaseModel):
-    """Context enrichment cache statistics."""
-
-    entries: int = Field(0, description="Number of cached entries")
-    hits: int = Field(0, description="Cache hits since startup")
-    misses: int = Field(0, description="Cache misses since startup")
-    hit_rate_pct: float = Field(0.0, description="Cache hit rate percentage")
-    startup_populated: bool = Field(False, description="Whether cache was populated at startup")
-
-
-class EnvironmentInfoResponse(BaseModel):
-    """Environment information response including location and context enrichment."""
-
-    location: LocationInfo = Field(description="User location from setup")
-    context_enrichment: Dict[str, Any] = Field(
-        default_factory=dict,
-        description="Context enrichment results from adapters, keyed by 'adapter_type:tool_name'",
-    )
-    cache_stats: EnrichmentCacheStats = Field(description="Context enrichment cache statistics")
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-
-
-@router.get("/environment")
-async def get_environment_info(
-    request: Request,
-    auth: AuthObserverDep,
-) -> SuccessResponse[EnvironmentInfoResponse]:
-    """
-    Environment context information.
-
-    Returns user location from setup and context enrichment data from all adapters.
-    This includes data from Home Assistant, weather services, navigation, and other
-    adapters that provide context_enrichment=True tools.
-
-    Useful for debugging why certain context data may not be available.
-    """
-    try:
-        # Get user location from environment variables
-        user_location = get_user_location()
-        location_dict = user_location.to_dict()
-
-        location_info = LocationInfo(
-            location=location_dict.get("location"),
-            latitude=location_dict.get("latitude"),
-            longitude=location_dict.get("longitude"),
-            timezone=location_dict.get("timezone"),
-            country=location_dict.get("country"),
-            region=location_dict.get("region"),
-            city=location_dict.get("city"),
-            iso6709=location_dict.get("iso6709"),
-            has_coordinates=user_location.has_coordinates(),
-        )
-
-        # Get context enrichment cache data
-        cache = get_enrichment_cache()
-        enrichment_data = cache.get_all_entries()
-        cache_stats_raw = cache.stats
-
-        cache_stats = EnrichmentCacheStats(
-            entries=cache_stats_raw.get("entries", 0),
-            hits=cache_stats_raw.get("hits", 0),
-            misses=cache_stats_raw.get("misses", 0),
-            hit_rate_pct=cache_stats_raw.get("hit_rate_pct", 0.0),
-            startup_populated=cache_stats_raw.get("startup_populated", False),
-        )
-
-        return SuccessResponse(
-            data=EnvironmentInfoResponse(
-                location=location_info,
-                context_enrichment=enrichment_data,
-                cache_stats=cache_stats,
-            )
-        )
-
-    except Exception as e:
-        logger.error(f"Error getting environment info: {e}")
-        raise HTTPException(status_code=500, detail=str(e))

--- a/ciris_engine/logic/adapters/api/routes/system/services.py
+++ b/ciris_engine/logic/adapters/api/routes/system/services.py
@@ -1,15 +1,18 @@
 """
 Services and resources endpoints.
 
-Provides resource usage information and service status monitoring.
+Provides resource usage information, service status monitoring, and environment context.
 """
 
 import logging
 from datetime import datetime, timezone
-from typing import Annotated, Dict
+from typing import Annotated, Any, Dict, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
 
+from ciris_engine.logic.context.system_snapshot_helpers import get_enrichment_cache
+from ciris_engine.logic.utils.location_utils import get_user_location
 from ciris_engine.schemas.api.responses import SuccessResponse
 
 from ...constants import ERROR_RESOURCE_MONITOR_NOT_AVAILABLE
@@ -125,3 +128,101 @@ async def get_services_status(
                 services=[], total_services=0, healthy_services=0, timestamp=datetime.now(timezone.utc)
             )
         )
+
+
+# ============================================================================
+# Environment Information Endpoint
+# ============================================================================
+
+
+class LocationInfo(BaseModel):
+    """User location information from setup."""
+
+    location: Optional[str] = Field(None, description="Human-readable location string")
+    latitude: Optional[float] = Field(None, description="Latitude in decimal degrees")
+    longitude: Optional[float] = Field(None, description="Longitude in decimal degrees")
+    timezone: Optional[str] = Field(None, description="IANA timezone")
+    country: Optional[str] = Field(None, description="Country name")
+    region: Optional[str] = Field(None, description="Region/state name")
+    city: Optional[str] = Field(None, description="City name")
+    iso6709: Optional[str] = Field(None, description="ISO 6709 coordinates string")
+    has_coordinates: bool = Field(False, description="Whether lat/long are available")
+
+
+class EnrichmentCacheStats(BaseModel):
+    """Context enrichment cache statistics."""
+
+    entries: int = Field(0, description="Number of cached entries")
+    hits: int = Field(0, description="Cache hits since startup")
+    misses: int = Field(0, description="Cache misses since startup")
+    hit_rate_pct: float = Field(0.0, description="Cache hit rate percentage")
+    startup_populated: bool = Field(False, description="Whether cache was populated at startup")
+
+
+class EnvironmentInfoResponse(BaseModel):
+    """Environment information response including location and context enrichment."""
+
+    location: LocationInfo = Field(description="User location from setup")
+    context_enrichment: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Context enrichment results from adapters, keyed by 'adapter_type:tool_name'",
+    )
+    cache_stats: EnrichmentCacheStats = Field(description="Context enrichment cache statistics")
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+@router.get("/environment")
+async def get_environment_info(
+    request: Request,
+    auth: AuthObserverDep,
+) -> SuccessResponse[EnvironmentInfoResponse]:
+    """
+    Environment context information.
+
+    Returns user location from setup and context enrichment data from all adapters.
+    This includes data from Home Assistant, weather services, navigation, and other
+    adapters that provide context_enrichment=True tools.
+
+    Useful for debugging why certain context data may not be available.
+    """
+    try:
+        # Get user location from environment variables
+        user_location = get_user_location()
+        location_dict = user_location.to_dict()
+
+        location_info = LocationInfo(
+            location=location_dict.get("location"),
+            latitude=location_dict.get("latitude"),
+            longitude=location_dict.get("longitude"),
+            timezone=location_dict.get("timezone"),
+            country=location_dict.get("country"),
+            region=location_dict.get("region"),
+            city=location_dict.get("city"),
+            iso6709=location_dict.get("iso6709"),
+            has_coordinates=user_location.has_coordinates(),
+        )
+
+        # Get context enrichment cache data
+        cache = get_enrichment_cache()
+        enrichment_data = cache.get_all_entries()
+        cache_stats_raw = cache.stats
+
+        cache_stats = EnrichmentCacheStats(
+            entries=cache_stats_raw.get("entries", 0),
+            hits=cache_stats_raw.get("hits", 0),
+            misses=cache_stats_raw.get("misses", 0),
+            hit_rate_pct=cache_stats_raw.get("hit_rate_pct", 0.0),
+            startup_populated=cache_stats_raw.get("startup_populated", False),
+        )
+
+        return SuccessResponse(
+            data=EnvironmentInfoResponse(
+                location=location_info,
+                context_enrichment=enrichment_data,
+                cache_stats=cache_stats,
+            )
+        )
+
+    except Exception as e:
+        logger.error(f"Error getting environment info: {e}")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/ciris_engine/logic/context/system_snapshot_helpers.py
+++ b/ciris_engine/logic/context/system_snapshot_helpers.py
@@ -136,6 +136,27 @@ class ContextEnrichmentCache:
         """Check if cache has been populated (at startup or otherwise)."""
         return len(self._cache) > 0 or self._startup_populated
 
+    def get_all_entries(self) -> Dict[str, Any]:
+        """Get all non-expired cache entries for API exposure.
+
+        Returns a dict of {tool_key: data} for all entries that haven't expired.
+        Used by /v1/system/environment endpoint to expose context enrichment data.
+        """
+        result: Dict[str, Any] = {}
+        expired_keys: List[str] = []
+
+        for key, entry in self._cache.items():
+            if entry.is_expired():
+                expired_keys.append(key)
+            else:
+                result[key] = entry.data
+
+        # Clean up expired entries
+        for key in expired_keys:
+            del self._cache[key]
+
+        return result
+
     def mark_startup_populated(self) -> None:
         """Mark that startup population has completed."""
         self._startup_populated = True

--- a/ciris_engine/logic/runtime/adapter_manager.py
+++ b/ciris_engine/logic/runtime/adapter_manager.py
@@ -8,7 +8,7 @@ extending the existing processor control capabilities with adapter lifecycle man
 import asyncio
 import logging
 import os
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
 
 import aiofiles
 
@@ -143,6 +143,8 @@ class RuntimeAdapterManager(AdapterManagerInterface):
         self.loaded_adapters: Dict[str, AdapterInstance] = {}
         self._adapter_counter = 0
         self._config_listener_registered = False
+        # Set to hold background tasks and prevent garbage collection
+        self._background_tasks: Set[asyncio.Task[Any]] = set()
         # Register for config changes after initialization
         self._register_config_listener()
 
@@ -249,10 +251,13 @@ class RuntimeAdapterManager(AdapterManagerInterface):
 
             # Refresh context enrichment cache in background (non-blocking)
             # This ensures newly loaded adapter tools are cached immediately
-            asyncio.create_task(
+            # Store task in set to prevent garbage collection (SonarCloud S5765)
+            task = asyncio.create_task(
                 self._refresh_enrichment_cache_for_adapter(instance),
                 name=f"refresh_enrichment_cache_{adapter_id}",
             )
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
 
             # Save adapter config to graph
             await self._save_adapter_config_to_graph(

--- a/ciris_engine/logic/runtime/adapter_manager.py
+++ b/ciris_engine/logic/runtime/adapter_manager.py
@@ -247,6 +247,13 @@ class RuntimeAdapterManager(AdapterManagerInterface):
 
             self._register_adapter_services(instance)
 
+            # Refresh context enrichment cache in background (non-blocking)
+            # This ensures newly loaded adapter tools are cached immediately
+            asyncio.create_task(
+                self._refresh_enrichment_cache_for_adapter(instance),
+                name=f"refresh_enrichment_cache_{adapter_id}",
+            )
+
             # Save adapter config to graph
             await self._save_adapter_config_to_graph(
                 adapter_id, adapter_type, config_params or AdapterConfig(adapter_type=adapter_type, enabled=True)
@@ -985,6 +992,67 @@ class RuntimeAdapterManager(AdapterManagerInterface):
 
         except Exception as e:
             logger.error(f"Error registering services for adapter {instance.adapter_id}: {e}", exc_info=True)
+
+    async def _refresh_enrichment_cache_for_adapter(self, instance: AdapterInstance) -> None:
+        """Refresh context enrichment cache for a newly loaded adapter.
+
+        This runs in the background after an adapter is loaded to ensure
+        its context_enrichment tools are cached immediately, rather than
+        waiting for the first thought to trigger cache population.
+        """
+        try:
+            from ciris_engine.logic.context.system_snapshot_helpers import (
+                _collect_available_tools,
+                get_enrichment_cache,
+                _collect_enrichment_tools,
+                _get_tool_services,
+                _execute_enrichment_tool,
+            )
+
+            # Give the adapter a moment to fully initialize
+            await asyncio.sleep(0.5)
+
+            # Collect tools from this adapter
+            available_tools = await _collect_available_tools(self.runtime)
+            if not available_tools:
+                logger.debug(f"No tools found for adapter {instance.adapter_id}")
+                return
+
+            # Find enrichment tools
+            enrichment_tools = _collect_enrichment_tools(available_tools)
+            if not enrichment_tools:
+                logger.debug(f"No context_enrichment tools in adapter {instance.adapter_id}")
+                return
+
+            # Execute enrichment tools and cache results
+            cache = get_enrichment_cache()
+            tool_services = _get_tool_services(self.runtime.service_registry)
+
+            for adapter_type, tool in enrichment_tools:
+                tool_key = f"{adapter_type}:{tool.name}"
+                try:
+                    # Skip if already cached
+                    if cache.get(tool_key) is not None:
+                        continue
+
+                    _, result = await _execute_enrichment_tool(tool_services, adapter_type, tool)
+                    if result is not None:
+                        params = tool.context_enrichment_params or {}
+                        ttl_raw = params.get("_cache_ttl")
+                        ttl = float(ttl_raw) if isinstance(ttl_raw, (int, float)) else None
+                        cache.set(tool_key, result, ttl)
+                        logger.info(f"[ENRICHMENT_CACHE] Cached {tool_key} after adapter load")
+                except Exception as e:
+                    logger.warning(f"[ENRICHMENT_CACHE] Failed to cache {tool_key}: {e}")
+
+            logger.info(
+                f"[ENRICHMENT_CACHE] Refreshed cache after loading {instance.adapter_id}, "
+                f"stats: {cache.stats}"
+            )
+
+        except Exception as e:
+            # Non-critical - just log and continue
+            logger.warning(f"Failed to refresh enrichment cache for {instance.adapter_id}: {e}")
 
     def _unregister_adapter_services(self, instance: AdapterInstance) -> None:
         """Unregister services for an adapter instance"""

--- a/ciris_engine/logic/runtime/component_builder.py
+++ b/ciris_engine/logic/runtime/component_builder.py
@@ -124,6 +124,7 @@ class ComponentBuilder:
             "thought_depth",
             ThoughtDepthGuardrail(time_service=time_service, max_depth=config.security.max_thought_depth),
             priority=4,
+            bypass_exemption=True,  # Must always run - enforces hard depth limit for safety
         )
 
         # ActionSequenceConscience - prevents repeated SPEAK without intervening actions

--- a/ciris_engine/logic/runtime/initialization_steps.py
+++ b/ciris_engine/logic/runtime/initialization_steps.py
@@ -769,6 +769,7 @@ async def populate_context_enrichment_cache(runtime: Any) -> None:
         )
 
         available_tools = await _collect_available_tools(runtime)
+
         if not available_tools:
             logger.info("No adapter tools available, skipping enrichment cache population")
             return

--- a/ciris_engine/logic/utils/path_resolution.py
+++ b/ciris_engine/logic/utils/path_resolution.py
@@ -1023,6 +1023,19 @@ def sync_language_preference(language_code: str) -> bool:
     except Exception as e:
         logger.warning(f"[env_sync] Failed to update DMA prompt loader: {e}")
 
+    # Update the conscience prompt loader
+    try:
+        from ciris_engine.logic.conscience.prompt_loader import set_conscience_prompt_language
+
+        set_conscience_prompt_language(language_code)
+        logger.info(
+            f"[env_sync] Synced language preference to conscience prompt loader: {sanitize_for_log(language_code)}"
+        )
+    except ImportError:
+        logger.debug("[env_sync] Conscience prompt_loader not available, skipping conscience language update")
+    except Exception as e:
+        logger.warning(f"[env_sync] Failed to update conscience prompt loader: {e}")
+
     return True
 
 

--- a/ios/CirisiOS/src/ciris_ios/version.py
+++ b/ios/CirisiOS/src/ciris_ios/version.py
@@ -6,7 +6,7 @@ The version hash is computed at build time from the main repository.
 """
 
 # Static version - updated at build time by the iOS build process
-__version__ = "ios-2.4.1"
+__version__ = "ios-2.4.2"
 
 
 def get_version() -> str:

--- a/mobile/androidApp/build.gradle
+++ b/mobile/androidApp/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 35
-        versionCode 85
-        versionName "2.4.1"
+        versionCode 86
+        versionName "2.4.2"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/mobile/androidApp/src/main/python/version.py
+++ b/mobile/androidApp/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.4.1"
+__version__ = "android-2.4.2"
 
 
 def get_version() -> str:

--- a/mobile/iosApp/iosApp/Info.plist
+++ b/mobile/iosApp/iosApp/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.1</string>
+	<string>2.4.2</string>
 	<key>CFBundleVersion</key>
-	<string>223</string>
+	<string>224</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/CIRISApp.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/CIRISApp.kt
@@ -55,6 +55,7 @@ import ai.ciris.mobile.shared.viewmodels.WiseAuthorityViewModel
 import ai.ciris.mobile.shared.viewmodels.TicketsViewModel
 import ai.ciris.mobile.shared.viewmodels.SchedulerViewModel
 import ai.ciris.mobile.shared.viewmodels.ToolsViewModel
+import ai.ciris.mobile.shared.viewmodels.EnvironmentInfoViewModel
 import ai.ciris.mobile.shared.viewmodels.DataManagementViewModel
 import ai.ciris.mobile.shared.viewmodels.SkillImportViewModel
 import ai.ciris.mobile.shared.ui.screens.graph.GraphMemoryScreen
@@ -589,6 +590,9 @@ fun CIRISApp(
     }
     val toolsViewModel: ToolsViewModel = viewModel {
         ToolsViewModel(apiClient)
+    }
+    val environmentInfoViewModel: EnvironmentInfoViewModel = viewModel {
+        EnvironmentInfoViewModel(apiClient)
     }
     val dataManagementViewModel: DataManagementViewModel = viewModel {
         DataManagementViewModel(apiClient, secureStorage, envFileUpdater)
@@ -1314,6 +1318,7 @@ fun CIRISApp(
                             onTicketsClick = { currentScreen = Screen.Tickets },
                             onSchedulerClick = { currentScreen = Screen.Scheduler },
                             onToolsClick = { currentScreen = Screen.Tools },
+                            onEnvironmentInfoClick = { currentScreen = Screen.EnvironmentInfo },
                             onHelpClick = { currentScreen = Screen.Help },
                             onLogoutClick = {
                                 PlatformLogger.i("CIRISApp", "[onLogout] User initiated logout from nav bar")
@@ -2455,6 +2460,24 @@ fun CIRISApp(
                 )
             }
 
+            Screen.EnvironmentInfo -> {
+                val environmentInfoState by environmentInfoViewModel.state.collectAsState()
+
+                LaunchedEffect(Unit) {
+                    PlatformLogger.i(TAG, "[Screen.EnvironmentInfo] Loading environment info on screen entry")
+                    environmentInfoViewModel.startPolling()
+                }
+
+                EnvironmentInfoScreen(
+                    state = environmentInfoState,
+                    onRefresh = {
+                        PlatformLogger.i("CIRISApp", "[Screen.EnvironmentInfo] User triggered refresh")
+                        environmentInfoViewModel.refresh()
+                    },
+                    onNavigateBack = { currentScreen = Screen.Interact }
+                )
+            }
+
             Screen.DataManagement -> {
                 DataManagementScreen(
                     viewModel = dataManagementViewModel,
@@ -2668,6 +2691,7 @@ private fun CIRISTopBar(
     onTicketsClick: () -> Unit = {},
     onSchedulerClick: () -> Unit = {},
     onToolsClick: () -> Unit = {},
+    onEnvironmentInfoClick: () -> Unit = {},
     onHelpClick: () -> Unit = {},
     onLogoutClick: () -> Unit = {},
     darkMode: Boolean = false,
@@ -2740,6 +2764,12 @@ private fun CIRISTopBar(
                         onClick = { activeCategory = NavCategory.NONE; onToolsClick() },
                         leadingIcon = { Icon(Icons.Default.Build, null) },
                         modifier = Modifier.testableClickable("menu_tools") { activeCategory = NavCategory.NONE; onToolsClick() }
+                    )
+                    DropdownMenuItem(
+                        text = { Text("Environment Info") },
+                        onClick = { activeCategory = NavCategory.NONE; onEnvironmentInfoClick() },
+                        leadingIcon = { Icon(Icons.Default.Info, null) },
+                        modifier = Modifier.testableClickable("menu_environment_info") { activeCategory = NavCategory.NONE; onEnvironmentInfoClick() }
                     )
                 }
             }
@@ -3017,6 +3047,7 @@ private sealed class Screen {
     object Tickets : Screen()
     object Scheduler : Screen()
     object Tools : Screen()
+    object EnvironmentInfo : Screen()
     object SkillImport : Screen()
     object DataManagement : Screen()
     object Help : Screen()

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/CIRISApp.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/CIRISApp.kt
@@ -2474,7 +2474,26 @@ fun CIRISApp(
                         PlatformLogger.i("CIRISApp", "[Screen.EnvironmentInfo] User triggered refresh")
                         environmentInfoViewModel.refresh()
                     },
-                    onNavigateBack = { currentScreen = Screen.Interact }
+                    onNavigateBack = { currentScreen = Screen.Interact },
+                    onCategorySelected = { category ->
+                        PlatformLogger.d("CIRISApp", "[Screen.EnvironmentInfo] Category selected: $category")
+                        environmentInfoViewModel.setCategory(category)
+                    },
+                    onAddItem = {
+                        PlatformLogger.d("CIRISApp", "[Screen.EnvironmentInfo] Add item clicked")
+                        environmentInfoViewModel.showAddDialog(true)
+                    },
+                    onCreateItem = { name, category, quantity, condition, notes ->
+                        PlatformLogger.i("CIRISApp", "[Screen.EnvironmentInfo] Creating item: $name")
+                        environmentInfoViewModel.createItem(name, category, quantity, condition, notes)
+                    },
+                    onDeleteItem = { nodeId ->
+                        PlatformLogger.i("CIRISApp", "[Screen.EnvironmentInfo] Deleting item: $nodeId")
+                        environmentInfoViewModel.deleteItem(nodeId)
+                    },
+                    onDismissAddDialog = {
+                        environmentInfoViewModel.showAddDialog(false)
+                    }
                 )
             }
 

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/api/CIRISApiClient.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/api/CIRISApiClient.kt
@@ -4222,7 +4222,7 @@ class CIRISApiClient(
                 header("Authorization", "Bearer $accessToken")
                 contentType(ContentType.Application.Json)
                 setBody(buildJsonObject {
-                    put("scope", "ENVIRONMENT")
+                    put("scope", "environment")  // GraphScope enum values are lowercase
                     put("limit", 100)
                 })
             }
@@ -4307,8 +4307,8 @@ class CIRISApiClient(
                 setBody(buildJsonObject {
                     put("node", buildJsonObject {
                         put("id", nodeId)
-                        put("type", "OBJECT")
-                        put("scope", "ENVIRONMENT")
+                        put("type", "object")  // NodeType enum values are lowercase
+                        put("scope", "environment")  // GraphScope enum values are lowercase
                         put("attributes", attributes)
                     })
                 })

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/api/CIRISApiClient.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/api/CIRISApiClient.kt
@@ -4145,6 +4145,93 @@ class CIRISApiClient(
         }
     }
 
+    // ===== Environment API =====
+
+    override suspend fun getEnvironmentInfo(): EnvironmentInfoResponse {
+        val method = "getEnvironmentInfo"
+        logInfo(method, "Fetching environment info")
+
+        return try {
+            val client = HttpClient {
+                install(ContentNegotiation) {
+                    json(Json {
+                        ignoreUnknownKeys = true
+                        isLenient = true
+                    })
+                }
+            }
+
+            val response = client.get("$baseUrl/v1/system/environment") {
+                header("Authorization", "Bearer $accessToken")
+            }
+
+            if (response.status != HttpStatusCode.OK) {
+                logError(method, "API returned non-success status: ${response.status}")
+                client.close()
+                throw RuntimeException("API error: HTTP ${response.status}")
+            }
+
+            val jsonString = response.bodyAsText()
+            client.close()
+
+            val json = Json.parseToJsonElement(jsonString).jsonObject
+            val data = json["data"]?.jsonObject
+                ?: throw RuntimeException("API returned null data")
+
+            // Parse location
+            val locationObj = data["location"]?.jsonObject
+            val location = LocationInfoData(
+                location = locationObj?.get("location")?.jsonPrimitive?.contentOrNull,
+                latitude = locationObj?.get("latitude")?.jsonPrimitive?.doubleOrNull,
+                longitude = locationObj?.get("longitude")?.jsonPrimitive?.doubleOrNull,
+                timezone = locationObj?.get("timezone")?.jsonPrimitive?.contentOrNull,
+                country = locationObj?.get("country")?.jsonPrimitive?.contentOrNull,
+                region = locationObj?.get("region")?.jsonPrimitive?.contentOrNull,
+                city = locationObj?.get("city")?.jsonPrimitive?.contentOrNull,
+                iso6709 = locationObj?.get("iso6709")?.jsonPrimitive?.contentOrNull,
+                hasCoordinates = locationObj?.get("has_coordinates")?.jsonPrimitive?.boolean ?: false
+            )
+
+            // Parse context enrichment (keep as raw map for flexibility)
+            val enrichmentObj = data["context_enrichment"]?.jsonObject ?: JsonObject(emptyMap())
+            val contextEnrichment = mutableMapOf<String, Any>()
+            for ((key, value) in enrichmentObj) {
+                // Convert JsonElement to a usable type
+                contextEnrichment[key] = when {
+                    value is JsonObject -> value.toString()
+                    value is JsonArray -> value.toString()
+                    value.jsonPrimitive.isString -> value.jsonPrimitive.content
+                    else -> value.toString()
+                }
+            }
+
+            // Parse cache stats
+            val statsObj = data["cache_stats"]?.jsonObject
+            val cacheStats = EnrichmentCacheStatsData(
+                entries = statsObj?.get("entries")?.jsonPrimitive?.int ?: 0,
+                hits = statsObj?.get("hits")?.jsonPrimitive?.int ?: 0,
+                misses = statsObj?.get("misses")?.jsonPrimitive?.int ?: 0,
+                hitRatePct = statsObj?.get("hit_rate_pct")?.jsonPrimitive?.double ?: 0.0,
+                startupPopulated = statsObj?.get("startup_populated")?.jsonPrimitive?.boolean ?: false
+            )
+
+            val timestamp = data["timestamp"]?.jsonPrimitive?.contentOrNull
+
+            logInfo(method, "Environment info fetched: hasCoordinates=${location.hasCoordinates}, " +
+                    "enrichmentEntries=${contextEnrichment.size}, cacheHitRate=${cacheStats.hitRatePct}%")
+
+            EnvironmentInfoResponse(
+                location = location,
+                contextEnrichment = contextEnrichment,
+                cacheStats = cacheStats,
+                timestamp = timestamp
+            )
+        } catch (e: Exception) {
+            logException(method, e)
+            throw e
+        }
+    }
+
     // ===== Runtime Control API =====
 
     override suspend fun getRuntimeState(): RuntimeStateResponse {

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/api/CIRISApiClient.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/api/CIRISApiClient.kt
@@ -48,6 +48,9 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.put
 
 /**
@@ -4147,21 +4150,18 @@ class CIRISApiClient(
 
     // ===== Environment API =====
 
-    override suspend fun getEnvironmentInfo(): EnvironmentInfoResponse {
-        val method = "getEnvironmentInfo"
-        logInfo(method, "Fetching environment info")
+    override suspend fun getContextEnrichment(): ContextEnrichmentResponse {
+        val method = "getContextEnrichment"
+        logInfo(method, "Fetching context enrichment cache")
 
         return try {
             val client = HttpClient {
                 install(ContentNegotiation) {
-                    json(Json {
-                        ignoreUnknownKeys = true
-                        isLenient = true
-                    })
+                    json(Json { ignoreUnknownKeys = true; isLenient = true })
                 }
             }
 
-            val response = client.get("$baseUrl/v1/system/environment") {
+            val response = client.get("$baseUrl/v1/system/adapters/context-enrichment") {
                 header("Authorization", "Bearer $accessToken")
             }
 
@@ -4175,29 +4175,13 @@ class CIRISApiClient(
             client.close()
 
             val json = Json.parseToJsonElement(jsonString).jsonObject
-            val data = json["data"]?.jsonObject
-                ?: throw RuntimeException("API returned null data")
+            val data = json["data"]?.jsonObject ?: throw RuntimeException("API returned null data")
 
-            // Parse location
-            val locationObj = data["location"]?.jsonObject
-            val location = LocationInfoData(
-                location = locationObj?.get("location")?.jsonPrimitive?.contentOrNull,
-                latitude = locationObj?.get("latitude")?.jsonPrimitive?.doubleOrNull,
-                longitude = locationObj?.get("longitude")?.jsonPrimitive?.doubleOrNull,
-                timezone = locationObj?.get("timezone")?.jsonPrimitive?.contentOrNull,
-                country = locationObj?.get("country")?.jsonPrimitive?.contentOrNull,
-                region = locationObj?.get("region")?.jsonPrimitive?.contentOrNull,
-                city = locationObj?.get("city")?.jsonPrimitive?.contentOrNull,
-                iso6709 = locationObj?.get("iso6709")?.jsonPrimitive?.contentOrNull,
-                hasCoordinates = locationObj?.get("has_coordinates")?.jsonPrimitive?.boolean ?: false
-            )
-
-            // Parse context enrichment (keep as raw map for flexibility)
-            val enrichmentObj = data["context_enrichment"]?.jsonObject ?: JsonObject(emptyMap())
-            val contextEnrichment = mutableMapOf<String, Any>()
-            for ((key, value) in enrichmentObj) {
-                // Convert JsonElement to a usable type
-                contextEnrichment[key] = when {
+            // Parse entries
+            val entriesObj = data["entries"]?.jsonObject ?: JsonObject(emptyMap())
+            val entries = mutableMapOf<String, Any>()
+            for ((key, value) in entriesObj) {
+                entries[key] = when {
                     value is JsonObject -> value.toString()
                     value is JsonArray -> value.toString()
                     value.jsonPrimitive.isString -> value.jsonPrimitive.content
@@ -4205,30 +4189,185 @@ class CIRISApiClient(
                 }
             }
 
-            // Parse cache stats
-            val statsObj = data["cache_stats"]?.jsonObject
-            val cacheStats = EnrichmentCacheStatsData(
-                entries = statsObj?.get("entries")?.jsonPrimitive?.int ?: 0,
+            // Parse stats
+            val statsObj = data["stats"]?.jsonObject
+            val stats = EnrichmentCacheStatsData(
+                entries = statsObj?.get("entry_count")?.jsonPrimitive?.int ?: 0,
                 hits = statsObj?.get("hits")?.jsonPrimitive?.int ?: 0,
                 misses = statsObj?.get("misses")?.jsonPrimitive?.int ?: 0,
                 hitRatePct = statsObj?.get("hit_rate_pct")?.jsonPrimitive?.double ?: 0.0,
                 startupPopulated = statsObj?.get("startup_populated")?.jsonPrimitive?.boolean ?: false
             )
 
-            val timestamp = data["timestamp"]?.jsonPrimitive?.contentOrNull
+            logInfo(method, "Context enrichment fetched: ${entries.size} entries, hitRate=${stats.hitRatePct}%")
+            ContextEnrichmentResponse(entries = entries, stats = stats)
+        } catch (e: Exception) {
+            logException(method, e)
+            throw e
+        }
+    }
 
-            logInfo(method, "Environment info fetched: hasCoordinates=${location.hasCoordinates}, " +
-                    "enrichmentEntries=${contextEnrichment.size}, cacheHitRate=${cacheStats.hitRatePct}%")
+    override suspend fun queryEnvironmentItems(): List<EnvironmentGraphNodeData> {
+        val method = "queryEnvironmentItems"
+        logInfo(method, "Querying environment items")
 
-            EnvironmentInfoResponse(
-                location = location,
-                contextEnrichment = contextEnrichment,
-                cacheStats = cacheStats,
-                timestamp = timestamp
+        return try {
+            val client = HttpClient {
+                install(ContentNegotiation) {
+                    json(Json { ignoreUnknownKeys = true; isLenient = true })
+                }
+            }
+
+            val response = client.post("$baseUrl/v1/memory/query") {
+                header("Authorization", "Bearer $accessToken")
+                contentType(ContentType.Application.Json)
+                setBody(buildJsonObject {
+                    put("scope", "ENVIRONMENT")
+                    put("limit", 100)
+                })
+            }
+
+            if (response.status != HttpStatusCode.OK) {
+                logError(method, "API returned non-success status: ${response.status}")
+                client.close()
+                throw RuntimeException("API error: HTTP ${response.status}")
+            }
+
+            val jsonString = response.bodyAsText()
+            client.close()
+
+            val json = Json.parseToJsonElement(jsonString).jsonObject
+            val dataArray = json["data"]?.jsonArray ?: JsonArray(emptyList())
+
+            val items = dataArray.mapNotNull { element ->
+                val nodeObj = element.jsonObject
+                try {
+                    val attrsObj = nodeObj["attributes"]?.jsonObject ?: JsonObject(emptyMap())
+                    val attributes = mutableMapOf<String, Any>()
+                    for ((k, v) in attrsObj) {
+                        attributes[k] = when {
+                            v is JsonObject -> v.toString()
+                            v is JsonArray -> v.toString()
+                            v.jsonPrimitive.isString -> v.jsonPrimitive.content
+                            v.jsonPrimitive.intOrNull != null -> v.jsonPrimitive.int
+                            v.jsonPrimitive.doubleOrNull != null -> v.jsonPrimitive.double
+                            else -> v.toString()
+                        }
+                    }
+                    EnvironmentGraphNodeData(
+                        id = nodeObj["id"]?.jsonPrimitive?.content ?: "",
+                        type = nodeObj["type"]?.jsonPrimitive?.content ?: "OBJECT",
+                        attributes = attributes,
+                        createdAt = nodeObj["updated_at"]?.jsonPrimitive?.contentOrNull,
+                        communityShared = false
+                    )
+                } catch (e: Exception) {
+                    logWarn(method, "Failed to parse item: ${e.message}")
+                    null
+                }
+            }
+
+            logInfo(method, "Fetched ${items.size} environment items")
+            items
+        } catch (e: Exception) {
+            logException(method, e)
+            throw e
+        }
+    }
+
+    override suspend fun createEnvironmentItem(
+        name: String,
+        category: String,
+        quantity: Int,
+        condition: String,
+        notes: String?
+    ): EnvironmentGraphNodeData {
+        val method = "createEnvironmentItem"
+        logInfo(method, "Creating environment item: $name")
+
+        return try {
+            val client = HttpClient {
+                install(ContentNegotiation) {
+                    json(Json { ignoreUnknownKeys = true; isLenient = true })
+                }
+            }
+
+            val nodeId = "item_${System.currentTimeMillis()}"
+            val attributes = buildJsonObject {
+                put("name", name)
+                put("category", category)
+                put("quantity", quantity)
+                put("condition", condition)
+                notes?.let { put("notes", it) }
+            }
+
+            val response = client.post("$baseUrl/v1/memory/store") {
+                header("Authorization", "Bearer $accessToken")
+                contentType(ContentType.Application.Json)
+                setBody(buildJsonObject {
+                    put("node", buildJsonObject {
+                        put("id", nodeId)
+                        put("type", "OBJECT")
+                        put("scope", "ENVIRONMENT")
+                        put("attributes", attributes)
+                    })
+                })
+            }
+
+            if (response.status != HttpStatusCode.OK) {
+                logError(method, "API returned non-success status: ${response.status}")
+                client.close()
+                throw RuntimeException("API error: HTTP ${response.status}")
+            }
+
+            client.close()
+            logInfo(method, "Created environment item: $nodeId")
+
+            EnvironmentGraphNodeData(
+                id = nodeId,
+                type = "OBJECT",
+                attributes = mapOf(
+                    "name" to name,
+                    "category" to category,
+                    "quantity" to quantity,
+                    "condition" to condition
+                ).let { if (notes != null) it + ("notes" to notes) else it },
+                createdAt = null,
+                communityShared = false
             )
         } catch (e: Exception) {
             logException(method, e)
             throw e
+        }
+    }
+
+    override suspend fun deleteEnvironmentItem(nodeId: String): Boolean {
+        val method = "deleteEnvironmentItem"
+        logInfo(method, "Deleting environment item: $nodeId")
+
+        return try {
+            val client = HttpClient {
+                install(ContentNegotiation) {
+                    json(Json { ignoreUnknownKeys = true; isLenient = true })
+                }
+            }
+
+            val response = client.delete("$baseUrl/v1/memory/$nodeId") {
+                header("Authorization", "Bearer $accessToken")
+            }
+
+            client.close()
+
+            if (response.status == HttpStatusCode.OK) {
+                logInfo(method, "Deleted environment item: $nodeId")
+                true
+            } else {
+                logError(method, "Failed to delete: ${response.status}")
+                false
+            }
+        } catch (e: Exception) {
+            logException(method, e)
+            false
         }
     }
 

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/api/CIRISApiClient.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/api/CIRISApiClient.kt
@@ -4307,8 +4307,8 @@ class CIRISApiClient(
                 setBody(buildJsonObject {
                     put("node", buildJsonObject {
                         put("id", nodeId)
-                        put("type", "object")  // NodeType enum values are lowercase
-                        put("scope", "environment")  // GraphScope enum values are lowercase
+                        put("type", "concept")  // NodeType.CONCEPT for environment items
+                        put("scope", "environment")  // GraphScope.ENVIRONMENT
                         put("attributes", attributes)
                     })
                 })
@@ -4325,7 +4325,7 @@ class CIRISApiClient(
 
             EnvironmentGraphNodeData(
                 id = nodeId,
-                type = "OBJECT",
+                type = "CONCEPT",
                 attributes = mapOf(
                     "name" to name,
                     "category" to category,
@@ -4352,7 +4352,8 @@ class CIRISApiClient(
                 }
             }
 
-            val response = client.delete("$baseUrl/v1/memory/$nodeId") {
+            // Pass scope=environment to delete from correct graph scope
+            val response = client.delete("$baseUrl/v1/memory/$nodeId?scope=environment") {
                 header("Authorization", "Bearer $accessToken")
             }
 

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/api/CIRISApiClientProtocol.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/api/CIRISApiClientProtocol.kt
@@ -172,9 +172,30 @@ interface CIRISApiClientProtocol {
     // ===== Environment API =====
 
     /**
-     * Get environment context information (location, context enrichment from adapters)
+     * Get context enrichment cache data from adapters
      */
-    suspend fun getEnvironmentInfo(): EnvironmentInfoResponse
+    suspend fun getContextEnrichment(): ContextEnrichmentResponse
+
+    /**
+     * Query environment graph nodes (items in ENVIRONMENT scope)
+     */
+    suspend fun queryEnvironmentItems(): List<EnvironmentGraphNodeData>
+
+    /**
+     * Create an environment item
+     */
+    suspend fun createEnvironmentItem(
+        name: String,
+        category: String,
+        quantity: Int,
+        condition: String,
+        notes: String?
+    ): EnvironmentGraphNodeData
+
+    /**
+     * Delete an environment item by ID
+     */
+    suspend fun deleteEnvironmentItem(nodeId: String): Boolean
 
     // ===== Runtime Control API =====
 
@@ -263,13 +284,11 @@ data class ServicesResponse(
 // ===== Environment API Data Models =====
 
 /**
- * Environment info response from /v1/system/environment
+ * Context enrichment response from /v1/system/adapters/context-enrichment
  */
-data class EnvironmentInfoResponse(
-    val location: LocationInfoData,
-    val contextEnrichment: Map<String, Any>,
-    val cacheStats: EnrichmentCacheStatsData,
-    val timestamp: String?
+data class ContextEnrichmentResponse(
+    val entries: Map<String, Any>,
+    val stats: EnrichmentCacheStatsData
 )
 
 /**
@@ -286,6 +305,46 @@ data class LocationInfoData(
     val iso6709: String?,
     val hasCoordinates: Boolean
 )
+
+/**
+ * Environment graph node (persistent ENVIRONMENT scope)
+ */
+data class EnvironmentGraphNodeData(
+    val id: String,
+    val type: String,
+    val attributes: Map<String, Any>,
+    val createdAt: String?,
+    val communityShared: Boolean
+) {
+    // Helper properties for item display
+    val name: String get() = attributes["name"]?.toString() ?: id
+    val category: String get() = attributes["category"]?.toString() ?: "have"
+    val quantity: Int get() = (attributes["quantity"] as? Number)?.toInt() ?: 1
+    val condition: String get() = attributes["condition"]?.toString() ?: "good"
+    val notes: String? get() = attributes["notes"]?.toString()
+}
+
+/**
+ * Item categories for environment items
+ */
+enum class ItemCategory(val displayName: String) {
+    WANT("Want"),
+    NEED("Need"),
+    HAVE("Have"),
+    CAN_BORROW("Can Borrow"),
+    CAN_BARTER("Can Barter")
+}
+
+/**
+ * Item conditions
+ */
+enum class ItemCondition(val displayName: String) {
+    NEW("New"),
+    GOOD("Good"),
+    FAIR("Fair"),
+    POOR("Poor"),
+    BROKEN("Broken")
+}
 
 /**
  * Context enrichment cache statistics

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/api/CIRISApiClientProtocol.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/api/CIRISApiClientProtocol.kt
@@ -169,6 +169,13 @@ interface CIRISApiClientProtocol {
      */
     suspend fun getServices(): ServicesResponse
 
+    // ===== Environment API =====
+
+    /**
+     * Get environment context information (location, context enrichment from adapters)
+     */
+    suspend fun getEnvironmentInfo(): EnvironmentInfoResponse
+
     // ===== Runtime Control API =====
 
     /**
@@ -251,6 +258,44 @@ data class AdapterActionData(
 data class ServicesResponse(
     val globalServices: Map<String, List<ServiceProviderData>>,
     val handlers: Map<String, Map<String, List<ServiceProviderData>>>
+)
+
+// ===== Environment API Data Models =====
+
+/**
+ * Environment info response from /v1/system/environment
+ */
+data class EnvironmentInfoResponse(
+    val location: LocationInfoData,
+    val contextEnrichment: Map<String, Any>,
+    val cacheStats: EnrichmentCacheStatsData,
+    val timestamp: String?
+)
+
+/**
+ * User location information from setup
+ */
+data class LocationInfoData(
+    val location: String?,
+    val latitude: Double?,
+    val longitude: Double?,
+    val timezone: String?,
+    val country: String?,
+    val region: String?,
+    val city: String?,
+    val iso6709: String?,
+    val hasCoordinates: Boolean
+)
+
+/**
+ * Context enrichment cache statistics
+ */
+data class EnrichmentCacheStatsData(
+    val entries: Int,
+    val hits: Int,
+    val misses: Int,
+    val hitRatePct: Double,
+    val startupPopulated: Boolean
 )
 
 /**

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/models/Setup.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/models/Setup.kt
@@ -187,12 +187,14 @@ data class CompleteSetupRequest(
     val oauth_email: String? = null,       // Google email
 
     // Language and location preferences (from PREFERENCES step)
-    // Mirrors Python: ciris_engine/logic/adapters/api/routes/setup/models.py:296-311
+    // Mirrors Python: ciris_engine/logic/adapters/api/routes/setup/models.py:296-320
     val preferred_language: String? = null,    // ISO 639-1 code (e.g., "en", "am", "es")
     val location_country: String? = null,      // Country name
     val location_region: String? = null,       // Region/state name
     val location_city: String? = null,         // City name
-    val timezone: String? = null,              // IANA timezone (auto-detected)
+    val location_latitude: Double? = null,     // Latitude in decimal degrees (ISO 6709)
+    val location_longitude: Double? = null,    // Longitude in decimal degrees (ISO 6709)
+    val timezone: String? = null,              // IANA timezone (from selected location)
     val share_location_in_traces: Boolean = false,  // Consent to include location in telemetry
 
     // Node flow fields (Connect to Node / Portal provisioning)

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/screens/EnvironmentInfoScreen.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/screens/EnvironmentInfoScreen.kt
@@ -1,37 +1,36 @@
 package ai.ciris.mobile.shared.ui.screens
 
 import ai.ciris.mobile.shared.api.EnrichmentCacheStatsData
-import ai.ciris.mobile.shared.api.LocationInfoData
+import ai.ciris.mobile.shared.api.EnvironmentGraphNodeData
+import ai.ciris.mobile.shared.api.ItemCategory
+import ai.ciris.mobile.shared.api.ItemCondition
 import ai.ciris.mobile.shared.localization.localizedString
 import ai.ciris.mobile.shared.platform.testableClickable
 import ai.ciris.mobile.shared.viewmodels.EnvironmentInfoScreenState
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.LocationOn
-import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 
 /**
- * Environment Info screen showing context from adapters.
+ * Environment Info screen - Shopping list style UI for environment items.
  *
- * Displays:
- * - User location from setup (for debugging lat/long issues)
- * - Context enrichment results from adapters (HA, weather, etc.)
- * - Cache statistics
+ * Features:
+ * - Category filter chips (Want/Need/Have/Can Borrow/Can Barter)
+ * - Item cards with quantity, condition, and community share toggle
+ * - Add new item dialog
+ * - Context enrichment section (expandable)
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -39,12 +38,17 @@ fun EnvironmentInfoScreen(
     state: EnvironmentInfoScreenState,
     onRefresh: () -> Unit,
     onNavigateBack: () -> Unit,
+    onCategorySelected: (String?) -> Unit,
+    onAddItem: () -> Unit,
+    onCreateItem: (name: String, category: String, quantity: Int, condition: String, notes: String?) -> Unit,
+    onDeleteItem: (String) -> Unit,
+    onDismissAddDialog: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Environment Info") },
+                title = { Text("My Environment") },
                 navigationIcon = {
                     IconButton(
                         onClick = onNavigateBack,
@@ -75,6 +79,14 @@ fun EnvironmentInfoScreen(
                     actionIconContentColor = MaterialTheme.colorScheme.onPrimary
                 )
             )
+        },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = onAddItem,
+                modifier = Modifier.testableClickable("btn_add_item") { onAddItem() }
+            ) {
+                Icon(Icons.Filled.Add, contentDescription = "Add Item")
+            }
         }
     ) { paddingValues ->
         LazyColumn(
@@ -85,7 +97,7 @@ fun EnvironmentInfoScreen(
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             // Loading state
-            if (state.isLoading && state.location == null) {
+            if (state.isLoading && state.items.isEmpty()) {
                 item {
                     Box(
                         modifier = Modifier.fillMaxWidth().padding(32.dp),
@@ -123,28 +135,36 @@ fun EnvironmentInfoScreen(
                 }
             }
 
-            // Location section
-            state.location?.let { location ->
-                item {
-                    LocationCard(location = location)
+            // Category filter chips
+            item {
+                CategoryFilterChips(
+                    selectedCategory = state.selectedCategory,
+                    categoryCounts = state.categoryCounts,
+                    onCategorySelected = onCategorySelected
+                )
+            }
+
+            // Items header with count
+            item {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = if (state.selectedCategory == null) {
+                            "All Items (${state.items.size})"
+                        } else {
+                            "${getCategoryDisplayName(state.selectedCategory)} (${state.filteredItems.size})"
+                        },
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold
+                    )
                 }
             }
 
-            // Context Enrichment section
-            if (state.contextEnrichment.isNotEmpty()) {
-                item {
-                    Text(
-                        text = "Context Enrichment (${state.contextEnrichment.size} sources)",
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold,
-                        modifier = Modifier.padding(top = 8.dp)
-                    )
-                }
-
-                items(state.contextEnrichment.entries.toList()) { (key, value) ->
-                    EnrichmentCard(key = key, value = value.toString())
-                }
-            } else if (!state.isLoading) {
+            // Item cards
+            if (state.filteredItems.isEmpty() && !state.isLoading) {
                 item {
                     Card(
                         colors = CardDefaults.cardColors(
@@ -162,146 +182,368 @@ fun EnvironmentInfoScreen(
                             )
                             Spacer(modifier = Modifier.width(8.dp))
                             Text(
-                                text = "No context enrichment data available. This may indicate that adapters with context_enrichment tools are not loaded, or the agent hasn't processed any thoughts yet.",
+                                text = "No items yet. Tap + to add your first item.",
                                 color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
                         }
                     }
                 }
+            } else {
+                items(state.filteredItems) { item ->
+                    ItemCard(
+                        item = item,
+                        onDelete = { onDeleteItem(item.id) }
+                    )
+                }
             }
 
-            // Cache stats section
+            // Context Enrichment section
+            if (state.contextEnrichment.isNotEmpty()) {
+                item {
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = "Context Enrichment (${state.contextEnrichment.size} sources)",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+
+                items(state.contextEnrichment.entries.toList()) { (key, value) ->
+                    EnrichmentCard(key = key, value = value.toString())
+                }
+            }
+
+            // Cache stats
             state.cacheStats?.let { stats ->
                 item {
                     CacheStatsCard(stats = stats)
                 }
             }
 
-            // Timestamp
-            state.timestamp?.let { timestamp ->
-                item {
-                    Text(
-                        text = "Last updated: $timestamp",
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(top = 8.dp)
+            // Community sharing note
+            item {
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
                     )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun LocationCard(location: LocationInfoData) {
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        colors = CardDefaults.cardColors(
-            containerColor = if (location.hasCoordinates) {
-                MaterialTheme.colorScheme.primaryContainer
-            } else {
-                MaterialTheme.colorScheme.errorContainer
-            }
-        )
-    ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(
-                    imageVector = Icons.Filled.LocationOn,
-                    contentDescription = null,
-                    tint = if (location.hasCoordinates) {
-                        MaterialTheme.colorScheme.onPrimaryContainer
-                    } else {
-                        MaterialTheme.colorScheme.error
+                ) {
+                    Row(
+                        modifier = Modifier.padding(12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Info,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = "Community sharing depends on community invitation system, coming soon.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f)
+                        )
                     }
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = "User Location",
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.Bold
-                )
-                Spacer(modifier = Modifier.weight(1f))
-                // Status indicator
-                if (location.hasCoordinates) {
-                    Icon(
-                        imageVector = Icons.Filled.Check,
-                        contentDescription = "Coordinates available",
-                        tint = Color(0xFF4CAF50)
-                    )
-                } else {
-                    Icon(
-                        imageVector = Icons.Filled.Close,
-                        contentDescription = "Coordinates missing",
-                        tint = MaterialTheme.colorScheme.error
-                    )
                 }
             }
-
-            Spacer(modifier = Modifier.height(12.dp))
-
-            // Location details
-            LocationRow("Location", location.location ?: "Not set")
-            LocationRow("City", location.city ?: "Not set")
-            LocationRow("Region", location.region ?: "Not set")
-            LocationRow("Country", location.country ?: "Not set")
-            LocationRow("Timezone", location.timezone ?: "Not set")
-
-            Spacer(modifier = Modifier.height(8.dp))
-            Divider()
-            Spacer(modifier = Modifier.height(8.dp))
-
-            // Coordinates (highlighted if missing)
-            LocationRow(
-                label = "Latitude",
-                value = location.latitude?.toString() ?: "MISSING - Weather/Nav won't work!",
-                isError = location.latitude == null
-            )
-            LocationRow(
-                label = "Longitude",
-                value = location.longitude?.toString() ?: "MISSING - Weather/Nav won't work!",
-                isError = location.longitude == null
-            )
-            location.iso6709?.let {
-                LocationRow("ISO 6709", it)
-            }
-
-            if (!location.hasCoordinates) {
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = "Tip: Re-run setup wizard and select a city from the location search to set coordinates.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.error
-                )
-            }
         }
+    }
+
+    // Add item dialog
+    if (state.showAddDialog) {
+        AddItemDialog(
+            isCreating = state.isCreating,
+            onDismiss = onDismissAddDialog,
+            onCreate = onCreateItem
+        )
     }
 }
 
 @Composable
-private fun LocationRow(
-    label: String,
-    value: String,
-    isError: Boolean = false
+private fun CategoryFilterChips(
+    selectedCategory: String?,
+    categoryCounts: Map<String, Int>,
+    onCategorySelected: (String?) -> Unit
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 2.dp),
-        horizontalArrangement = Arrangement.SpaceBetween
+            .horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+        // "All" chip
+        FilterChip(
+            selected = selectedCategory == null,
+            onClick = { onCategorySelected(null) },
+            label = { Text("All") }
         )
-        Text(
-            text = value,
-            style = MaterialTheme.typography.bodyMedium,
-            fontFamily = FontFamily.Monospace,
-            color = if (isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface
+
+        // Category chips
+        listOf("want", "need", "have", "can_borrow", "can_barter").forEach { category ->
+            val count = categoryCounts[category] ?: 0
+            FilterChip(
+                selected = selectedCategory == category,
+                onClick = { onCategorySelected(category) },
+                label = { Text("${getCategoryDisplayName(category)} ($count)") }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ItemCard(
+    item: EnvironmentGraphNodeData,
+    onDelete: () -> Unit
+) {
+    var showDeleteConfirm by remember { mutableStateOf(false) }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.Top
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = item.name,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        // Category badge
+                        AssistChip(
+                            onClick = {},
+                            label = { Text(getCategoryDisplayName(item.category)) },
+                            colors = AssistChipDefaults.assistChipColors(
+                                containerColor = getCategoryColor(item.category)
+                            )
+                        )
+                        // Quantity
+                        if (item.quantity > 1) {
+                            Text(
+                                text = "x${item.quantity}",
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                        // Condition
+                        Text(
+                            text = getConditionDisplayName(item.condition),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+
+                // Actions
+                Row {
+                    // Community share toggle (grayed out)
+                    Switch(
+                        checked = item.communityShared,
+                        onCheckedChange = null,
+                        enabled = false,
+                        colors = SwitchDefaults.colors(
+                            disabledCheckedThumbColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.38f),
+                            disabledUncheckedThumbColor = MaterialTheme.colorScheme.outline.copy(alpha = 0.38f)
+                        )
+                    )
+
+                    // Delete button
+                    IconButton(onClick = { showDeleteConfirm = true }) {
+                        Icon(
+                            imageVector = Icons.Filled.Delete,
+                            contentDescription = "Delete",
+                            tint = MaterialTheme.colorScheme.error.copy(alpha = 0.7f)
+                        )
+                    }
+                }
+            }
+
+            // Notes
+            item.notes?.let { notes ->
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = notes,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+    }
+
+    // Delete confirmation dialog
+    if (showDeleteConfirm) {
+        AlertDialog(
+            onDismissRequest = { showDeleteConfirm = false },
+            title = { Text("Delete Item") },
+            text = { Text("Are you sure you want to delete \"${item.name}\"?") },
+            confirmButton = {
+                TextButton(onClick = {
+                    showDeleteConfirm = false
+                    onDelete()
+                }) {
+                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteConfirm = false }) {
+                    Text("Cancel")
+                }
+            }
         )
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AddItemDialog(
+    isCreating: Boolean,
+    onDismiss: () -> Unit,
+    onCreate: (name: String, category: String, quantity: Int, condition: String, notes: String?) -> Unit
+) {
+    var name by remember { mutableStateOf("") }
+    var category by remember { mutableStateOf("have") }
+    var quantity by remember { mutableStateOf("1") }
+    var condition by remember { mutableStateOf("good") }
+    var notes by remember { mutableStateOf("") }
+    var expandedCategory by remember { mutableStateOf(false) }
+    var expandedCondition by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = { if (!isCreating) onDismiss() },
+        title = { Text("Add Item") },
+        text = {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Item Name") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                // Category dropdown
+                ExposedDropdownMenuBox(
+                    expanded = expandedCategory,
+                    onExpandedChange = { expandedCategory = it }
+                ) {
+                    OutlinedTextField(
+                        value = getCategoryDisplayName(category),
+                        onValueChange = {},
+                        readOnly = true,
+                        label = { Text("Category") },
+                        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expandedCategory) },
+                        modifier = Modifier.menuAnchor().fillMaxWidth()
+                    )
+                    ExposedDropdownMenu(
+                        expanded = expandedCategory,
+                        onDismissRequest = { expandedCategory = false }
+                    ) {
+                        listOf("want", "need", "have", "can_borrow", "can_barter").forEach { cat ->
+                            DropdownMenuItem(
+                                text = { Text(getCategoryDisplayName(cat)) },
+                                onClick = {
+                                    category = cat
+                                    expandedCategory = false
+                                }
+                            )
+                        }
+                    }
+                }
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    OutlinedTextField(
+                        value = quantity,
+                        onValueChange = { quantity = it.filter { c -> c.isDigit() } },
+                        label = { Text("Qty") },
+                        singleLine = true,
+                        modifier = Modifier.weight(1f)
+                    )
+
+                    // Condition dropdown
+                    ExposedDropdownMenuBox(
+                        expanded = expandedCondition,
+                        onExpandedChange = { expandedCondition = it },
+                        modifier = Modifier.weight(2f)
+                    ) {
+                        OutlinedTextField(
+                            value = getConditionDisplayName(condition),
+                            onValueChange = {},
+                            readOnly = true,
+                            label = { Text("Condition") },
+                            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expandedCondition) },
+                            modifier = Modifier.menuAnchor().fillMaxWidth()
+                        )
+                        ExposedDropdownMenu(
+                            expanded = expandedCondition,
+                            onDismissRequest = { expandedCondition = false }
+                        ) {
+                            listOf("new", "good", "fair", "poor", "broken").forEach { cond ->
+                                DropdownMenuItem(
+                                    text = { Text(getConditionDisplayName(cond)) },
+                                    onClick = {
+                                        condition = cond
+                                        expandedCondition = false
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+
+                OutlinedTextField(
+                    value = notes,
+                    onValueChange = { notes = it },
+                    label = { Text("Notes (optional)") },
+                    modifier = Modifier.fillMaxWidth(),
+                    minLines = 2
+                )
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = {
+                    onCreate(
+                        name,
+                        category,
+                        quantity.toIntOrNull() ?: 1,
+                        condition,
+                        notes.takeIf { it.isNotBlank() }
+                    )
+                },
+                enabled = name.isNotBlank() && !isCreating
+            ) {
+                if (isCreating) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 2.dp
+                    )
+                } else {
+                    Text("Add")
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(
+                onClick = onDismiss,
+                enabled = !isCreating
+            ) {
+                Text("Cancel")
+            }
+        }
+    )
 }
 
 @Composable
@@ -378,12 +620,6 @@ private fun CacheStatsCard(stats: EnrichmentCacheStatsData) {
                 StatItem("Misses", stats.misses.toString())
                 StatItem("Hit Rate", "${stats.hitRatePct}%")
             }
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = if (stats.startupPopulated) "Cache populated at startup" else "Cache not yet populated",
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
         }
     }
 }
@@ -402,4 +638,32 @@ private fun StatItem(label: String, value: String) {
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
     }
+}
+
+private fun getCategoryDisplayName(category: String): String = when (category) {
+    "want" -> "Want"
+    "need" -> "Need"
+    "have" -> "Have"
+    "can_borrow" -> "Can Borrow"
+    "can_barter" -> "Can Barter"
+    else -> category.replaceFirstChar { it.uppercase() }
+}
+
+private fun getConditionDisplayName(condition: String): String = when (condition) {
+    "new" -> "New"
+    "good" -> "Good"
+    "fair" -> "Fair"
+    "poor" -> "Poor"
+    "broken" -> "Broken"
+    else -> condition.replaceFirstChar { it.uppercase() }
+}
+
+@Composable
+private fun getCategoryColor(category: String) = when (category) {
+    "want" -> MaterialTheme.colorScheme.tertiaryContainer
+    "need" -> MaterialTheme.colorScheme.errorContainer
+    "have" -> MaterialTheme.colorScheme.primaryContainer
+    "can_borrow" -> MaterialTheme.colorScheme.secondaryContainer
+    "can_barter" -> MaterialTheme.colorScheme.surfaceVariant
+    else -> MaterialTheme.colorScheme.surfaceVariant
 }

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/screens/EnvironmentInfoScreen.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/screens/EnvironmentInfoScreen.kt
@@ -1,0 +1,405 @@
+package ai.ciris.mobile.shared.ui.screens
+
+import ai.ciris.mobile.shared.api.EnrichmentCacheStatsData
+import ai.ciris.mobile.shared.api.LocationInfoData
+import ai.ciris.mobile.shared.localization.localizedString
+import ai.ciris.mobile.shared.platform.testableClickable
+import ai.ciris.mobile.shared.viewmodels.EnvironmentInfoScreenState
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+/**
+ * Environment Info screen showing context from adapters.
+ *
+ * Displays:
+ * - User location from setup (for debugging lat/long issues)
+ * - Context enrichment results from adapters (HA, weather, etc.)
+ * - Cache statistics
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EnvironmentInfoScreen(
+    state: EnvironmentInfoScreenState,
+    onRefresh: () -> Unit,
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Environment Info") },
+                navigationIcon = {
+                    IconButton(
+                        onClick = onNavigateBack,
+                        modifier = Modifier.testableClickable("btn_environment_back") { onNavigateBack() }
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.ArrowBack,
+                            contentDescription = localizedString("mobile.common_back")
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(
+                        onClick = onRefresh,
+                        enabled = !state.isLoading && !state.isRefreshing,
+                        modifier = Modifier.testableClickable("btn_environment_refresh") { onRefresh() }
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Refresh,
+                            contentDescription = localizedString("mobile.common_refresh")
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimary,
+                    navigationIconContentColor = MaterialTheme.colorScheme.onPrimary,
+                    actionIconContentColor = MaterialTheme.colorScheme.onPrimary
+                )
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(paddingValues),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            // Loading state
+            if (state.isLoading && state.location == null) {
+                item {
+                    Box(
+                        modifier = Modifier.fillMaxWidth().padding(32.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+            }
+
+            // Error state
+            state.error?.let { error ->
+                item {
+                    Card(
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.errorContainer
+                        )
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(16.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Close,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.error
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = error,
+                                color = MaterialTheme.colorScheme.onErrorContainer
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Location section
+            state.location?.let { location ->
+                item {
+                    LocationCard(location = location)
+                }
+            }
+
+            // Context Enrichment section
+            if (state.contextEnrichment.isNotEmpty()) {
+                item {
+                    Text(
+                        text = "Context Enrichment (${state.contextEnrichment.size} sources)",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.padding(top = 8.dp)
+                    )
+                }
+
+                items(state.contextEnrichment.entries.toList()) { (key, value) ->
+                    EnrichmentCard(key = key, value = value.toString())
+                }
+            } else if (!state.isLoading) {
+                item {
+                    Card(
+                        colors = CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant
+                        )
+                    ) {
+                        Row(
+                            modifier = Modifier.padding(16.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Info,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(
+                                text = "No context enrichment data available. This may indicate that adapters with context_enrichment tools are not loaded, or the agent hasn't processed any thoughts yet.",
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Cache stats section
+            state.cacheStats?.let { stats ->
+                item {
+                    CacheStatsCard(stats = stats)
+                }
+            }
+
+            // Timestamp
+            state.timestamp?.let { timestamp ->
+                item {
+                    Text(
+                        text = "Last updated: $timestamp",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 8.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LocationCard(location: LocationInfoData) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = if (location.hasCoordinates) {
+                MaterialTheme.colorScheme.primaryContainer
+            } else {
+                MaterialTheme.colorScheme.errorContainer
+            }
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Filled.LocationOn,
+                    contentDescription = null,
+                    tint = if (location.hasCoordinates) {
+                        MaterialTheme.colorScheme.onPrimaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.error
+                    }
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "User Location",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.weight(1f))
+                // Status indicator
+                if (location.hasCoordinates) {
+                    Icon(
+                        imageVector = Icons.Filled.Check,
+                        contentDescription = "Coordinates available",
+                        tint = Color(0xFF4CAF50)
+                    )
+                } else {
+                    Icon(
+                        imageVector = Icons.Filled.Close,
+                        contentDescription = "Coordinates missing",
+                        tint = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Location details
+            LocationRow("Location", location.location ?: "Not set")
+            LocationRow("City", location.city ?: "Not set")
+            LocationRow("Region", location.region ?: "Not set")
+            LocationRow("Country", location.country ?: "Not set")
+            LocationRow("Timezone", location.timezone ?: "Not set")
+
+            Spacer(modifier = Modifier.height(8.dp))
+            Divider()
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Coordinates (highlighted if missing)
+            LocationRow(
+                label = "Latitude",
+                value = location.latitude?.toString() ?: "MISSING - Weather/Nav won't work!",
+                isError = location.latitude == null
+            )
+            LocationRow(
+                label = "Longitude",
+                value = location.longitude?.toString() ?: "MISSING - Weather/Nav won't work!",
+                isError = location.longitude == null
+            )
+            location.iso6709?.let {
+                LocationRow("ISO 6709", it)
+            }
+
+            if (!location.hasCoordinates) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "Tip: Re-run setup wizard and select a city from the location search to set coordinates.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LocationRow(
+    label: String,
+    value: String,
+    isError: Boolean = false
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 2.dp),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontFamily = FontFamily.Monospace,
+            color = if (isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurface
+        )
+    }
+}
+
+@Composable
+private fun EnrichmentCard(key: String, value: String) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(8.dp)
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = key,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    fontFamily = FontFamily.Monospace
+                )
+                TextButton(onClick = { expanded = !expanded }) {
+                    Text(if (expanded) "Collapse" else "Expand")
+                }
+            }
+
+            if (expanded) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Surface(
+                    color = MaterialTheme.colorScheme.surfaceVariant,
+                    shape = RoundedCornerShape(4.dp)
+                ) {
+                    Text(
+                        text = value,
+                        style = MaterialTheme.typography.bodySmall,
+                        fontFamily = FontFamily.Monospace,
+                        modifier = Modifier.padding(8.dp)
+                    )
+                }
+            } else {
+                Text(
+                    text = if (value.length > 100) value.take(100) + "..." else value,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CacheStatsCard(stats: EnrichmentCacheStatsData) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "Cache Statistics",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                StatItem("Entries", stats.entries.toString())
+                StatItem("Hits", stats.hits.toString())
+                StatItem("Misses", stats.misses.toString())
+                StatItem("Hit Rate", "${stats.hitRatePct}%")
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = if (stats.startupPopulated) "Cache populated at startup" else "Cache not yet populated",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatItem(label: String, value: String) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = value,
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/EnvironmentInfoViewModel.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/EnvironmentInfoViewModel.kt
@@ -1,0 +1,131 @@
+package ai.ciris.mobile.shared.viewmodels
+
+import ai.ciris.mobile.shared.api.CIRISApiClient
+import ai.ciris.mobile.shared.api.EnrichmentCacheStatsData
+import ai.ciris.mobile.shared.api.EnvironmentInfoResponse
+import ai.ciris.mobile.shared.api.LocationInfoData
+import ai.ciris.mobile.shared.platform.PlatformLogger
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * State for the Environment Info screen.
+ */
+data class EnvironmentInfoScreenState(
+    val location: LocationInfoData? = null,
+    val contextEnrichment: Map<String, Any> = emptyMap(),
+    val cacheStats: EnrichmentCacheStatsData? = null,
+    val timestamp: String? = null,
+    val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val error: String? = null
+)
+
+/**
+ * ViewModel for the Environment Info screen.
+ *
+ * Shows context data from adapters including:
+ * - User location from setup (lat/long, timezone, city)
+ * - Context enrichment results from adapters (weather, HA entities, etc.)
+ * - Cache statistics for debugging
+ */
+class EnvironmentInfoViewModel(
+    private val apiClient: CIRISApiClient
+) : ViewModel() {
+
+    companion object {
+        private const val TAG = "EnvironmentInfoViewModel"
+    }
+
+    private fun log(level: String, method: String, message: String) {
+        val fullMessage = "[$method] $message"
+        when (level) {
+            "DEBUG" -> PlatformLogger.d(TAG, fullMessage)
+            "INFO" -> PlatformLogger.i(TAG, fullMessage)
+            "WARN" -> PlatformLogger.w(TAG, fullMessage)
+            "ERROR" -> PlatformLogger.e(TAG, fullMessage)
+            else -> PlatformLogger.i(TAG, fullMessage)
+        }
+    }
+
+    private fun logDebug(method: String, message: String) = log("DEBUG", method, message)
+    private fun logInfo(method: String, message: String) = log("INFO", method, message)
+    private fun logError(method: String, message: String) = log("ERROR", method, message)
+
+    // State
+    private val _state = MutableStateFlow(EnvironmentInfoScreenState())
+    val state: StateFlow<EnvironmentInfoScreenState> = _state.asStateFlow()
+
+    private var dataLoadStarted = false
+
+    init {
+        logInfo("init", "EnvironmentInfoViewModel initialized")
+    }
+
+    /**
+     * Start loading environment info.
+     */
+    fun startPolling() {
+        val method = "startPolling"
+        if (dataLoadStarted) {
+            logDebug(method, "Data load already started, skipping")
+            return
+        }
+        dataLoadStarted = true
+        loadEnvironmentInfo()
+    }
+
+    /**
+     * Refresh environment info.
+     */
+    fun refresh() {
+        val method = "refresh"
+        logInfo(method, "Refreshing environment info")
+        _state.update { it.copy(isRefreshing = true, error = null) }
+        loadEnvironmentInfo()
+    }
+
+    private fun loadEnvironmentInfo() {
+        val method = "loadEnvironmentInfo"
+        logInfo(method, "Loading environment info from API")
+
+        viewModelScope.launch {
+            try {
+                if (!_state.value.isRefreshing) {
+                    _state.update { it.copy(isLoading = true, error = null) }
+                }
+
+                val response = apiClient.getEnvironmentInfo()
+
+                logInfo(method, "Environment info loaded: hasCoordinates=${response.location.hasCoordinates}, " +
+                        "enrichmentCount=${response.contextEnrichment.size}")
+
+                _state.update {
+                    it.copy(
+                        location = response.location,
+                        contextEnrichment = response.contextEnrichment,
+                        cacheStats = response.cacheStats,
+                        timestamp = response.timestamp,
+                        isLoading = false,
+                        isRefreshing = false,
+                        error = null
+                    )
+                }
+            } catch (e: Exception) {
+                logError(method, "Error loading environment info: ${e.message}")
+                _state.update {
+                    it.copy(
+                        isLoading = false,
+                        isRefreshing = false,
+                        error = e.message ?: "Unknown error"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/EnvironmentInfoViewModel.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/EnvironmentInfoViewModel.kt
@@ -2,7 +2,7 @@ package ai.ciris.mobile.shared.viewmodels
 
 import ai.ciris.mobile.shared.api.CIRISApiClient
 import ai.ciris.mobile.shared.api.EnrichmentCacheStatsData
-import ai.ciris.mobile.shared.api.EnvironmentInfoResponse
+import ai.ciris.mobile.shared.api.EnvironmentGraphNodeData
 import ai.ciris.mobile.shared.api.LocationInfoData
 import ai.ciris.mobile.shared.platform.PlatformLogger
 import androidx.lifecycle.ViewModel
@@ -18,21 +18,31 @@ import kotlinx.coroutines.launch
  */
 data class EnvironmentInfoScreenState(
     val location: LocationInfoData? = null,
+    val items: List<EnvironmentGraphNodeData> = emptyList(),
     val contextEnrichment: Map<String, Any> = emptyMap(),
     val cacheStats: EnrichmentCacheStatsData? = null,
-    val timestamp: String? = null,
+    val selectedCategory: String? = null, // null = all categories
     val isLoading: Boolean = false,
     val isRefreshing: Boolean = false,
-    val error: String? = null
-)
+    val isCreating: Boolean = false,
+    val error: String? = null,
+    val showAddDialog: Boolean = false
+) {
+    val filteredItems: List<EnvironmentGraphNodeData>
+        get() = if (selectedCategory == null) items
+                else items.filter { it.category == selectedCategory }
+
+    val categoryCounts: Map<String, Int>
+        get() = items.groupBy { it.category }.mapValues { it.value.size }
+}
 
 /**
  * ViewModel for the Environment Info screen.
  *
- * Shows context data from adapters including:
+ * Shows:
  * - User location from setup (lat/long, timezone, city)
+ * - Environment items (shopping list style with categories)
  * - Context enrichment results from adapters (weather, HA entities, etc.)
- * - Cache statistics for debugging
  */
 class EnvironmentInfoViewModel(
     private val apiClient: CIRISApiClient
@@ -77,22 +87,104 @@ class EnvironmentInfoViewModel(
             return
         }
         dataLoadStarted = true
-        loadEnvironmentInfo()
+        loadAll()
     }
 
     /**
-     * Refresh environment info.
+     * Refresh all data.
      */
     fun refresh() {
         val method = "refresh"
         logInfo(method, "Refreshing environment info")
         _state.update { it.copy(isRefreshing = true, error = null) }
-        loadEnvironmentInfo()
+        loadAll()
     }
 
-    private fun loadEnvironmentInfo() {
-        val method = "loadEnvironmentInfo"
-        logInfo(method, "Loading environment info from API")
+    /**
+     * Set selected category filter.
+     */
+    fun setCategory(category: String?) {
+        _state.update { it.copy(selectedCategory = category) }
+    }
+
+    /**
+     * Show/hide add item dialog.
+     */
+    fun showAddDialog(show: Boolean) {
+        _state.update { it.copy(showAddDialog = show) }
+    }
+
+    /**
+     * Create a new environment item.
+     */
+    fun createItem(
+        name: String,
+        category: String,
+        quantity: Int,
+        condition: String,
+        notes: String?
+    ) {
+        val method = "createItem"
+        logInfo(method, "Creating item: $name")
+
+        viewModelScope.launch {
+            _state.update { it.copy(isCreating = true) }
+            try {
+                val newItem = apiClient.createEnvironmentItem(
+                    name = name,
+                    category = category,
+                    quantity = quantity,
+                    condition = condition,
+                    notes = notes
+                )
+                _state.update {
+                    it.copy(
+                        items = it.items + newItem,
+                        isCreating = false,
+                        showAddDialog = false
+                    )
+                }
+                logInfo(method, "Item created: ${newItem.id}")
+            } catch (e: Exception) {
+                logError(method, "Failed to create item: ${e.message}")
+                _state.update {
+                    it.copy(
+                        isCreating = false,
+                        error = "Failed to create item: ${e.message}"
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Delete an environment item.
+     */
+    fun deleteItem(nodeId: String) {
+        val method = "deleteItem"
+        logInfo(method, "Deleting item: $nodeId")
+
+        viewModelScope.launch {
+            try {
+                val success = apiClient.deleteEnvironmentItem(nodeId)
+                if (success) {
+                    _state.update {
+                        it.copy(items = it.items.filter { item -> item.id != nodeId })
+                    }
+                    logInfo(method, "Item deleted: $nodeId")
+                } else {
+                    _state.update { it.copy(error = "Failed to delete item") }
+                }
+            } catch (e: Exception) {
+                logError(method, "Failed to delete item: ${e.message}")
+                _state.update { it.copy(error = "Failed to delete item: ${e.message}") }
+            }
+        }
+    }
+
+    private fun loadAll() {
+        val method = "loadAll"
+        logInfo(method, "Loading all environment data")
 
         viewModelScope.launch {
             try {
@@ -100,24 +192,37 @@ class EnvironmentInfoViewModel(
                     _state.update { it.copy(isLoading = true, error = null) }
                 }
 
-                val response = apiClient.getEnvironmentInfo()
+                // Load items from memory API
+                val items = try {
+                    apiClient.queryEnvironmentItems()
+                } catch (e: Exception) {
+                    logError(method, "Failed to load items: ${e.message}")
+                    emptyList()
+                }
 
-                logInfo(method, "Environment info loaded: hasCoordinates=${response.location.hasCoordinates}, " +
-                        "enrichmentCount=${response.contextEnrichment.size}")
+                // Load context enrichment
+                val (enrichment, stats) = try {
+                    val response = apiClient.getContextEnrichment()
+                    Pair(response.entries, response.stats)
+                } catch (e: Exception) {
+                    logError(method, "Failed to load context enrichment: ${e.message}")
+                    Pair(emptyMap<String, Any>(), null)
+                }
+
+                logInfo(method, "Loaded ${items.size} items, ${enrichment.size} enrichment entries")
 
                 _state.update {
                     it.copy(
-                        location = response.location,
-                        contextEnrichment = response.contextEnrichment,
-                        cacheStats = response.cacheStats,
-                        timestamp = response.timestamp,
+                        items = items,
+                        contextEnrichment = enrichment,
+                        cacheStats = stats,
                         isLoading = false,
                         isRefreshing = false,
                         error = null
                     )
                 }
             } catch (e: Exception) {
-                logError(method, "Error loading environment info: ${e.message}")
+                logError(method, "Error loading data: ${e.message}")
                 _state.update {
                     it.copy(
                         isLoading = false,

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/InteractViewModel.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/InteractViewModel.kt
@@ -892,9 +892,11 @@ class InteractViewModel(
                     levelPending = verifyStatus.levelPending
                 )
 
-                // Log level change
+                // Log level change and refresh wallet status (badge color depends on trust level)
                 if (verifyStatus.maxLevel != previousLevel) {
                     logInfo("refreshTrustStatus", "Trust level changed: $previousLevel -> ${verifyStatus.maxLevel}")
+                    // Wallet spending authority changes with trust level - refresh to update badge color
+                    fetchWalletStatus()
                 }
 
                 // Restart fast polling if still pending and job isn't active

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupViewModel.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupViewModel.kt
@@ -1305,11 +1305,14 @@ class SetupViewModel : ViewModel() {
                 oauth_external_id = currentState.googleUserId,
                 oauth_email = currentState.googleEmail,
 
-                // Language and location preferences
+                // Language and location preferences (extract from selectedLocation)
                 preferred_language = currentState.preferredLanguage,
-                location_country = null,  // Simplified: only city is collected now
-                location_region = null,
-                location_city = currentState.city.takeIf { it.isNotEmpty() },
+                location_country = currentState.selectedLocation?.country,
+                location_region = currentState.selectedLocation?.region,
+                location_city = currentState.selectedLocation?.city ?: currentState.city.takeIf { it.isNotEmpty() },
+                location_latitude = currentState.selectedLocation?.latitude,
+                location_longitude = currentState.selectedLocation?.longitude,
+                timezone = currentState.selectedLocation?.timezone,
                 share_location_in_traces = currentState.shareLocationInTraces,
 
                 // Node flow fields
@@ -1374,11 +1377,14 @@ class SetupViewModel : ViewModel() {
                 oauth_external_id = if (isOAuthUser) currentState.googleUserId else null,
                 oauth_email = if (isOAuthUser) currentState.googleEmail else null,
 
-                // Language and location preferences
+                // Language and location preferences (extract from selectedLocation)
                 preferred_language = currentState.preferredLanguage,
-                location_country = null,  // Simplified: only city is collected now
-                location_region = null,
-                location_city = currentState.city.takeIf { it.isNotEmpty() },
+                location_country = currentState.selectedLocation?.country,
+                location_region = currentState.selectedLocation?.region,
+                location_city = currentState.selectedLocation?.city ?: currentState.city.takeIf { it.isNotEmpty() },
+                location_latitude = currentState.selectedLocation?.latitude,
+                location_longitude = currentState.selectedLocation?.longitude,
+                timezone = currentState.selectedLocation?.timezone,
                 share_location_in_traces = currentState.shareLocationInTraces,
 
                 // Node flow fields

--- a/tests/adapters/api/test_memory_routes.py
+++ b/tests/adapters/api/test_memory_routes.py
@@ -317,6 +317,85 @@ class TestForgetMemory:
         assert data["data"]["status"] == "error"
         assert "not found" in data["data"]["reason"].lower()
 
+    def test_forget_memory_with_environment_scope(self, client, app, auth_context):
+        """Test forgetting a node with environment scope parameter."""
+        env_node = GraphNode(
+            id="env_item_123",
+            type=NodeType.CONCEPT,
+            scope=GraphScope.ENVIRONMENT,
+            attributes={"name": "Test Item"},
+        )
+        app.state.memory_service.forget.return_value = MemoryOpResult(
+            status=MemoryOpStatus.OK, reason="Memory forgotten", data=env_node
+        )
+
+        app.dependency_overrides[require_admin] = lambda: auth_context
+        response = client.delete("/memory/env_item_123?scope=environment")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["data"]["status"] == "ok"
+
+        # Verify the forget was called with ENVIRONMENT scope
+        call_args = app.state.memory_service.forget.call_args
+        assert call_args is not None
+        node_arg = call_args.kwargs.get("node") or call_args.args[0]
+        assert node_arg.scope == GraphScope.ENVIRONMENT
+
+    def test_forget_memory_with_community_scope(self, client, app, auth_context):
+        """Test forgetting a node with community scope parameter."""
+        community_node = GraphNode(
+            id="community_item_456",
+            type=NodeType.CONCEPT,
+            scope=GraphScope.COMMUNITY,
+            attributes={"shared": True},
+        )
+        app.state.memory_service.forget.return_value = MemoryOpResult(
+            status=MemoryOpStatus.OK, reason="Memory forgotten", data=community_node
+        )
+
+        app.dependency_overrides[require_admin] = lambda: auth_context
+        response = client.delete("/memory/community_item_456?scope=community")
+
+        assert response.status_code == 200
+
+        # Verify the forget was called with COMMUNITY scope
+        call_args = app.state.memory_service.forget.call_args
+        node_arg = call_args.kwargs.get("node") or call_args.args[0]
+        assert node_arg.scope == GraphScope.COMMUNITY
+
+    def test_forget_memory_defaults_to_local_scope(self, client, app, sample_node, auth_context):
+        """Test that forget defaults to LOCAL scope when no scope param provided."""
+        app.state.memory_service.forget.return_value = MemoryOpResult(
+            status=MemoryOpStatus.OK, reason="Memory forgotten", data=sample_node
+        )
+
+        app.dependency_overrides[require_admin] = lambda: auth_context
+        response = client.delete("/memory/test_node_1")  # No scope param
+
+        assert response.status_code == 200
+
+        # Verify the forget was called with LOCAL scope (default)
+        call_args = app.state.memory_service.forget.call_args
+        node_arg = call_args.kwargs.get("node") or call_args.args[0]
+        assert node_arg.scope == GraphScope.LOCAL
+
+    def test_forget_memory_ignores_invalid_scope(self, client, app, sample_node, auth_context):
+        """Test that invalid scope parameter falls back to LOCAL."""
+        app.state.memory_service.forget.return_value = MemoryOpResult(
+            status=MemoryOpStatus.OK, reason="Memory forgotten", data=sample_node
+        )
+
+        app.dependency_overrides[require_admin] = lambda: auth_context
+        response = client.delete("/memory/test_node_1?scope=invalid_scope")
+
+        assert response.status_code == 200
+
+        # Verify the forget was called with LOCAL scope (fallback)
+        call_args = app.state.memory_service.forget.call_args
+        node_arg = call_args.kwargs.get("node") or call_args.args[0]
+        assert node_arg.scope == GraphScope.LOCAL
+
 
 class TestMemoryStats:
     """Test the /memory/stats endpoint."""

--- a/tests/adapters/api/test_setup_routes.py
+++ b/tests/adapters/api/test_setup_routes.py
@@ -1225,3 +1225,117 @@ class TestListModelsEndpoint:
             },
         )
         assert response.status_code == status.HTTP_200_OK
+
+
+class TestLocationEnvParsing:
+    """Test location environment variable parsing in setup config."""
+
+    @patch("ciris_engine.logic.adapters.api.routes.setup.config._is_setup_allowed_without_auth")
+    @patch("ciris_engine.logic.adapters.api.routes.setup.config._detect_llm_provider")
+    def test_get_config_with_valid_location(self, mock_detect, mock_allowed, client):
+        """Test that valid location env vars are parsed correctly."""
+        mock_allowed.return_value = True
+        mock_detect.return_value = "openai"
+
+        with patch.dict(
+            os.environ,
+            {
+                "CIRIS_USER_LATITUDE": "37.7749",
+                "CIRIS_USER_LONGITUDE": "-122.4194",
+            },
+        ):
+            response = client.get("/v1/setup/config")
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()["data"]
+        assert data["location_latitude"] == 37.7749
+        assert data["location_longitude"] == -122.4194
+        assert data["has_coordinates"] is True
+
+    @patch("ciris_engine.logic.adapters.api.routes.setup.config._is_setup_allowed_without_auth")
+    @patch("ciris_engine.logic.adapters.api.routes.setup.config._detect_llm_provider")
+    def test_get_config_with_invalid_latitude(self, mock_detect, mock_allowed, client):
+        """Test that invalid latitude env var falls back to None (no 500 error)."""
+        mock_allowed.return_value = True
+        mock_detect.return_value = "openai"
+
+        with patch.dict(
+            os.environ,
+            {
+                "CIRIS_USER_LATITUDE": "not_a_number",
+                "CIRIS_USER_LONGITUDE": "-122.4194",
+            },
+        ):
+            response = client.get("/v1/setup/config")
+
+        # Should NOT return 500, should gracefully return None for invalid lat
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()["data"]
+        assert data["location_latitude"] is None
+        assert data["location_longitude"] == -122.4194
+        assert data["has_coordinates"] is False
+
+    @patch("ciris_engine.logic.adapters.api.routes.setup.config._is_setup_allowed_without_auth")
+    @patch("ciris_engine.logic.adapters.api.routes.setup.config._detect_llm_provider")
+    def test_get_config_with_invalid_longitude(self, mock_detect, mock_allowed, client):
+        """Test that invalid longitude env var falls back to None (no 500 error)."""
+        mock_allowed.return_value = True
+        mock_detect.return_value = "openai"
+
+        with patch.dict(
+            os.environ,
+            {
+                "CIRIS_USER_LATITUDE": "37.7749",
+                "CIRIS_USER_LONGITUDE": "invalid",
+            },
+        ):
+            response = client.get("/v1/setup/config")
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()["data"]
+        assert data["location_latitude"] == 37.7749
+        assert data["location_longitude"] is None
+        assert data["has_coordinates"] is False
+
+    @patch("ciris_engine.logic.adapters.api.routes.setup.config._is_setup_allowed_without_auth")
+    @patch("ciris_engine.logic.adapters.api.routes.setup.config._detect_llm_provider")
+    def test_get_config_with_empty_location(self, mock_detect, mock_allowed, client):
+        """Test that empty location env vars return None."""
+        mock_allowed.return_value = True
+        mock_detect.return_value = "openai"
+
+        # Clear any existing location env vars
+        env_copy = os.environ.copy()
+        env_copy.pop("CIRIS_USER_LATITUDE", None)
+        env_copy.pop("CIRIS_USER_LONGITUDE", None)
+
+        with patch.dict(os.environ, env_copy, clear=True):
+            response = client.get("/v1/setup/config")
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()["data"]
+        assert data["location_latitude"] is None
+        assert data["location_longitude"] is None
+        assert data["has_coordinates"] is False
+
+    @patch("ciris_engine.logic.adapters.api.routes.setup.config._is_setup_allowed_without_auth")
+    @patch("ciris_engine.logic.adapters.api.routes.setup.config._detect_llm_provider")
+    def test_get_config_with_both_invalid_locations(self, mock_detect, mock_allowed, client):
+        """Test that both invalid location env vars fall back to None."""
+        mock_allowed.return_value = True
+        mock_detect.return_value = "openai"
+
+        with patch.dict(
+            os.environ,
+            {
+                "CIRIS_USER_LATITUDE": "abc",
+                "CIRIS_USER_LONGITUDE": "xyz",
+            },
+        ):
+            response = client.get("/v1/setup/config")
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()["data"]
+        assert data["location_latitude"] is None
+        assert data["location_longitude"] is None
+        assert data["has_coordinates"] is False

--- a/tests/ciris_engine/logic/context/test_system_snapshot_helpers.py
+++ b/tests/ciris_engine/logic/context/test_system_snapshot_helpers.py
@@ -1501,3 +1501,194 @@ class TestSystemSnapshotFormatter:
 
         # Should be truncated
         assert "... (truncated)" in result
+
+
+# =============================================================================
+# 11. STARTUP CACHE POPULATION TESTS
+# =============================================================================
+
+
+class TestStartupCachePopulation:
+    """Test the populate_enrichment_cache_at_startup function."""
+
+    @pytest.fixture(autouse=True)
+    def clear_enrichment_cache(self):
+        """Clear the enrichment cache before each test."""
+        from ciris_engine.logic.context.system_snapshot_helpers import get_enrichment_cache
+
+        cache = get_enrichment_cache()
+        cache.clear()
+        # Reset the _startup_populated flag for isolated tests
+        cache._startup_populated = False
+        cache._hit_count = 0
+        cache._miss_count = 0
+        yield
+        cache.clear()
+        cache._startup_populated = False
+
+    @pytest.mark.asyncio
+    async def test_populate_cache_at_startup_with_no_tools(self, mock_runtime, caplog):
+        """Test startup cache population with no available tools."""
+        from ciris_engine.logic.context.system_snapshot_helpers import (
+            get_enrichment_cache,
+            populate_enrichment_cache_at_startup,
+        )
+
+        await populate_enrichment_cache_at_startup(mock_runtime, {})
+
+        cache = get_enrichment_cache()
+        assert cache.stats["hits"] == 0
+        assert cache.stats["misses"] == 0
+        assert cache.is_populated is True
+
+    @pytest.mark.asyncio
+    async def test_populate_cache_at_startup_with_enrichment_tools(
+        self, mock_runtime_with_enrichment, mock_enrichment_tool_info, caplog
+    ):
+        """Test startup cache population executes enrichment tools."""
+        from ciris_engine.logic.context.system_snapshot_helpers import (
+            get_enrichment_cache,
+            populate_enrichment_cache_at_startup,
+        )
+
+        available_tools = {"test": [mock_enrichment_tool_info]}
+
+        await populate_enrichment_cache_at_startup(mock_runtime_with_enrichment, available_tools)
+
+        cache = get_enrichment_cache()
+        assert cache.is_populated is True
+        assert "[ENRICHMENT_CACHE] Startup population complete:" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_populate_cache_at_startup_skips_if_already_populated(
+        self, mock_runtime_with_enrichment, mock_enrichment_tool_info, caplog
+    ):
+        """Test startup cache population skips if cache already populated."""
+        from ciris_engine.logic.context.system_snapshot_helpers import (
+            get_enrichment_cache,
+            populate_enrichment_cache_at_startup,
+        )
+
+        # Mark cache as already populated
+        cache = get_enrichment_cache()
+        cache.mark_startup_populated()
+
+        available_tools = {"test": [mock_enrichment_tool_info]}
+
+        await populate_enrichment_cache_at_startup(mock_runtime_with_enrichment, available_tools)
+
+        assert "[ENRICHMENT_CACHE] Cache already populated, skipping" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_populate_cache_stores_results(
+        self, mock_runtime_with_enrichment, mock_enrichment_tool_info
+    ):
+        """Test that startup cache population stores tool results."""
+        from ciris_engine.logic.context.system_snapshot_helpers import (
+            get_enrichment_cache,
+            populate_enrichment_cache_at_startup,
+        )
+
+        available_tools = {"test": [mock_enrichment_tool_info]}
+
+        await populate_enrichment_cache_at_startup(mock_runtime_with_enrichment, available_tools)
+
+        cache = get_enrichment_cache()
+        # Check that result is cached
+        cached_result = cache.get("test:test_list_items")
+        assert cached_result is not None
+        assert cached_result["count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_cache_get_with_hit(self, mock_runtime_with_enrichment, mock_enrichment_tool_info):
+        """Test cache get returns cached value and increments hits."""
+        from ciris_engine.logic.context.system_snapshot_helpers import (
+            get_enrichment_cache,
+            populate_enrichment_cache_at_startup,
+        )
+
+        available_tools = {"test": [mock_enrichment_tool_info]}
+        await populate_enrichment_cache_at_startup(mock_runtime_with_enrichment, available_tools)
+
+        cache = get_enrichment_cache()
+        initial_hits = cache.stats["hits"]
+
+        # Get the cached value
+        result = cache.get("test:test_list_items")
+        assert result is not None
+        assert cache.stats["hits"] == initial_hits + 1
+
+    @pytest.mark.asyncio
+    async def test_cache_get_with_miss(self):
+        """Test cache get returns None for missing key and increments misses."""
+        from ciris_engine.logic.context.system_snapshot_helpers import get_enrichment_cache
+
+        cache = get_enrichment_cache()
+        initial_misses = cache.stats["misses"]
+
+        result = cache.get("nonexistent:tool")
+        assert result is None
+        assert cache.stats["misses"] == initial_misses + 1
+
+    @pytest.mark.asyncio
+    async def test_cache_set_and_get(self):
+        """Test cache set and get operations."""
+        from ciris_engine.logic.context.system_snapshot_helpers import get_enrichment_cache
+
+        cache = get_enrichment_cache()
+
+        test_data = {"value": 42, "items": ["a", "b", "c"]}
+        cache.set("test:my_tool", test_data)
+
+        result = cache.get("test:my_tool")
+        assert result == test_data
+
+    @pytest.mark.asyncio
+    async def test_cache_clear(self):
+        """Test cache clear removes all entries."""
+        from ciris_engine.logic.context.system_snapshot_helpers import get_enrichment_cache
+
+        cache = get_enrichment_cache()
+
+        cache.set("test:tool1", {"data": 1})
+        cache.set("test:tool2", {"data": 2})
+        assert len(cache.get_all_entries()) == 2
+
+        cache.clear()
+        assert len(cache.get_all_entries()) == 0
+        # Note: clear() only clears entries, not _startup_populated flag
+        # is_populated returns True if entries > 0 OR _startup_populated is set
+        assert cache.stats["entries"] == 0
+
+    @pytest.mark.asyncio
+    async def test_cache_get_all_entries(self):
+        """Test getting all cache entries."""
+        from ciris_engine.logic.context.system_snapshot_helpers import get_enrichment_cache
+
+        cache = get_enrichment_cache()
+
+        cache.set("test:tool1", {"data": 1})
+        cache.set("test:tool2", {"data": 2})
+
+        entries = cache.get_all_entries()
+        assert len(entries) == 2
+        assert "test:tool1" in entries
+        assert "test:tool2" in entries
+
+    @pytest.mark.asyncio
+    async def test_cache_ttl_expiration(self):
+        """Test cache entries expire after TTL."""
+        import time
+
+        from ciris_engine.logic.context.system_snapshot_helpers import get_enrichment_cache
+
+        cache = get_enrichment_cache()
+
+        # Set with very short TTL (minimum is 5 seconds, so we test near that)
+        # Note: The cache has MIN_TTL=5.0, so we can't test sub-second expiry easily
+        # Instead, test that the TTL parameter is accepted and entry is stored
+        cache.set("test:expiring", {"data": "value"}, ttl_seconds=5.0)
+
+        # Should be present immediately
+        assert cache.get("test:expiring") is not None
+        assert cache.get("test:expiring")["data"] == "value"

--- a/tests/ciris_engine/logic/utils/test_localization_integration.py
+++ b/tests/ciris_engine/logic/utils/test_localization_integration.py
@@ -185,6 +185,12 @@ class TestEnvironmentSync:
         sync_language_preference("fr")
         mock_set_lang.assert_called_once_with("fr")
 
+    @patch("ciris_engine.logic.conscience.prompt_loader.set_conscience_prompt_language")
+    def test_sync_language_preference_updates_conscience_prompt_loader(self, mock_set_lang):
+        """Test that sync_language_preference updates conscience prompt loader."""
+        sync_language_preference("am")
+        mock_set_lang.assert_called_once_with("am")
+
 
 # ============================================================================
 # Conscience Localization Tests

--- a/tests/logic/runtime/test_adapter_manager_coverage.py
+++ b/tests/logic/runtime/test_adapter_manager_coverage.py
@@ -1716,3 +1716,317 @@ class TestEnvVarPersistence:
 
         # Should NOT have called set_config since persist=False
         mock_config.set_config.assert_not_called()
+
+
+class TestEnrichmentCacheRefresh:
+    """Tests for the _refresh_enrichment_cache_for_adapter method."""
+
+    @pytest.fixture
+    def mock_time_service(self):
+        """Create a mock time service."""
+        mock = Mock(spec=TimeServiceProtocol)
+        mock.now.return_value = datetime.now(timezone.utc)
+        return mock
+
+    @pytest.fixture
+    def mock_runtime_with_enrichment(self):
+        """Create a mock runtime with enrichment tool support."""
+        from ciris_engine.schemas.config.essential import EssentialConfig
+
+        mock = Mock()
+        mock.service_registry = Mock()
+        mock.config_service = None
+        mock.adapters = []
+        mock.essential_config = EssentialConfig()
+        mock.modules_to_load = []
+        mock.startup_channel_id = "test_channel"
+        mock.debug = False
+        mock.bus_manager = Mock()
+        mock.agent_name = "test"
+        mock.agent_version = "1.0.0"
+        return mock
+
+    @pytest.fixture
+    def adapter_manager(self, mock_runtime_with_enrichment, mock_time_service):
+        """Create an adapter manager instance."""
+        return RuntimeAdapterManager(mock_runtime_with_enrichment, mock_time_service)
+
+    @pytest.fixture
+    def mock_adapter_instance(self, mock_time_service):
+        """Create a mock adapter instance."""
+        adapter = MockAdapter(None)
+        return AdapterInstance(
+            adapter_id="test_adapter",
+            adapter_type="home_assistant",
+            adapter=adapter,
+            config_params=AdapterConfig(adapter_type="home_assistant"),
+            loaded_at=mock_time_service.now(),
+            is_running=True,
+        )
+
+    @pytest.fixture(autouse=True)
+    def clear_enrichment_cache(self):
+        """Clear the enrichment cache before each test."""
+        from ciris_engine.logic.context.system_snapshot_helpers import get_enrichment_cache
+
+        cache = get_enrichment_cache()
+        cache.clear()
+        yield
+        cache.clear()
+
+    @pytest.mark.asyncio
+    async def test_refresh_enrichment_cache_no_tools(
+        self, adapter_manager, mock_adapter_instance, mock_runtime_with_enrichment
+    ):
+        """Test refresh when no tools are available."""
+        from ciris_engine.logic.context.system_snapshot_helpers import get_enrichment_cache
+
+        # Setup - no tool services
+        mock_runtime_with_enrichment.service_registry.get_services_by_type.return_value = []
+
+        # Get initial cache state
+        cache = get_enrichment_cache()
+        initial_entries = len(cache.get_all_entries())
+
+        await adapter_manager._refresh_enrichment_cache_for_adapter(mock_adapter_instance)
+
+        # Cache should not have new entries when no tools available
+        assert len(cache.get_all_entries()) == initial_entries
+
+    @pytest.mark.asyncio
+    async def test_refresh_enrichment_cache_no_enrichment_tools(
+        self, adapter_manager, mock_adapter_instance, mock_runtime_with_enrichment
+    ):
+        """Test refresh when tools exist but none are marked for enrichment."""
+        from ciris_engine.logic.context.system_snapshot_helpers import get_enrichment_cache
+        from ciris_engine.schemas.adapters.tools import ToolInfo, ToolParameterSchema
+
+        # Create non-enrichment tool
+        tool_info = ToolInfo(
+            name="regular_tool",
+            description="A regular tool",
+            parameters=ToolParameterSchema(type="object", properties={}, required=[]),
+            context_enrichment=False,
+        )
+
+        tool_service = Mock()
+        tool_service.adapter_id = "test_adapter"
+        tool_service.get_available_tools = AsyncMock(return_value=["regular_tool"])
+        tool_service.get_tool_info = AsyncMock(return_value=tool_info)
+
+        mock_runtime_with_enrichment.service_registry.get_services_by_type.return_value = [tool_service]
+
+        # Get initial cache state
+        cache = get_enrichment_cache()
+        initial_entries = len(cache.get_all_entries())
+
+        await adapter_manager._refresh_enrichment_cache_for_adapter(mock_adapter_instance)
+
+        # Cache should not have new entries for non-enrichment tools
+        assert len(cache.get_all_entries()) == initial_entries
+        # execute_tool should never be called
+        tool_service.execute_tool = AsyncMock()  # Not called
+
+    @pytest.mark.asyncio
+    async def test_refresh_enrichment_cache_executes_tool(
+        self, adapter_manager, mock_adapter_instance, mock_runtime_with_enrichment, caplog
+    ):
+        """Test that refresh executes enrichment tools and caches results."""
+        from ciris_engine.logic.context.system_snapshot_helpers import get_enrichment_cache
+        from ciris_engine.schemas.adapters.tools import (
+            ToolExecutionResult,
+            ToolExecutionStatus,
+            ToolInfo,
+            ToolParameterSchema,
+        )
+
+        # Create enrichment tool
+        tool_info = ToolInfo(
+            name="ha_list_entities",
+            description="List HA entities",
+            parameters=ToolParameterSchema(type="object", properties={}, required=[]),
+            context_enrichment=True,
+            context_enrichment_params={},
+        )
+
+        tool_result = ToolExecutionResult(
+            tool_name="ha_list_entities",
+            status=ToolExecutionStatus.COMPLETED,
+            success=True,
+            data={"entities": ["light.living_room", "switch.garage"]},
+            error=None,
+            correlation_id="test-123",
+        )
+
+        tool_service = Mock()
+        tool_service.adapter_id = "test_adapter"
+        tool_service.get_available_tools = AsyncMock(return_value=["ha_list_entities"])
+        tool_service.get_tool_info = AsyncMock(return_value=tool_info)
+        tool_service.execute_tool = AsyncMock(return_value=tool_result)
+
+        mock_runtime_with_enrichment.service_registry.get_services_by_type.return_value = [tool_service]
+
+        await adapter_manager._refresh_enrichment_cache_for_adapter(mock_adapter_instance)
+
+        # Verify cache was populated
+        cache = get_enrichment_cache()
+        cached = cache.get("test:ha_list_entities")
+        assert cached is not None
+        assert cached["entities"] == ["light.living_room", "switch.garage"]
+
+        # Verify logging
+        assert "[ENRICHMENT_CACHE] Cached test:ha_list_entities after adapter load" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_refresh_enrichment_cache_skips_existing(
+        self, adapter_manager, mock_adapter_instance, mock_runtime_with_enrichment
+    ):
+        """Test that refresh skips tools already in cache."""
+        from ciris_engine.logic.context.system_snapshot_helpers import get_enrichment_cache
+        from ciris_engine.schemas.adapters.tools import ToolInfo, ToolParameterSchema
+
+        # Pre-populate cache
+        cache = get_enrichment_cache()
+        cache.set("test:cached_tool", {"already": "cached"})
+
+        # Create enrichment tool
+        tool_info = ToolInfo(
+            name="cached_tool",
+            description="Already cached",
+            parameters=ToolParameterSchema(type="object", properties={}, required=[]),
+            context_enrichment=True,
+            context_enrichment_params={},
+        )
+
+        tool_service = Mock()
+        tool_service.adapter_id = "test_adapter"
+        tool_service.get_available_tools = AsyncMock(return_value=["cached_tool"])
+        tool_service.get_tool_info = AsyncMock(return_value=tool_info)
+        tool_service.execute_tool = AsyncMock()  # Should not be called
+
+        mock_runtime_with_enrichment.service_registry.get_services_by_type.return_value = [tool_service]
+
+        await adapter_manager._refresh_enrichment_cache_for_adapter(mock_adapter_instance)
+
+        # execute_tool should not have been called since it's already cached
+        tool_service.execute_tool.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_refresh_enrichment_cache_handles_tool_error(
+        self, adapter_manager, mock_adapter_instance, mock_runtime_with_enrichment, caplog
+    ):
+        """Test that refresh handles tool execution errors gracefully."""
+        from ciris_engine.schemas.adapters.tools import ToolInfo, ToolParameterSchema
+
+        # Create enrichment tool
+        tool_info = ToolInfo(
+            name="failing_tool",
+            description="Tool that fails",
+            parameters=ToolParameterSchema(type="object", properties={}, required=[]),
+            context_enrichment=True,
+            context_enrichment_params={},
+        )
+
+        tool_service = Mock()
+        tool_service.adapter_id = "test_adapter"
+        tool_service.get_available_tools = AsyncMock(return_value=["failing_tool"])
+        tool_service.get_tool_info = AsyncMock(return_value=tool_info)
+        tool_service.execute_tool = AsyncMock(side_effect=Exception("Tool execution failed"))
+
+        mock_runtime_with_enrichment.service_registry.get_services_by_type.return_value = [tool_service]
+
+        # Should not raise
+        await adapter_manager._refresh_enrichment_cache_for_adapter(mock_adapter_instance)
+
+        # Should log warning
+        assert "[ENRICHMENT_CACHE] Failed to cache test:failing_tool" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_refresh_enrichment_cache_with_ttl(
+        self, adapter_manager, mock_adapter_instance, mock_runtime_with_enrichment
+    ):
+        """Test that refresh respects TTL in enrichment params."""
+        from ciris_engine.logic.context.system_snapshot_helpers import get_enrichment_cache
+        from ciris_engine.schemas.adapters.tools import (
+            ToolExecutionResult,
+            ToolExecutionStatus,
+            ToolInfo,
+            ToolParameterSchema,
+        )
+
+        # Create enrichment tool with TTL
+        tool_info = ToolInfo(
+            name="ttl_tool",
+            description="Tool with TTL",
+            parameters=ToolParameterSchema(type="object", properties={}, required=[]),
+            context_enrichment=True,
+            context_enrichment_params={"_cache_ttl": 60.0},
+        )
+
+        tool_result = ToolExecutionResult(
+            tool_name="ttl_tool",
+            status=ToolExecutionStatus.COMPLETED,
+            success=True,
+            data={"value": 42},
+            error=None,
+            correlation_id="test-456",
+        )
+
+        tool_service = Mock()
+        tool_service.adapter_id = "test_adapter"
+        tool_service.get_available_tools = AsyncMock(return_value=["ttl_tool"])
+        tool_service.get_tool_info = AsyncMock(return_value=tool_info)
+        tool_service.execute_tool = AsyncMock(return_value=tool_result)
+
+        mock_runtime_with_enrichment.service_registry.get_services_by_type.return_value = [tool_service]
+
+        await adapter_manager._refresh_enrichment_cache_for_adapter(mock_adapter_instance)
+
+        # Verify cache was populated
+        cache = get_enrichment_cache()
+        cached = cache.get("test:ttl_tool")
+        assert cached is not None
+        assert cached["value"] == 42
+
+    @pytest.mark.asyncio
+    async def test_refresh_enrichment_cache_logs_stats(
+        self, adapter_manager, mock_adapter_instance, mock_runtime_with_enrichment, caplog
+    ):
+        """Test that refresh logs cache stats after completion."""
+        from ciris_engine.schemas.adapters.tools import (
+            ToolExecutionResult,
+            ToolExecutionStatus,
+            ToolInfo,
+            ToolParameterSchema,
+        )
+
+        tool_info = ToolInfo(
+            name="stats_tool",
+            description="Tool for stats test",
+            parameters=ToolParameterSchema(type="object", properties={}, required=[]),
+            context_enrichment=True,
+            context_enrichment_params={},
+        )
+
+        tool_result = ToolExecutionResult(
+            tool_name="stats_tool",
+            status=ToolExecutionStatus.COMPLETED,
+            success=True,
+            data={"result": "ok"},
+            error=None,
+            correlation_id="test-789",
+        )
+
+        tool_service = Mock()
+        tool_service.adapter_id = "test_adapter"
+        tool_service.get_available_tools = AsyncMock(return_value=["stats_tool"])
+        tool_service.get_tool_info = AsyncMock(return_value=tool_info)
+        tool_service.execute_tool = AsyncMock(return_value=tool_result)
+
+        mock_runtime_with_enrichment.service_registry.get_services_by_type.return_value = [tool_service]
+
+        await adapter_manager._refresh_enrichment_cache_for_adapter(mock_adapter_instance)
+
+        # Verify stats were logged
+        assert "[ENRICHMENT_CACHE] Refreshed cache after loading test_adapter" in caplog.text
+        assert "stats:" in caplog.text

--- a/tools/qa_runner/modules/streaming_verification.py
+++ b/tools/qa_runner/modules/streaming_verification.py
@@ -1175,25 +1175,26 @@ class StreamingVerificationModule:
                 "message": f"Error updating language: {e}",
             }
 
-    # Language-specific markers to detect proper localization in conscience prompts
-    # These are phrases that MUST appear in conscience prompts for each language
+    # Language-specific markers to detect proper localization in DMA prompts
+    # These are phrases that MUST appear in DMA prompts for each language
     # and MUST NOT appear when the language is different
-    CONSCIENCE_LANGUAGE_MARKERS = {
-        "en": ["You are IRIS-E", "You are IRIS-C", "You are CIRIS-EOV", "You are CIRIS-EH"],
-        "am": ["እርስዎ IRIS-E", "ኤንትሮፒ"],  # Amharic: formal "you are IRIS-E"
-        "ar": ["أنت IRIS-E", "الانتروبيا"],  # Arabic
-        "de": ["Sie sind IRIS-E", "Entropie"],  # German (formal Sie)
-        "es": ["Eres IRIS-E", "entropía"],  # Spanish
-        "fr": ["Vous êtes IRIS-E", "entropie"],  # French
-        "hi": ["आप IRIS-E हैं", "एन्ट्रॉपी"],  # Hindi
-        "it": ["Sei IRIS-E", "entropia"],  # Italian
-        "ja": ["あなたはIRIS-E", "エントロピー"],  # Japanese
-        "ko": ["당신은 IRIS-E", "엔트로피"],  # Korean
-        "pt": ["Você é IRIS-E", "entropia"],  # Portuguese
-        "ru": ["Ты IRIS-E", "энтропии"],  # Russian
-        "sw": ["Wewe ni IRIS-E", "entropy"],  # Swahili
-        "tr": ["Sen IRIS-E", "entropi"],  # Turkish
-        "zh": ["你是IRIS-E", "熵"],  # Chinese
+    # DMA prompts are used instead of conscience prompts because they are streamed in events
+    DMA_LANGUAGE_MARKERS = {
+        "en": ["Context Summary:", "Main Thought:", "Thought to evaluate:"],
+        "am": ["የአውድ ማጠቃለያ:", "ዋና ሀሳብ:", "የሚገመገም ሀሳብ:"],  # Amharic DMA markers
+        "ar": ["ملخص السياق:", "الفكرة الرئيسية:", "الفكرة للتقييم:"],  # Arabic
+        "de": ["Kontextzusammenfassung:", "Hauptgedanke:", "Zu bewertender Gedanke:"],  # German
+        "es": ["Resumen del contexto:", "Pensamiento principal:", "Pensamiento a evaluar:"],  # Spanish
+        "fr": ["Résumé du contexte:", "Pensée principale:", "Pensée à évaluer:"],  # French
+        "hi": ["संदर्भ सारांश:", "मुख्य विचार:", "मूल्यांकन के लिए विचार:"],  # Hindi
+        "it": ["Riepilogo del contesto:", "Pensiero principale:", "Pensiero da valutare:"],  # Italian
+        "ja": ["コンテキストの概要:", "主な考え:", "評価する考え:"],  # Japanese
+        "ko": ["컨텍스트 요약:", "주요 생각:", "평가할 생각:"],  # Korean
+        "pt": ["Resumo do contexto:", "Pensamento principal:", "Pensamento a avaliar:"],  # Portuguese
+        "ru": ["Резюме контекста:", "Основная мысль:", "Мысль для оценки:"],  # Russian
+        "sw": ["Muhtasari wa Muktadha:", "Wazo Kuu:", "Wazo la kutathmini:"],  # Swahili
+        "tr": ["Bağlam özeti:", "Ana düşünce:", "Değerlendirilecek düşünce:"],  # Turkish
+        "zh": ["上下文摘要:", "主要思想:", "待评估思想:"],  # Chinese
     }
 
     @staticmethod
@@ -1216,7 +1217,6 @@ class StreamingVerificationModule:
         """
         # Use separate typed variables to avoid mypy issues with heterogeneous dicts
         localization_evidence: List[Dict[str, Any]] = []
-        conscience_prompt_analysis: List[Dict[str, Any]] = []
         errors: List[str] = []
         language_update: Optional[Dict[str, Any]] = None
         streaming_result: Optional[Dict[str, Any]] = None
@@ -1237,7 +1237,7 @@ class StreamingVerificationModule:
                 "language_update": language_update,
                 "streaming_result": streaming_result,
                 "localization_evidence": localization_evidence,
-                "conscience_prompt_analysis": conscience_prompt_analysis,
+                "dma_prompt_analysis": [],
                 "errors": errors,
             }
 
@@ -1265,9 +1265,9 @@ class StreamingVerificationModule:
             errors.append(f"Failed to verify user profile: {e}")
 
         # Step 3: Run streaming verification with extended event collection
-        # We need to capture the raw events to analyze conscience prompts
+        # We need to capture the raw events to analyze DMA prompts
         print(f"\n📡 Running streaming verification with language '{target_language}'...")
-        print(f"   Capturing conscience prompts for localization analysis...")
+        print(f"   Capturing DMA prompts for localization analysis...")
 
         streaming_events_result = StreamingVerificationModule.verify_streaming_events_with_prompts(
             base_url, token, timeout=60
@@ -1278,24 +1278,25 @@ class StreamingVerificationModule:
             "total_events": streaming_events_result.get("total_events", 0),
         }
 
-        # Step 4: Analyze conscience prompts for localization
+        # Step 4: Analyze DMA prompts for localization (DMA prompts ARE streamed unlike conscience prompts)
         print(f"\n{'='*80}")
-        print(f"📝 CONSCIENCE PROMPT LOCALIZATION ANALYSIS")
+        print(f"📝 DMA PROMPT LOCALIZATION ANALYSIS")
         print(f"{'='*80}")
 
-        conscience_prompts_list: List[Dict[str, Any]] = streaming_events_result.get("conscience_prompts", [])
-        english_markers = StreamingVerificationModule.CONSCIENCE_LANGUAGE_MARKERS.get("en", [])
-        target_markers = StreamingVerificationModule.CONSCIENCE_LANGUAGE_MARKERS.get(target_language, [])
+        dma_prompts_list: List[Dict[str, Any]] = streaming_events_result.get("dma_prompts", [])
+        english_markers = StreamingVerificationModule.DMA_LANGUAGE_MARKERS.get("en", [])
+        target_markers = StreamingVerificationModule.DMA_LANGUAGE_MARKERS.get(target_language, [])
 
-        conscience_localized = False
+        dma_localized = False
         english_detected = False
+        dma_prompt_analysis: List[Dict[str, Any]] = []
 
-        for i, prompt_data in enumerate(conscience_prompts_list):
+        for i, prompt_data in enumerate(dma_prompts_list):
             prompt_text = prompt_data.get("prompt", "")
-            conscience_type = prompt_data.get("type", "unknown")
+            dma_type = prompt_data.get("type", "unknown")
 
             analysis = {
-                "conscience_type": conscience_type,
+                "dma_type": dma_type,
                 "prompt_length": len(prompt_text),
                 "english_markers_found": [],
                 "target_markers_found": [],
@@ -1312,7 +1313,7 @@ class StreamingVerificationModule:
             for marker in target_markers:
                 if marker in prompt_text:
                     analysis["target_markers_found"].append(marker)
-                    conscience_localized = True
+                    dma_localized = True
 
             # Determine if this prompt is properly localized
             if target_language != "en":
@@ -1324,11 +1325,11 @@ class StreamingVerificationModule:
                 # For English, we expect English markers
                 analysis["is_localized"] = len(analysis["english_markers_found"]) > 0
 
-            conscience_prompt_analysis.append(analysis)
+            dma_prompt_analysis.append(analysis)
 
             # Print analysis
             status = "✅" if analysis["is_localized"] else "❌"
-            print(f"\n  {status} Conscience: {conscience_type}")
+            print(f"\n  {status} DMA: {dma_type}")
             print(f"     Prompt length: {analysis['prompt_length']} chars")
             if analysis["english_markers_found"]:
                 print(f"     ⚠️  English markers found: {analysis['english_markers_found']}")
@@ -1369,13 +1370,13 @@ class StreamingVerificationModule:
 
         # Step 6: Determine overall localization success
         if target_language != "en":
-            # For non-English: success if at least one conscience prompt is localized
+            # For non-English: success if at least one DMA prompt is localized
             # and NO English markers were found
-            localization_passed = conscience_localized and not english_detected
+            localization_passed = dma_localized and not english_detected
             if localization_passed:
                 localization_evidence.append(
                     {
-                        "source": "conscience_prompts",
+                        "source": "dma_prompts",
                         "field": "localization",
                         "value": f"Prompts localized to {target_language}",
                     }
@@ -1383,11 +1384,11 @@ class StreamingVerificationModule:
             else:
                 if english_detected:
                     errors.append(
-                        f"English markers found in conscience prompts when language should be {target_language}"
+                        f"English markers found in DMA prompts when language should be {target_language}"
                     )
-                if not conscience_localized:
+                if not dma_localized:
                     errors.append(
-                        f"No {target_language} markers found in conscience prompts - localization may have failed"
+                        f"No {target_language} markers found in DMA prompts - localization may have failed"
                     )
         else:
             # For English: success if English markers are found
@@ -1403,8 +1404,8 @@ class StreamingVerificationModule:
         streaming_total = streaming_result.get("total_events", 0) if streaming_result else 0
         print(f"  Streaming test passed: {'✅' if streaming_success else '❌'}")
         print(f"  Events received: {streaming_total}")
-        print(f"  Conscience prompts captured: {len(conscience_prompts_list)}")
-        print(f"  Conscience localization: {'✅ PASSED' if localization_passed else '❌ FAILED'}")
+        print(f"  DMA prompts captured: {len(dma_prompts_list)}")
+        print(f"  DMA localization: {'✅ PASSED' if localization_passed else '❌ FAILED'}")
         print(f"  Localization evidence: {len(localization_evidence)} items")
 
         for evidence in localization_evidence:
@@ -1415,17 +1416,17 @@ class StreamingVerificationModule:
             for error in errors:
                 print(f"   - {error}")
 
-        # Success requires: language stored, streaming passed, AND conscience prompts localized
+        # Success requires: language stored, streaming passed, AND DMA prompts localized
         success = len(localization_evidence) > 0 and streaming_success and localization_passed and len(errors) == 0
 
         if success:
             print(f"\n✅ LOCALIZATION TEST PASSED")
             print(f"   Language preference '{target_language}' is stored and propagated through reasoning pipeline")
-            print(f"   Conscience prompts are properly localized to {target_language}")
+            print(f"   DMA prompts are properly localized to {target_language}")
         else:
             print(f"\n❌ LOCALIZATION TEST FAILED")
             if not localization_passed:
-                print(f"   Conscience prompts are NOT properly localized to {target_language}")
+                print(f"   DMA prompts are NOT properly localized to {target_language}")
 
         print(f"{'='*80}\n")
 
@@ -1434,7 +1435,7 @@ class StreamingVerificationModule:
             "language_update": language_update,
             "streaming_result": streaming_result,
             "localization_evidence": localization_evidence,
-            "conscience_prompt_analysis": conscience_prompt_analysis,
+            "dma_prompt_analysis": dma_prompt_analysis,
             "errors": errors,
         }
 
@@ -1450,6 +1451,7 @@ class StreamingVerificationModule:
         event_details: List[Dict[str, Any]] = []
         errors: List[str] = []
         conscience_prompts: List[Dict[str, Any]] = []
+        dma_prompts: List[Dict[str, Any]] = []
         start_time = time.time()
 
         # Track event-specific data
@@ -1461,7 +1463,7 @@ class StreamingVerificationModule:
         stream_error = threading.Event()
 
         def monitor_stream() -> None:
-            """Monitor SSE stream in a separate thread, capturing conscience prompts."""
+            """Monitor SSE stream in a separate thread, capturing DMA prompts."""
             nonlocal events_with_audit_data, unexpected_events
 
             try:
@@ -1506,7 +1508,20 @@ class StreamingVerificationModule:
                                 if event_type not in all_valid_events:
                                     unexpected_events.add(event_type)
 
-                                # Capture conscience prompts for localization analysis
+                                # Capture DMA prompts for localization analysis (from dma_results event)
+                                if event_type == "dma_results":
+                                    for prompt_key in ["csdma_prompt", "dsdma_prompt", "pdma_prompt"]:
+                                        prompt_value = event.get(prompt_key, "")
+                                        if prompt_value:
+                                            dma_prompts.append(
+                                                {
+                                                    "type": prompt_key.replace("_prompt", "").upper(),
+                                                    "prompt": prompt_value,
+                                                    "thought_id": event.get("thought_id"),
+                                                }
+                                            )
+
+                                # Also capture conscience prompts if present
                                 if event_type == "conscience_result":
                                     conscience_prompt = event.get("conscience_prompt", "")
                                     if conscience_prompt:
@@ -1573,6 +1588,7 @@ class StreamingVerificationModule:
                 "error": "Failed to connect to SSE stream",
                 "errors": errors,
                 "conscience_prompts": [],
+                "dma_prompts": [],
             }
 
         time.sleep(1)
@@ -1608,6 +1624,7 @@ class StreamingVerificationModule:
             "events_with_audit_data": events_with_audit_data,
             "event_details": event_details,
             "conscience_prompts": conscience_prompts,
+            "dma_prompts": dma_prompts,
             "errors": errors,
         }
 


### PR DESCRIPTION
## Summary
- Auto-populate context enrichment cache at startup and when adapters load dynamically
- Fix 404 on `/adapters/context-enrichment` endpoint (route ordering)
- Add comprehensive unit tests for enrichment cache functionality

## Test plan
- [x] Run `pytest -n 28` - all 10635 tests pass
- [x] Run `mypy` - no new errors
- [x] Manual test on device - enrichment cache populates on HA adapter load

🤖 Generated with [Claude Code](https://claude.com/claude-code)