### PR TITLE
Add mobile_local_llm adapter for on-device Gemma 4 inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to CIRIS Agent will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.4] - 2026-04-13
+
+### Added
+
+- **Local LLM Server Discovery** - Backend endpoint to discover local inference servers (Ollama, vLLM, llama.cpp, LM Studio) via hostname probing
+- **Settings Screen LLM Discovery UI** - Mobile/desktop UI for discovering and selecting local LLM servers
+
+### Fixed
+
+- **Localization Pipeline** - Fixed DMA prompts caching templates at init; now load fresh each request to respect runtime language changes
+- **User Preferences Enrichment** - Fixed user enrichment to query and merge `preferences/{user_id}` node alongside `user/{user_id}` for complete profile data
+- **Fallback Admin Production Security** - Fallback admin now only created with `CIRIS_TESTING_MODE=true`; production requires setup wizard
+
+### Changed
+
+- **DMA Type Safety** - All DMAs now use proper `DMAPromptLoader` and `PromptCollection` return types instead of `Any`
+- **Test Infrastructure** - Global `CIRIS_TESTING_MODE` set in `tests/conftest.py` for all test authentication
+
 ## [2.4.3] - 2026-04-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 **A type-safe, auditable AI agent framework with built-in ethical reasoning**
 
-**BETA RELEASE 2.4.3-stable** | [Release Notes](CHANGELOG.md) | [Documentation Hub](docs/README.md)
+**BETA RELEASE 2.4.4-stable** | [Release Notes](CHANGELOG.md) | [Documentation Hub](docs/README.md)
 
 CIRIS lets you run AI agents that explain their decisions, defer to humans when uncertain, and maintain complete audit trails. Currently powering Discord community moderation, designed to scale to healthcare and education.
 

--- a/ciris_adapters/mobile_local_llm/README.md
+++ b/ciris_adapters/mobile_local_llm/README.md
@@ -1,0 +1,115 @@
+# Mobile Local LLM Adapter
+
+Runs a local Gemma 4 inference server as part of the CIRIS runtime on
+mobile devices — Android today, iOS as soon as Google AI Edge ships an
+adequate LiteRT-LM model for iPhone/iPad — that are capable enough to
+host it. The adapter registers the local provider with the LLM bus so
+the rest of CIRIS can call it through the same `call_llm_structured`
+interface it uses for every other provider.
+
+Built around the Google AI Edge / LiteRT-LM guidance for mobile Gemma 4:
+
+- Prefer the smaller **E2B** variant on mobile; only step up to **E4B** on
+  high-end phones with headroom for memory and thermals.
+- Android builds target **arm64-v8a**; iOS targets **arm64** only.
+- Start with a small model that works reliably, not the largest model that
+  barely fits.
+
+On weaker devices (insufficient RAM, 32-bit CPU, etc.) the adapter still
+loads cleanly but stays unavailable, so the LLM bus silently falls back
+to the hosted provider. On iOS the adapter may detect a capable device
+but report a dedicated `IOS_STUB` tier when the Gemma 4 model bundle is
+not yet installed — the setup wizard uses this state to show a
+"coming soon" option rather than offering a broken local path.
+
+## Architecture
+
+| File | Responsibility |
+|------|----------------|
+| `config.py` | Typed config + environment variable bindings |
+| `capability.py` | Device tier probe (RAM, ABI, disk, platform) |
+| `inference_server.py` | Subprocess lifecycle + `/health` probing |
+| `service.py` | `LLMServiceProtocol` implementation |
+| `adapter.py` | `BaseAdapterProtocol` wrapper + health loop |
+| `manifest.json` | Adapter metadata for dynamic loading |
+
+The adapter registers a single `LLM` service at `Priority.HIGH`, one step
+below the mock LLM provider (`CRITICAL`) and above hosted providers
+(`NORMAL`). That means capable phones try on-device inference first and
+drop to cloud automatically on failure.
+
+## Capability tiers
+
+Set by `probe_device_capability()` in `capability.py`:
+
+| Tier | Meaning | When the wizard uses it |
+|------|---------|-------------------------|
+| `capable_e4b` | ≥ 8 GB RAM, arm64, mobile — can run E2B and E4B | Offer local inference with E4B as default |
+| `capable_e2b` | ≥ 6 GB RAM, arm64, mobile — can run E2B only | Offer local inference with E2B |
+| `ios_stub`    | iOS hardware looks fine but no Gemma 4 model bundle installed yet | Show "On-Device (Coming Soon)" — disabled |
+| `incapable`   | < 6 GB RAM, wrong ABI, desktop without opt-in, etc. | Do not show the local option at all |
+
+The reasons list on the report shows exactly why a device landed in a
+given tier, which makes it easy to debug a phone that the LLM bus keeps
+routing to the cloud.
+
+## Lifecycle
+
+1. `start()` probes `DeviceCapabilityReport`.
+2. If the device is incapable or iOS-stub, the service stays unhealthy
+   and the adapter logs the reasons. Nothing else runs.
+3. If the device is capable, the adapter either spawns the configured
+   `server_binary` or attaches to an already-running inference server on
+   `host:port`. It then polls `/health` until the server responds or
+   `ready_timeout_seconds` elapses.
+4. A background health loop re-probes every `health_interval_seconds`.
+   After three consecutive failed probes the adapter marks the local
+   provider permanently unavailable and the LLM bus takes over.
+5. `stop()` sends SIGTERM, waits 10s, and SIGKILLs if necessary. Any
+   owned process is reaped and the exit code is reported via
+   `get_status()`.
+
+## Configuration
+
+Everything is driven by environment variables so the mobile harness can
+configure it at startup without touching Python code. See `manifest.json`
+for the full list; the most important ones:
+
+| Env var | Default | Meaning |
+|---------|---------|---------|
+| `CIRIS_MOBILE_LOCAL_LLM_ENABLED` | `true` | Master switch |
+| `CIRIS_MOBILE_LOCAL_LLM_MODEL` | `gemma-4-e2b` | Variant to serve |
+| `CIRIS_MOBILE_LOCAL_LLM_MODEL_PATH` | _(none)_ | Path to the model bundle |
+| `CIRIS_MOBILE_LOCAL_LLM_IOS_MODEL_PATH` | _(none)_ | Expected path to the iOS model bundle (absence => IOS_STUB) |
+| `CIRIS_MOBILE_LOCAL_LLM_SERVER_BINARY` | _(none)_ | Path to the local server binary |
+| `CIRIS_MOBILE_LOCAL_LLM_PORT` | `8091` | Loopback port for the server |
+| `CIRIS_MOBILE_LOCAL_LLM_MIN_RAM_GB` | `6.0` | RAM gate for the E2B tier |
+| `CIRIS_MOBILE_LOCAL_LLM_FORCE_CAPABILITY` | _(none)_ | Override the probe for testing |
+| `CIRIS_MOBILE_LOCAL_LLM_ALLOW_DESKTOP` | `false` | Allow desktop dev/QA use |
+
+## Wizard integration
+
+The cross-platform Kotlin Multiplatform wizard uses `canRunLocalInference()`
+(in `mobile/shared/src/commonMain/.../platform/Platform.kt`) to decide
+whether to show the "On-Device (Local)" option on the LLM selection
+screen. The mapping between the Python capability tiers and the wizard
+states is:
+
+- `capable_e2b` / `capable_e4b` → wizard shows local option as normal.
+- `ios_stub` → wizard shows local option labelled "Coming Soon" and
+  disabled. Selecting BYOK / proxy continues normally.
+- `incapable` → wizard hides the local option entirely.
+
+## Testing
+
+The adapter is designed so every layer can be unit tested without
+touching the real mobile runtime:
+
+- `probe_device_capability()` accepts callable overrides for every probe.
+- `InferenceServerManager` works against any OpenAI-compatible server,
+  so tests can point it at a lightweight fixture.
+- `MobileLocalLLMService` accepts a pre-built capability report so tests
+  can simulate the full capability / model-tier matrix without monkey
+  patching the filesystem.
+
+Unit tests live in `tests/ciris_adapters/mobile_local_llm/`.

--- a/ciris_adapters/mobile_local_llm/__init__.py
+++ b/ciris_adapters/mobile_local_llm/__init__.py
@@ -1,0 +1,43 @@
+"""
+Mobile Local LLM Adapter.
+
+Runs a local OpenAI-compatible Gemma 4 inference server (LiteRT-LM,
+llama.cpp, etc.) as part of the CIRIS runtime on mobile devices — Android
+today, iOS as soon as Google AI Edge ships an adequate LiteRT-LM model
+for iPhone/iPad — that are determined to be capable enough per the Google
+AI Edge guidance.
+
+Key modules:
+- :mod:`config`           - Pydantic config + env var bindings
+- :mod:`capability`       - Device tier detection (RAM, arch, platform)
+- :mod:`inference_server` - Subprocess lifecycle for the local server
+- :mod:`service`          - LLMServiceProtocol implementation
+- :mod:`adapter`          - BaseAdapterProtocol wrapper that registers with the LLM bus
+"""
+
+from .adapter import Adapter, MobileLocalLLMAdapter
+from .capability import DeviceCapabilityReport, probe_device_capability
+from .config import (
+    DeviceTier,
+    MobileLocalLLMConfig,
+    ModelVariant,
+    Platform,
+    load_config_from_env,
+)
+from .inference_server import InferenceServerError, InferenceServerManager
+from .service import MobileLocalLLMService
+
+__all__ = [
+    "Adapter",
+    "DeviceCapabilityReport",
+    "DeviceTier",
+    "InferenceServerError",
+    "InferenceServerManager",
+    "MobileLocalLLMAdapter",
+    "MobileLocalLLMConfig",
+    "MobileLocalLLMService",
+    "ModelVariant",
+    "Platform",
+    "load_config_from_env",
+    "probe_device_capability",
+]

--- a/ciris_adapters/mobile_local_llm/adapter.py
+++ b/ciris_adapters/mobile_local_llm/adapter.py
@@ -44,7 +44,10 @@ class MobileLocalLLMAdapter(Service):
     """Adapter that runs a local Gemma 4 inference server on capable phones."""
 
     def __init__(self, runtime: Any, context: Optional[Any] = None, **kwargs: Any) -> None:
-        super().__init__(config=kwargs.get("adapter_config"))
+        # Don't pass config to super().__init__() - we handle config ourselves
+        # via _config and the config property. The base Service class would try
+        # to set self.config which conflicts with our property.
+        super().__init__(config=None)
         self.runtime = runtime
         self.context = context
 
@@ -260,6 +263,12 @@ class MobileLocalLLMAdapter(Service):
     @property
     def config(self) -> MobileLocalLLMConfig:
         return self._config
+
+    @config.setter
+    def config(self, value: Any) -> None:
+        # Base class Service.__init__ sets self.config = {} - ignore it.
+        # We manage config via _config and load_config_from_env().
+        pass
 
 
 # Export as Adapter for RuntimeAdapterManager.load_adapter() compatibility.

--- a/ciris_adapters/mobile_local_llm/adapter.py
+++ b/ciris_adapters/mobile_local_llm/adapter.py
@@ -1,0 +1,268 @@
+"""
+BaseAdapterProtocol-compliant wrapper for the mobile local LLM service.
+
+The adapter owns the lifecycle of the on-device inference server and
+registers the service with the CIRIS LLM bus. Its behaviour matches the
+other LLM adapters (``mock_llm``, production ``llm_service``) so it plugs
+into :class:`RuntimeAdapterManager` without special cases:
+
+* ``start()`` probes device capability, spawns the inference server if the
+  device is capable, and flips the service to healthy.
+* ``run_lifecycle()`` runs a background health loop so a crashed server is
+  detected quickly and the LLM bus routes to the hosted fallback.
+* ``stop()`` terminates the inference server gracefully.
+* ``get_status()`` exposes the tier, model variant, and server PID so the
+  status endpoints can show whether local inference is in use.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, List, Optional
+
+from ciris_engine.logic.adapters.base import Service
+from ciris_engine.logic.registries.base import Priority
+from ciris_engine.schemas.adapters import AdapterServiceRegistration
+from ciris_engine.schemas.runtime.adapter_management import AdapterConfig, RuntimeAdapterStatus
+from ciris_engine.schemas.runtime.enums import ServiceType
+
+from .capability import probe_device_capability
+from .config import MobileLocalLLMConfig, DeviceTier, load_config_from_env
+from .service import MobileLocalLLMService
+
+logger = logging.getLogger(__name__)
+
+
+# Health loop cadence guard. The config exposes the nominal interval, but we
+# never poll faster than this floor so we do not starve the inference server
+# of CPU on weaker devices.
+_MIN_HEALTH_INTERVAL_SECONDS = 5.0
+
+
+class MobileLocalLLMAdapter(Service):
+    """Adapter that runs a local Gemma 4 inference server on capable phones."""
+
+    def __init__(self, runtime: Any, context: Optional[Any] = None, **kwargs: Any) -> None:
+        super().__init__(config=kwargs.get("adapter_config"))
+        self.runtime = runtime
+        self.context = context
+
+        # Allow callers to pass a fully built config (tests) or an env override.
+        provided = kwargs.get("adapter_config")
+        if isinstance(provided, MobileLocalLLMConfig):
+            self._config = provided
+        else:
+            # Start from env then layer any dict-form overrides on top.
+            self._config = load_config_from_env()
+            if isinstance(provided, dict):
+                self._config = self._config.model_copy(update=provided)
+
+        self._llm_service = MobileLocalLLMService(self._config)
+        self._capability = None  # populated during start()
+        self._running = False
+        self._lifecycle_task: Optional[asyncio.Task[None]] = None
+        self._health_task: Optional[asyncio.Task[None]] = None
+
+        logger.info(
+            "MobileLocalLLMAdapter initialised (enabled=%s, variant=%s)",
+            self._config.enabled,
+            self._config.model_variant.value,
+        )
+
+    # ------------------------------------------------------------------
+    # Service registration
+    # ------------------------------------------------------------------
+
+    def get_services_to_register(self) -> List[AdapterServiceRegistration]:
+        """Register the local LLM with HIGH priority.
+
+        HIGH (not CRITICAL) sits just below the mock provider so tests still
+        work, but above the NORMAL cloud providers. On capable phones the
+        bus will prefer on-device inference; when the adapter reports
+        unhealthy (weak device, crashed server, etc.) the bus drops to the
+        cloud provider automatically.
+        """
+        return [
+            AdapterServiceRegistration(
+                service_type=ServiceType.LLM,
+                provider=self._llm_service,
+                priority=Priority.HIGH,
+                capabilities=[
+                    "call_llm_structured",
+                    "provider:mobile_local",
+                    f"model:{self._config.model_variant.value}",
+                ],
+            )
+        ]
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        logger.info("Starting MobileLocalLLMAdapter")
+        # Probe once at adapter level so get_status() has something to show
+        # even if the service layer short-circuits due to enabled=False.
+        self._capability = probe_device_capability(self._config)
+        logger.info("Device capability: %s", self._capability.summary())
+
+        await self._llm_service.start()
+        self._running = True
+
+        # Only run the health loop on devices that actually started the
+        # server. Weaker devices never flip to available, so the loop would
+        # be pure noise there.
+        if self._llm_service.available:
+            self._health_task = asyncio.create_task(
+                self._health_loop(), name="mobile-local-llm-health"
+            )
+
+        logger.info(
+            "MobileLocalLLMAdapter started (available=%s, tier=%s)",
+            self._llm_service.available,
+            self._capability.tier.value,
+        )
+
+    async def stop(self) -> None:
+        logger.info("Stopping MobileLocalLLMAdapter")
+        self._running = False
+
+        if self._health_task and not self._health_task.done():
+            self._health_task.cancel()
+            try:
+                await self._health_task
+            except asyncio.CancelledError:
+                pass
+        self._health_task = None
+
+        if self._lifecycle_task and not self._lifecycle_task.done():
+            self._lifecycle_task.cancel()
+            try:
+                await self._lifecycle_task
+            except asyncio.CancelledError:
+                pass
+        self._lifecycle_task = None
+
+        await self._llm_service.stop()
+        logger.info("MobileLocalLLMAdapter stopped")
+
+    async def run_lifecycle(self, agent_task: Any) -> None:
+        """Block until the agent task signals shutdown.
+
+        The actual health polling runs in :meth:`_health_loop`, which was
+        started from :meth:`start`. We keep ``run_lifecycle`` minimal so the
+        adapter matches the pattern used by mock_llm.
+        """
+        logger.info("MobileLocalLLMAdapter lifecycle started")
+        try:
+            await agent_task
+        except asyncio.CancelledError:
+            logger.info("MobileLocalLLMAdapter lifecycle cancelled")
+        finally:
+            await self.stop()
+
+    # ------------------------------------------------------------------
+    # Health loop
+    # ------------------------------------------------------------------
+
+    async def _health_loop(self) -> None:
+        """Periodically probe the local server and flip availability.
+
+        On three consecutive failed probes we ask the service to fully stop
+        so that its ``is_healthy()`` returns False. The LLM bus will then
+        route all traffic to the cloud fallback until the adapter is
+        restarted — we intentionally do NOT attempt automatic restarts here
+        because restart policy belongs at the ``RuntimeAdapterManager``
+        layer, not inside a single adapter.
+        """
+        interval = max(_MIN_HEALTH_INTERVAL_SECONDS, self._config.health_interval_seconds)
+        consecutive_failures = 0
+        while self._running:
+            try:
+                await asyncio.sleep(interval)
+            except asyncio.CancelledError:
+                break
+
+            if not self._running:
+                break
+            try:
+                healthy = await self._llm_service.is_healthy()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.exception("MobileLocalLLM health probe raised: %s", exc)
+                healthy = False
+
+            if healthy:
+                if consecutive_failures:
+                    logger.info("MobileLocalLLM: server recovered after %s failures", consecutive_failures)
+                consecutive_failures = 0
+                continue
+
+            consecutive_failures += 1
+            logger.warning(
+                "MobileLocalLLM: health probe failed (consecutive=%s)", consecutive_failures
+            )
+            if consecutive_failures >= 3:
+                logger.error(
+                    "MobileLocalLLM: marking local provider permanently unavailable after "
+                    "3 failed health probes; LLM bus will use hosted fallback."
+                )
+                try:
+                    await self._llm_service.stop()
+                except Exception:  # pragma: no cover - defensive
+                    logger.exception("MobileLocalLLM: error during health-triggered stop")
+                break
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    def get_config(self) -> AdapterConfig:
+        tier = self._capability.tier.value if self._capability else DeviceTier.INCAPABLE.value
+        return AdapterConfig(
+            adapter_type="mobile_local_llm",
+            enabled=self._running and self._llm_service.available,
+            settings={
+                "enabled": self._config.enabled,
+                "variant": self._config.model_variant.value,
+                "host": self._config.host,
+                "port": self._config.port,
+                "device_tier": tier,
+                "available": self._llm_service.available,
+            },
+        )
+
+    def get_status(self) -> RuntimeAdapterStatus:
+        error: Optional[str] = None
+        if self._running and self._capability and self._capability.is_stub:
+            # iOS-stub is not an error per se — it is the documented
+            # "platform supported, model not shipped yet" state. The wizard
+            # uses this to surface a "coming soon" option. We still report
+            # it here so the runtime status is accurate.
+            error = "ios_stub: " + "; ".join(self._capability.reasons)
+        elif self._running and self._capability and not self._capability.capable:
+            error = "device_not_capable: " + "; ".join(self._capability.reasons)
+        elif self._running and not self._llm_service.available:
+            error = "local_inference_unavailable"
+        return RuntimeAdapterStatus(
+            adapter_id="mobile_local_llm",
+            adapter_type="mobile_local_llm",
+            is_running=self._running,
+            loaded_at=None,
+            error=error,
+        )
+
+    # Useful for QA / tests
+    @property
+    def llm_service(self) -> MobileLocalLLMService:
+        return self._llm_service
+
+    @property
+    def config(self) -> MobileLocalLLMConfig:
+        return self._config
+
+
+# Export as Adapter for RuntimeAdapterManager.load_adapter() compatibility.
+Adapter = MobileLocalLLMAdapter
+
+__all__ = ["Adapter", "MobileLocalLLMAdapter"]

--- a/ciris_adapters/mobile_local_llm/capability.py
+++ b/ciris_adapters/mobile_local_llm/capability.py
@@ -1,0 +1,404 @@
+"""
+Device capability detection for local Gemma 4 inference on mobile devices.
+
+Google AI Edge and LiteRT-LM documentation for Gemma 4 says:
+
+- E2B can run in ~1.5 GB of memory "on some devices"
+- E4B is heavier and only suitable for high-end phones
+- arm64-v8a is the supported Android ABI; arm64 is the supported iOS ABI
+- Thermal / sustained latency matter more than peak parameter count
+
+We translate that guidance into a concrete capability probe so the runtime
+can decide whether to start the local inference server or skip it and let
+the LLM bus fall back to a hosted provider.
+
+On iOS the adapter can detect capable hardware (enough RAM, arm64, recent
+iOS) but Google AI Edge / LiteRT-LM does not yet ship an adequate
+on-device model in every configuration. When the expected model bundle is
+missing we return :attr:`DeviceTier.IOS_STUB` so the wizard can display a
+"coming soon" option rather than offering a broken local path.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import platform as _platform
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, List, Optional
+
+from .config import DeviceTier, MobileLocalLLMConfig, ModelVariant, Platform
+
+logger = logging.getLogger(__name__)
+
+
+# Android app data directories follow /data/data/<pkg>/ — this is the most
+# reliable way to detect we are inside a Chaquopy-hosted Python runtime.
+_ANDROID_DATA_PREFIX = "/data/data/"
+_ANDROID_USER_PREFIX = "/data/user/"
+
+# iOS app container paths — we will not match the Android prefixes, and
+# PythonKit / embedded Python on iOS typically executes out of a sandboxed
+# path that includes one of these substrings.
+_IOS_PATH_MARKERS = (
+    "/var/mobile/Containers/",  # user apps on device
+    "/var/containers/Bundle/Application/",  # installed app bundles
+    "/CoreSimulator/Devices/",  # simulator
+)
+
+
+@dataclass(frozen=True)
+class DeviceCapabilityReport:
+    """Structured outcome of the capability probe.
+
+    Immutable by design: the adapter caches one report per start() call and
+    derives all decisions from its fields.
+    """
+
+    tier: DeviceTier
+    platform: Platform
+    architecture: str
+    total_ram_gb: float
+    available_ram_gb: float
+    free_disk_gb: float
+    reasons: List[str]
+
+    @property
+    def capable(self) -> bool:
+        """True when the device can actually run local inference today."""
+        return self.tier in {DeviceTier.CAPABLE_E2B, DeviceTier.CAPABLE_E4B}
+
+    @property
+    def is_stub(self) -> bool:
+        """True when the platform is supported but the model is not yet shipped."""
+        return self.tier == DeviceTier.IOS_STUB
+
+    @property
+    def is_android(self) -> bool:
+        return self.platform == Platform.ANDROID
+
+    @property
+    def is_ios(self) -> bool:
+        return self.platform == Platform.IOS
+
+    def can_run(self, variant: ModelVariant) -> bool:
+        """Does this device tier support the given variant?"""
+        if variant == ModelVariant.GEMMA_4_E2B:
+            return self.capable
+        if variant == ModelVariant.GEMMA_4_E4B:
+            return self.tier == DeviceTier.CAPABLE_E4B
+        return False
+
+    def summary(self) -> str:
+        """Short human-readable summary for logs and status endpoints."""
+        return (
+            f"tier={self.tier.value} platform={self.platform.value} "
+            f"arch={self.architecture} ram_total={self.total_ram_gb:.1f}GB "
+            f"ram_avail={self.available_ram_gb:.1f}GB "
+            f"disk_free={self.free_disk_gb:.1f}GB"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Low-level probes (pure functions, kept small for unit testing)
+# ---------------------------------------------------------------------------
+
+
+def detect_platform() -> Platform:
+    """Return the high-level platform this Python process is running on.
+
+    We check Android first because an Android Chaquopy process reports
+    ``platform.system() == 'Linux'``. iOS is identified through path
+    markers and the CoreFoundation/NSBundle bridge that PythonKit exposes.
+    """
+    # Signal 1: Chaquopy / Android app data path.
+    try:
+        current = str(Path(__file__).resolve())
+    except OSError:
+        current = ""
+    if _ANDROID_DATA_PREFIX in current or _ANDROID_USER_PREFIX in current:
+        return Platform.ANDROID
+
+    # Signal 2: Android-specific environment variables.
+    if os.environ.get("ANDROID_ROOT") and os.environ.get("ANDROID_DATA"):
+        return Platform.ANDROID
+
+    # Signal 3: Chaquopy `java` module.
+    try:
+        import java  # type: ignore[import-not-found]
+
+        _ = java  # presence is the signal
+        return Platform.ANDROID
+    except ImportError:
+        pass
+
+    # Signal 4: iOS — look for container paths or the mobile sysname.
+    if any(marker in current for marker in _IOS_PATH_MARKERS):
+        return Platform.IOS
+    if sys.platform == "ios" or _platform.system() == "iOS":  # type: ignore[comparison-overlap]
+        return Platform.IOS
+    if os.environ.get("CIRIS_MOBILE_LOCAL_LLM_FORCE_PLATFORM") == "ios":
+        # Only used in dev loops / unit tests where the probes are injected.
+        return Platform.IOS
+
+    # Signal 5: Desktop fallback.
+    if _platform.system() in {"Linux", "Darwin", "Windows"}:
+        return Platform.DESKTOP
+    return Platform.UNKNOWN
+
+
+def detect_architecture() -> str:
+    """Return a normalised ABI name for the current CPU."""
+    machine = _platform.machine().lower()
+    if "aarch64" in machine or "arm64" in machine:
+        return "arm64-v8a"
+    if machine.startswith("armv7") or machine == "armv7l" or machine.startswith("arm"):
+        return "armeabi-v7a"
+    if "x86_64" in machine or machine == "amd64":
+        return "x86_64"
+    if machine.startswith("i") and machine.endswith("86"):
+        return "x86"
+    return machine or "unknown"
+
+
+def read_total_ram_gb() -> float:
+    """Read total RAM in gigabytes.
+
+    Uses /proc/meminfo on Linux/Android. Falls back to psutil when available
+    so iOS and desktop dev also report a reasonable number.
+    """
+    meminfo = _read_proc_file("/proc/meminfo")
+    if meminfo:
+        for line in meminfo.splitlines():
+            if line.startswith("MemTotal:"):
+                try:
+                    kb = int(line.split()[1])
+                    return kb / (1024 * 1024)
+                except (ValueError, IndexError):
+                    break
+    try:
+        import psutil  # type: ignore[import-not-found]
+
+        return float(psutil.virtual_memory().total) / (1024**3)
+    except Exception:  # pragma: no cover - optional dependency
+        return 0.0
+
+
+def read_available_ram_gb() -> float:
+    """Read currently available RAM in gigabytes."""
+    meminfo = _read_proc_file("/proc/meminfo")
+    if meminfo:
+        available_kb: Optional[int] = None
+        free_kb: Optional[int] = None
+        for line in meminfo.splitlines():
+            if line.startswith("MemAvailable:"):
+                try:
+                    available_kb = int(line.split()[1])
+                except (ValueError, IndexError):
+                    pass
+            elif line.startswith("MemFree:"):
+                try:
+                    free_kb = int(line.split()[1])
+                except (ValueError, IndexError):
+                    pass
+        if available_kb is not None:
+            return available_kb / (1024 * 1024)
+        if free_kb is not None:
+            return free_kb / (1024 * 1024)
+    try:
+        import psutil  # type: ignore[import-not-found]
+
+        return float(psutil.virtual_memory().available) / (1024**3)
+    except Exception:  # pragma: no cover - optional dependency
+        return 0.0
+
+
+def read_free_disk_gb(path: Optional[Path] = None) -> float:
+    """Free disk space in gigabytes for the given path (app data dir by default)."""
+    target = path or _default_disk_path()
+    try:
+        usage = shutil.disk_usage(str(target))
+        return usage.free / (1024**3)
+    except (OSError, FileNotFoundError):
+        return 0.0
+
+
+def _default_disk_path() -> Path:
+    """Best-effort guess of the writable data directory we care about."""
+    home = os.environ.get("HOME")
+    if home:
+        return Path(home)
+    ciris_home = os.environ.get("CIRIS_HOME")
+    if ciris_home:
+        return Path(ciris_home)
+    return Path(os.getcwd())
+
+
+def _read_proc_file(path: str) -> Optional[str]:
+    """Read a /proc file, returning None on any permission or IO error."""
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            return handle.read()
+    except (OSError, PermissionError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Public probe
+# ---------------------------------------------------------------------------
+
+
+def probe_device_capability(
+    config: MobileLocalLLMConfig,
+    *,
+    platform_fn: Optional[Callable[[], Platform]] = None,
+    arch_fn: Optional[Callable[[], str]] = None,
+    total_ram_fn: Optional[Callable[[], float]] = None,
+    available_ram_fn: Optional[Callable[[], float]] = None,
+    free_disk_fn: Optional[Callable[[], float]] = None,
+) -> DeviceCapabilityReport:
+    """Probe the current device and decide whether local inference is safe.
+
+    The returned report is what the adapter uses to decide whether to spawn
+    the inference server. Callable overrides let the unit tests simulate
+    phones without the probe needing to reach the real system.
+    """
+    current_platform = (platform_fn or detect_platform)()
+    architecture = (arch_fn or detect_architecture)()
+    total_ram_gb = (total_ram_fn or read_total_ram_gb)()
+    available_ram_gb = (available_ram_fn or read_available_ram_gb)()
+    free_disk_gb = (free_disk_fn or read_free_disk_gb)()
+
+    reasons: List[str] = []
+
+    # Honour explicit override (testing / power users) but still populate the
+    # observed fields for visibility.
+    if config.force_capability is not None:
+        reasons.append(f"tier forced via config to {config.force_capability.value}")
+        return DeviceCapabilityReport(
+            tier=config.force_capability,
+            platform=current_platform,
+            architecture=architecture,
+            total_ram_gb=total_ram_gb,
+            available_ram_gb=available_ram_gb,
+            free_disk_gb=free_disk_gb,
+            reasons=reasons,
+        )
+
+    # Gate 1: platform — Android and iOS (with caveats) are supported.
+    # Desktop only passes when ``allow_desktop`` is explicitly set for QA.
+    if current_platform == Platform.DESKTOP and not config.allow_desktop:
+        reasons.append(
+            "running on desktop; set allow_desktop=true to opt in for development"
+        )
+        return _result(
+            DeviceTier.INCAPABLE, current_platform, architecture,
+            total_ram_gb, available_ram_gb, free_disk_gb, reasons,
+        )
+    if current_platform == Platform.UNKNOWN:
+        reasons.append("unknown platform; refusing to run local inference")
+        return _result(
+            DeviceTier.INCAPABLE, current_platform, architecture,
+            total_ram_gb, available_ram_gb, free_disk_gb, reasons,
+        )
+
+    # Gate 2: arm64 on mobile. Desktop dev can be x86_64.
+    if current_platform in {Platform.ANDROID, Platform.IOS} and architecture != "arm64-v8a":
+        reasons.append(
+            f"architecture {architecture} is not arm64; Gemma 4 mobile builds require arm64"
+        )
+        return _result(
+            DeviceTier.INCAPABLE, current_platform, architecture,
+            total_ram_gb, available_ram_gb, free_disk_gb, reasons,
+        )
+
+    # Gate 3: free disk.
+    if free_disk_gb > 0.0 and free_disk_gb < config.min_free_disk_gb:
+        reasons.append(
+            f"free disk {free_disk_gb:.2f}GB is below required {config.min_free_disk_gb:.2f}GB"
+        )
+        return _result(
+            DeviceTier.INCAPABLE, current_platform, architecture,
+            total_ram_gb, available_ram_gb, free_disk_gb, reasons,
+        )
+
+    # Gate 4: RAM thresholds.
+    if total_ram_gb <= 0.0:
+        reasons.append("could not determine total RAM; skipping local inference for safety")
+        return _result(
+            DeviceTier.INCAPABLE, current_platform, architecture,
+            total_ram_gb, available_ram_gb, free_disk_gb, reasons,
+        )
+
+    if total_ram_gb >= config.min_total_ram_gb_e4b:
+        reasons.append(
+            f"total RAM {total_ram_gb:.1f}GB >= E4B threshold {config.min_total_ram_gb_e4b:.1f}GB"
+        )
+        tentative_tier = DeviceTier.CAPABLE_E4B
+    elif total_ram_gb >= config.min_total_ram_gb_e2b:
+        reasons.append(
+            f"total RAM {total_ram_gb:.1f}GB >= E2B threshold {config.min_total_ram_gb_e2b:.1f}GB"
+        )
+        tentative_tier = DeviceTier.CAPABLE_E2B
+    else:
+        reasons.append(
+            f"total RAM {total_ram_gb:.1f}GB is below E2B threshold {config.min_total_ram_gb_e2b:.1f}GB"
+        )
+        return _result(
+            DeviceTier.INCAPABLE, current_platform, architecture,
+            total_ram_gb, available_ram_gb, free_disk_gb, reasons,
+        )
+
+    # Gate 5: iOS stub — hardware looks fine but we may not have a model to
+    # feed LiteRT-LM yet. If the model bundle does not exist we demote the
+    # tier to IOS_STUB so the wizard can show "coming soon".
+    if current_platform == Platform.IOS:
+        model_path = config.ios_model_path or config.model_path
+        if model_path is None or not model_path.exists():
+            reasons.append(
+                "iOS local inference is supported on this device but no Gemma 4 model "
+                "bundle was found; marking as stub so the wizard shows 'coming soon'"
+            )
+            return _result(
+                DeviceTier.IOS_STUB, current_platform, architecture,
+                total_ram_gb, available_ram_gb, free_disk_gb, reasons,
+            )
+
+    return _result(
+        tentative_tier, current_platform, architecture,
+        total_ram_gb, available_ram_gb, free_disk_gb, reasons,
+    )
+
+
+def _result(
+    tier: DeviceTier,
+    current_platform: Platform,
+    architecture: str,
+    total_ram_gb: float,
+    available_ram_gb: float,
+    free_disk_gb: float,
+    reasons: List[str],
+) -> DeviceCapabilityReport:
+    return DeviceCapabilityReport(
+        tier=tier,
+        platform=current_platform,
+        architecture=architecture,
+        total_ram_gb=total_ram_gb,
+        available_ram_gb=available_ram_gb,
+        free_disk_gb=free_disk_gb,
+        reasons=reasons,
+    )
+
+
+__all__ = [
+    "DeviceCapabilityReport",
+    "detect_architecture",
+    "detect_platform",
+    "probe_device_capability",
+    "read_available_ram_gb",
+    "read_free_disk_gb",
+    "read_total_ram_gb",
+]

--- a/ciris_adapters/mobile_local_llm/capability.py
+++ b/ciris_adapters/mobile_local_llm/capability.py
@@ -69,7 +69,7 @@ class DeviceCapabilityReport:
     @property
     def capable(self) -> bool:
         """True when the device can actually run local inference today."""
-        return self.tier in {DeviceTier.CAPABLE_E2B, DeviceTier.CAPABLE_E4B}
+        return self.tier in {DeviceTier.CAPABLE_E2B, DeviceTier.CAPABLE_E4B, DeviceTier.DESKTOP_CAPABLE}
 
     @property
     def is_stub(self) -> bool:
@@ -288,16 +288,10 @@ def probe_device_capability(
             reasons=reasons,
         )
 
-    # Gate 1: platform — Android and iOS (with caveats) are supported.
-    # Desktop only passes when ``allow_desktop`` is explicitly set for QA.
-    if current_platform == Platform.DESKTOP and not config.allow_desktop:
-        reasons.append(
-            "running on desktop; set allow_desktop=true to opt in for development"
-        )
-        return _result(
-            DeviceTier.INCAPABLE, current_platform, architecture,
-            total_ram_gb, available_ram_gb, free_disk_gb, reasons,
-        )
+    # Gate 1: platform — Android, iOS (with caveats), and Desktop are all supported.
+    # None auto-start the server; all platforms detect capability and let the
+    # user opt in via the wizard. This keeps behavior predictable and gives
+    # users control over when to allocate resources for local inference.
     if current_platform == Platform.UNKNOWN:
         reasons.append("unknown platform; refusing to run local inference")
         return _result(
@@ -366,6 +360,17 @@ def probe_device_capability(
                 DeviceTier.IOS_STUB, current_platform, architecture,
                 total_ram_gb, available_ram_gb, free_disk_gb, reasons,
             )
+
+    # Gate 6: Desktop — return DESKTOP_CAPABLE so the wizard can offer to
+    # start a local llama.cpp server. User must explicitly opt in.
+    if current_platform == Platform.DESKTOP:
+        reasons.append(
+            f"desktop system with {total_ram_gb:.1f}GB RAM can run local llama.cpp inference"
+        )
+        return _result(
+            DeviceTier.DESKTOP_CAPABLE, current_platform, architecture,
+            total_ram_gb, available_ram_gb, free_disk_gb, reasons,
+        )
 
     return _result(
         tentative_tier, current_platform, architecture,

--- a/ciris_adapters/mobile_local_llm/config.py
+++ b/ciris_adapters/mobile_local_llm/config.py
@@ -1,0 +1,314 @@
+"""
+Configuration schemas for the Mobile Local LLM adapter.
+
+Runs a local OpenAI-compatible Gemma 4 inference server on mobile devices
+(Android today, iOS when an adequate LiteRT-LM build is available) that
+are determined to be capable enough per the Google AI Edge guidance.
+
+All configuration is strongly typed via Pydantic - no Dict[str, Any].
+Values are read from environment variables at runtime so they can be
+injected from the mobile harness or the interactive configuration wizard.
+"""
+
+from __future__ import annotations
+
+import os
+from enum import Enum
+from pathlib import Path
+from typing import List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+# ---------------------------------------------------------------------------
+# Environment variable names (single source of truth)
+# ---------------------------------------------------------------------------
+
+ENV_ENABLED = "CIRIS_MOBILE_LOCAL_LLM_ENABLED"
+ENV_MODEL_VARIANT = "CIRIS_MOBILE_LOCAL_LLM_MODEL"
+ENV_MODEL_PATH = "CIRIS_MOBILE_LOCAL_LLM_MODEL_PATH"
+ENV_SERVER_BINARY = "CIRIS_MOBILE_LOCAL_LLM_SERVER_BINARY"
+ENV_SERVER_HOST = "CIRIS_MOBILE_LOCAL_LLM_HOST"
+ENV_SERVER_PORT = "CIRIS_MOBILE_LOCAL_LLM_PORT"
+ENV_READY_TIMEOUT = "CIRIS_MOBILE_LOCAL_LLM_READY_TIMEOUT"
+ENV_REQUEST_TIMEOUT = "CIRIS_MOBILE_LOCAL_LLM_REQUEST_TIMEOUT"
+ENV_HEALTH_INTERVAL = "CIRIS_MOBILE_LOCAL_LLM_HEALTH_INTERVAL"
+ENV_MIN_RAM_GB = "CIRIS_MOBILE_LOCAL_LLM_MIN_RAM_GB"
+ENV_MIN_FREE_DISK_GB = "CIRIS_MOBILE_LOCAL_LLM_MIN_FREE_DISK_GB"
+ENV_FORCE_CAPABILITY = "CIRIS_MOBILE_LOCAL_LLM_FORCE_CAPABILITY"
+ENV_ALLOW_DESKTOP = "CIRIS_MOBILE_LOCAL_LLM_ALLOW_DESKTOP"
+ENV_IOS_STUB_MODEL_PATH = "CIRIS_MOBILE_LOCAL_LLM_IOS_MODEL_PATH"
+
+
+class ModelVariant(str, Enum):
+    """Gemma 4 mobile variants supported by this adapter.
+
+    Values match the variant names used by the Google AI Edge / LiteRT-LM
+    documentation. The tier also governs the minimum device capability
+    required before the adapter will start the inference server.
+    """
+
+    GEMMA_4_E2B = "gemma-4-e2b"  # ~1.5 GB, works on capable mid/high-tier phones
+    GEMMA_4_E4B = "gemma-4-e4b"  # heavier variant, high-end phones only
+
+
+class DeviceTier(str, Enum):
+    """Outcome of the capability probe for a device.
+
+    ``IOS_STUB`` is a distinct value because on iOS we can detect a capable
+    device (enough RAM, arm64, recent OS) but Google AI Edge / LiteRT-LM
+    does not yet ship an adequate on-device model in every configuration.
+    The wizard surfaces iOS-stub devices differently so the user knows the
+    path exists but is not yet active.
+    """
+
+    CAPABLE_E4B = "capable_e4b"  # can run the heavier E4B model
+    CAPABLE_E2B = "capable_e2b"  # can run E2B reliably
+    IOS_STUB = "ios_stub"  # iOS device that would be capable, model not yet available
+    INCAPABLE = "incapable"  # local inference is not safe on this device
+
+
+class Platform(str, Enum):
+    """Mobile-aware platform identifier used by the capability probe."""
+
+    ANDROID = "android"
+    IOS = "ios"
+    DESKTOP = "desktop"
+    UNKNOWN = "unknown"
+
+
+class MobileLocalLLMConfig(BaseModel):
+    """Typed configuration for the mobile local LLM adapter."""
+
+    model_config = ConfigDict(extra="forbid", protected_namespaces=())
+
+    # --- Feature gate -------------------------------------------------------
+    enabled: bool = Field(
+        default=True,
+        description="Master switch. When False the adapter loads but never starts the server.",
+    )
+
+    # --- Model selection ----------------------------------------------------
+    model_variant: ModelVariant = Field(
+        default=ModelVariant.GEMMA_4_E2B,
+        description="Gemma 4 variant to load. Start with E2B on mobile per Google AI Edge guidance.",
+    )
+    model_path: Optional[Path] = Field(
+        default=None,
+        description=(
+            "Path to the LiteRT-LM model bundle on disk. If None the adapter "
+            "looks in the default on-device model directory."
+        ),
+    )
+
+    # --- Inference server binary -------------------------------------------
+    server_binary: Optional[Path] = Field(
+        default=None,
+        description=(
+            "Absolute path to the local inference server binary (e.g. LiteRT-LM "
+            "or llama.cpp 'server'). Required when the adapter must spawn the "
+            "server itself. If None and the server is already running at host:port "
+            "the adapter will attach instead of spawning."
+        ),
+    )
+    server_extra_args: List[str] = Field(
+        default_factory=list,
+        description="Extra CLI arguments passed to the inference server binary.",
+    )
+
+    # --- Network transport --------------------------------------------------
+    host: str = Field(
+        default="127.0.0.1",
+        description="Host the local inference server binds to. Must stay on loopback by default.",
+    )
+    port: int = Field(
+        default=8091,
+        ge=1024,
+        le=65535,
+        description="Port the local inference server listens on for OpenAI-compatible requests.",
+    )
+
+    # --- Timeouts and probing ----------------------------------------------
+    ready_timeout_seconds: float = Field(
+        default=30.0,
+        gt=0.0,
+        description="How long to wait for the server to become healthy after start().",
+    )
+    request_timeout_seconds: float = Field(
+        default=60.0,
+        gt=0.0,
+        description="Per-request timeout for inference calls.",
+    )
+    health_interval_seconds: float = Field(
+        default=15.0,
+        gt=0.0,
+        description="Interval between background health probes while the adapter is running.",
+    )
+
+    # --- Device capability gates -------------------------------------------
+    min_total_ram_gb_e2b: float = Field(
+        default=6.0,
+        gt=0.0,
+        description="Minimum total RAM (GB) required to run the E2B variant safely.",
+    )
+    min_total_ram_gb_e4b: float = Field(
+        default=8.0,
+        gt=0.0,
+        description="Minimum total RAM (GB) required to run the E4B variant safely.",
+    )
+    min_free_disk_gb: float = Field(
+        default=3.0,
+        gt=0.0,
+        description="Minimum free disk space (GB) required before model download/load.",
+    )
+
+    # --- iOS-specific -------------------------------------------------------
+    ios_model_path: Optional[Path] = Field(
+        default=None,
+        description=(
+            "Expected path to the iOS Gemma 4 model bundle. When unset or the "
+            "path does not exist the adapter reports the device as IOS_STUB "
+            "so the wizard can show 'coming soon' rather than offering a "
+            "broken local option."
+        ),
+    )
+
+    # --- Escape hatches (for testing / power users) ------------------------
+    force_capability: Optional[DeviceTier] = Field(
+        default=None,
+        description="Override the capability probe. Only use for testing or known-good devices.",
+    )
+    allow_desktop: bool = Field(
+        default=False,
+        description="Allow the adapter to run on desktop platforms (development / QA only).",
+    )
+
+    @field_validator("host")
+    @classmethod
+    def _validate_host(cls, value: str) -> str:
+        """Safety rail: block accidental empty bind host."""
+        if not value:
+            raise ValueError("host must not be empty")
+        return value
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def base_url(self) -> str:
+        """OpenAI-compatible base URL for the local server."""
+        return f"http://{self.host}:{self.port}/v1"
+
+    def health_url(self) -> str:
+        """HTTP URL the adapter probes to confirm the server is up."""
+        return f"http://{self.host}:{self.port}/health"
+
+    def required_ram_gb(self) -> float:
+        """Minimum RAM required for the configured model variant."""
+        if self.model_variant == ModelVariant.GEMMA_4_E4B:
+            return self.min_total_ram_gb_e4b
+        return self.min_total_ram_gb_e2b
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+def _env_path(name: str) -> Optional[Path]:
+    raw = os.environ.get(name)
+    if not raw:
+        return None
+    return Path(raw).expanduser()
+
+
+def _env_tier(name: str) -> Optional[DeviceTier]:
+    raw = os.environ.get(name)
+    if not raw:
+        return None
+    try:
+        return DeviceTier(raw.strip().lower())
+    except ValueError:
+        return None
+
+
+def _env_variant(name: str, default: ModelVariant) -> ModelVariant:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return ModelVariant(raw.strip().lower())
+    except ValueError:
+        return default
+
+
+def load_config_from_env() -> MobileLocalLLMConfig:
+    """Build a config instance from environment variables.
+
+    This mirrors the pattern used by the wallet and mock_llm adapters: the
+    interactive configurable adapter writes env vars, and the service reads
+    them here. Anything unset falls back to the defaults on the model.
+    """
+    defaults = MobileLocalLLMConfig()
+    return MobileLocalLLMConfig(
+        enabled=_env_bool(ENV_ENABLED, defaults.enabled),
+        model_variant=_env_variant(ENV_MODEL_VARIANT, defaults.model_variant),
+        model_path=_env_path(ENV_MODEL_PATH),
+        server_binary=_env_path(ENV_SERVER_BINARY),
+        host=os.environ.get(ENV_SERVER_HOST, defaults.host),
+        port=_env_int(ENV_SERVER_PORT, defaults.port),
+        ready_timeout_seconds=_env_float(ENV_READY_TIMEOUT, defaults.ready_timeout_seconds),
+        request_timeout_seconds=_env_float(ENV_REQUEST_TIMEOUT, defaults.request_timeout_seconds),
+        health_interval_seconds=_env_float(ENV_HEALTH_INTERVAL, defaults.health_interval_seconds),
+        min_total_ram_gb_e2b=_env_float(ENV_MIN_RAM_GB, defaults.min_total_ram_gb_e2b),
+        min_free_disk_gb=_env_float(ENV_MIN_FREE_DISK_GB, defaults.min_free_disk_gb),
+        ios_model_path=_env_path(ENV_IOS_STUB_MODEL_PATH),
+        force_capability=_env_tier(ENV_FORCE_CAPABILITY),
+        allow_desktop=_env_bool(ENV_ALLOW_DESKTOP, defaults.allow_desktop),
+    )
+
+
+__all__ = [
+    "MobileLocalLLMConfig",
+    "DeviceTier",
+    "ModelVariant",
+    "Platform",
+    "load_config_from_env",
+    # Env var names
+    "ENV_ENABLED",
+    "ENV_MODEL_VARIANT",
+    "ENV_MODEL_PATH",
+    "ENV_SERVER_BINARY",
+    "ENV_SERVER_HOST",
+    "ENV_SERVER_PORT",
+    "ENV_READY_TIMEOUT",
+    "ENV_REQUEST_TIMEOUT",
+    "ENV_HEALTH_INTERVAL",
+    "ENV_MIN_RAM_GB",
+    "ENV_MIN_FREE_DISK_GB",
+    "ENV_FORCE_CAPABILITY",
+    "ENV_ALLOW_DESKTOP",
+    "ENV_IOS_STUB_MODEL_PATH",
+]

--- a/ciris_adapters/mobile_local_llm/config.py
+++ b/ciris_adapters/mobile_local_llm/config.py
@@ -60,10 +60,15 @@ class DeviceTier(str, Enum):
     does not yet ship an adequate on-device model in every configuration.
     The wizard surfaces iOS-stub devices differently so the user knows the
     path exists but is not yet active.
+
+    ``DESKTOP_CAPABLE`` indicates a desktop system with enough RAM/disk to
+    run llama.cpp with Gemma4. Unlike mobile, desktop doesn't auto-start
+    the server - the user must opt in via the wizard.
     """
 
     CAPABLE_E4B = "capable_e4b"  # can run the heavier E4B model
     CAPABLE_E2B = "capable_e2b"  # can run E2B reliably
+    DESKTOP_CAPABLE = "desktop_capable"  # desktop with enough RAM/disk for llama.cpp
     IOS_STUB = "ios_stub"  # iOS device that would be capable, model not yet available
     INCAPABLE = "incapable"  # local inference is not safe on this device
 

--- a/ciris_adapters/mobile_local_llm/inference_server.py
+++ b/ciris_adapters/mobile_local_llm/inference_server.py
@@ -1,0 +1,248 @@
+"""
+Lifecycle manager for a local OpenAI-compatible inference server.
+
+The adapter runs the inference server *as part of the CIRIS runtime* so that
+service health follows process health: if the binary crashes, the LLM bus
+marks this provider unhealthy and falls back to a hosted LLM. If the binary
+can't start (missing model, port in use, etc.) the adapter simply stays
+unhealthy without tearing the whole runtime down.
+
+The underlying binary is pluggable. Anything that speaks the OpenAI REST
+surface on ``http://host:port/v1`` is fine: LiteRT-LM, llama.cpp's
+``server``, Ollama, etc. The adapter only owns:
+
+* spawning / terminating the subprocess
+* polling the ``/health`` endpoint for readiness
+* surfacing health and status for the LLM bus
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+import signal
+import subprocess
+from pathlib import Path
+from typing import List, Optional
+
+from .config import MobileLocalLLMConfig
+
+logger = logging.getLogger(__name__)
+
+
+# Try to use httpx if available (it is already a transitive dependency on
+# desktop + server), fall back to urllib so the adapter can still probe
+# health on stripped-down Android builds.
+try:  # pragma: no cover - import guard
+    import httpx  # type: ignore[import-not-found]
+
+    _HAVE_HTTPX = True
+except ImportError:  # pragma: no cover - fallback path
+    httpx = None  # type: ignore[assignment]
+    _HAVE_HTTPX = False
+
+
+class InferenceServerError(RuntimeError):
+    """Raised when the local inference server cannot be managed."""
+
+
+class InferenceServerManager:
+    """Spawns and supervises the local inference server binary."""
+
+    def __init__(self, config: MobileLocalLLMConfig) -> None:
+        self._config = config
+        self._process: Optional[asyncio.subprocess.Process] = None
+        self._owned_process = False  # False when we attached to a pre-existing server
+        self._last_exit_code: Optional[int] = None
+        self._started = False
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def owns_process(self) -> bool:
+        """True if we spawned the server ourselves (vs. attached to one)."""
+        return self._owned_process
+
+    @property
+    def process_id(self) -> Optional[int]:
+        """PID of the managed inference server, or None."""
+        return self._process.pid if self._process else None
+
+    @property
+    def last_exit_code(self) -> Optional[int]:
+        """Exit code from the last terminated inference server process."""
+        return self._last_exit_code
+
+    @property
+    def is_running(self) -> bool:
+        """True if our managed process is still alive."""
+        if self._process is None:
+            return not self._owned_process and self._started
+        return self._process.returncode is None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Start or attach to the local inference server.
+
+        If ``config.server_binary`` is set we spawn the subprocess. If not,
+        we assume the caller (or the Android app) has already started the
+        server and we simply probe it for readiness. Either way we block
+        until the ``/health`` endpoint responds successfully or
+        ``ready_timeout_seconds`` elapses.
+        """
+        if self._started:
+            logger.debug("Inference server already started; ignoring duplicate start()")
+            return
+
+        if self._config.server_binary is not None:
+            await self._spawn_subprocess()
+        else:
+            logger.info(
+                "No server_binary configured; attaching to existing inference server at %s",
+                self._config.base_url(),
+            )
+            self._owned_process = False
+
+        await self._wait_until_ready()
+        self._started = True
+        logger.info("Local inference server ready at %s", self._config.base_url())
+
+    async def stop(self) -> None:
+        """Stop the managed process gracefully, with a forced kill fallback."""
+        self._started = False
+        if self._process is None:
+            return
+
+        if self._process.returncode is not None:
+            self._last_exit_code = self._process.returncode
+            self._process = None
+            return
+
+        logger.info("Stopping local inference server (pid=%s)", self._process.pid)
+        try:
+            self._process.send_signal(signal.SIGTERM)
+        except ProcessLookupError:
+            self._process = None
+            return
+
+        try:
+            await asyncio.wait_for(self._process.wait(), timeout=10.0)
+        except asyncio.TimeoutError:
+            logger.warning("Inference server did not exit in 10s; killing pid=%s", self._process.pid)
+            try:
+                self._process.kill()
+            except ProcessLookupError:
+                pass
+            try:
+                await asyncio.wait_for(self._process.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                logger.error("Inference server pid=%s did not die after SIGKILL", self._process.pid)
+
+        self._last_exit_code = self._process.returncode
+        self._process = None
+
+    async def health_check(self) -> bool:
+        """Return True if the server responds on /health within a short timeout."""
+        # If we own the process and it has exited, we are definitely unhealthy.
+        if self._owned_process and self._process is not None and self._process.returncode is not None:
+            self._last_exit_code = self._process.returncode
+            return False
+        return await self._probe_health(timeout=2.0)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _spawn_subprocess(self) -> None:
+        binary = self._config.server_binary
+        assert binary is not None  # guarded by caller
+        if not self._binary_available(binary):
+            raise InferenceServerError(
+                f"Inference server binary not found or not executable: {binary}"
+            )
+
+        argv = self._build_argv(binary)
+        logger.info("Spawning local inference server: %s", " ".join(argv))
+        try:
+            self._process = await asyncio.create_subprocess_exec(
+                *argv,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+            )
+        except (OSError, FileNotFoundError) as exc:
+            raise InferenceServerError(f"Failed to spawn inference server: {exc}") from exc
+        self._owned_process = True
+
+    def _build_argv(self, binary: Path) -> List[str]:
+        argv: List[str] = [str(binary)]
+
+        # Common args most OpenAI-compatible inference servers accept.
+        # Unknown flags on a specific binary will be rejected at spawn time,
+        # which surfaces clearly in the logs.
+        argv += ["--host", self._config.host, "--port", str(self._config.port)]
+        if self._config.model_path is not None:
+            argv += ["--model", str(self._config.model_path)]
+        argv += list(self._config.server_extra_args)
+        return argv
+
+    @staticmethod
+    def _binary_available(binary: Path) -> bool:
+        if binary.is_file():
+            return True
+        # Support bare binary names that resolve via PATH.
+        return shutil.which(str(binary)) is not None
+
+    async def _wait_until_ready(self) -> None:
+        timeout = self._config.ready_timeout_seconds
+        deadline = asyncio.get_event_loop().time() + timeout
+        interval = 0.5
+        last_error: Optional[str] = None
+        while True:
+            if self._owned_process and self._process is not None and self._process.returncode is not None:
+                self._last_exit_code = self._process.returncode
+                raise InferenceServerError(
+                    f"Inference server exited during startup (code={self._process.returncode})"
+                )
+            if await self._probe_health(timeout=1.5):
+                return
+            if asyncio.get_event_loop().time() >= deadline:
+                raise InferenceServerError(
+                    f"Inference server did not become ready within {timeout:.1f}s"
+                    + (f": {last_error}" if last_error else "")
+                )
+            await asyncio.sleep(interval)
+
+    async def _probe_health(self, *, timeout: float) -> bool:
+        url = self._config.health_url()
+        if _HAVE_HTTPX:
+            try:
+                async with httpx.AsyncClient(timeout=timeout) as client:  # type: ignore[union-attr]
+                    response = await client.get(url)
+                    return 200 <= response.status_code < 500
+            except Exception as exc:  # pragma: no cover - network variability
+                logger.debug("httpx health probe failed for %s: %s", url, exc)
+                return False
+        return await asyncio.to_thread(self._sync_probe_health, url, timeout)
+
+    @staticmethod
+    def _sync_probe_health(url: str, timeout: float) -> bool:
+        from urllib.error import URLError
+        from urllib.request import urlopen
+
+        try:
+            with urlopen(url, timeout=timeout) as response:  # noqa: S310 - loopback only
+                return 200 <= response.status < 500
+        except URLError:
+            return False
+        except Exception:  # pragma: no cover - best-effort probe
+            return False
+
+
+__all__ = ["InferenceServerManager", "InferenceServerError"]

--- a/ciris_adapters/mobile_local_llm/manifest.json
+++ b/ciris_adapters/mobile_local_llm/manifest.json
@@ -1,0 +1,130 @@
+{
+  "module": {
+    "name": "mobile_local_llm",
+    "version": "1.0.0",
+    "description": "Local Gemma 4 inference on capable mobile devices via an on-device OpenAI-compatible server (Android today, iOS stub pending LiteRT-LM model)",
+    "author": "CIRIS Team"
+  },
+  "services": [{
+    "type": "LLM",
+    "priority": "HIGH",
+    "class": "mobile_local_llm.service.MobileLocalLLMService",
+    "capabilities": [
+      "call_llm_structured",
+      "provider:mobile_local"
+    ]
+  }],
+  "capabilities": [
+    "call_llm_structured",
+    "provider:mobile_local",
+    "on_device_inference"
+  ],
+  "dependencies": {
+    "protocols": [
+      "ciris_engine.protocols.services.LLMService"
+    ],
+    "schemas": [
+      "ciris_engine.schemas.runtime.resources",
+      "ciris_engine.schemas.services.core"
+    ]
+  },
+  "exports": {
+    "adapter_class": "mobile_local_llm.adapter.MobileLocalLLMAdapter",
+    "service_class": "mobile_local_llm.service.MobileLocalLLMService",
+    "config": "mobile_local_llm.config.MobileLocalLLMConfig"
+  },
+  "configuration": {
+    "enabled": {
+      "type": "boolean",
+      "env": "CIRIS_MOBILE_LOCAL_LLM_ENABLED",
+      "default": true,
+      "description": "Master switch for the local inference adapter."
+    },
+    "model_variant": {
+      "type": "string",
+      "env": "CIRIS_MOBILE_LOCAL_LLM_MODEL",
+      "default": "gemma-4-e2b",
+      "description": "Gemma 4 variant to run on-device (gemma-4-e2b or gemma-4-e4b)."
+    },
+    "model_path": {
+      "type": "string",
+      "env": "CIRIS_MOBILE_LOCAL_LLM_MODEL_PATH",
+      "default": null,
+      "description": "Absolute path to the LiteRT-LM model bundle on disk."
+    },
+    "ios_model_path": {
+      "type": "string",
+      "env": "CIRIS_MOBILE_LOCAL_LLM_IOS_MODEL_PATH",
+      "default": null,
+      "description": "Expected path to the iOS Gemma 4 model bundle. When missing the adapter reports IOS_STUB so the wizard can show 'coming soon'."
+    },
+    "server_binary": {
+      "type": "string",
+      "env": "CIRIS_MOBILE_LOCAL_LLM_SERVER_BINARY",
+      "default": null,
+      "description": "Absolute path to the local inference server binary. If unset the adapter attaches to a pre-running server."
+    },
+    "host": {
+      "type": "string",
+      "env": "CIRIS_MOBILE_LOCAL_LLM_HOST",
+      "default": "127.0.0.1",
+      "description": "Host the local inference server binds to (loopback by default)."
+    },
+    "port": {
+      "type": "integer",
+      "env": "CIRIS_MOBILE_LOCAL_LLM_PORT",
+      "default": 8091,
+      "description": "Port the local inference server listens on."
+    },
+    "ready_timeout_seconds": {
+      "type": "float",
+      "env": "CIRIS_MOBILE_LOCAL_LLM_READY_TIMEOUT",
+      "default": 30.0,
+      "description": "How long to wait for the server to become healthy after start()."
+    },
+    "request_timeout_seconds": {
+      "type": "float",
+      "env": "CIRIS_MOBILE_LOCAL_LLM_REQUEST_TIMEOUT",
+      "default": 60.0,
+      "description": "Per-request inference timeout."
+    },
+    "health_interval_seconds": {
+      "type": "float",
+      "env": "CIRIS_MOBILE_LOCAL_LLM_HEALTH_INTERVAL",
+      "default": 15.0,
+      "description": "Interval between background health probes."
+    },
+    "min_total_ram_gb_e2b": {
+      "type": "float",
+      "env": "CIRIS_MOBILE_LOCAL_LLM_MIN_RAM_GB",
+      "default": 6.0,
+      "description": "Minimum total RAM (GB) required for the E2B tier."
+    },
+    "min_free_disk_gb": {
+      "type": "float",
+      "env": "CIRIS_MOBILE_LOCAL_LLM_MIN_FREE_DISK_GB",
+      "default": 3.0,
+      "description": "Minimum free disk space (GB) required before local inference starts."
+    },
+    "force_capability": {
+      "type": "string",
+      "env": "CIRIS_MOBILE_LOCAL_LLM_FORCE_CAPABILITY",
+      "default": null,
+      "description": "Override the capability probe with 'capable_e2b', 'capable_e4b', 'ios_stub', or 'incapable'. Testing only."
+    },
+    "allow_desktop": {
+      "type": "boolean",
+      "env": "CIRIS_MOBILE_LOCAL_LLM_ALLOW_DESKTOP",
+      "default": false,
+      "description": "Allow the adapter to run on desktop platforms for development."
+    }
+  },
+  "metadata": {
+    "provider": "mobile_local",
+    "platforms": ["android", "ios"],
+    "supported_architectures": ["arm64-v8a"],
+    "models": ["gemma-4-e2b", "gemma-4-e4b"],
+    "ios_status": "stub - adapter detects capable iOS hardware but stays unavailable until an adequate Gemma 4 LiteRT-LM model is shipped via the iOS bundle",
+    "notes": "Adapter owns the subprocess lifecycle of the inference server and reports unhealthy on weak devices so the LLM bus falls back to a hosted provider."
+  }
+}

--- a/ciris_adapters/mobile_local_llm/service.py
+++ b/ciris_adapters/mobile_local_llm/service.py
@@ -1,0 +1,352 @@
+"""
+LLM service backed by a local on-device inference server.
+
+This service implements :class:`LLMServiceProtocol` so that the CIRIS
+``LLMBus`` can route structured inference calls to it just like any other
+provider. It talks to an OpenAI-compatible HTTP server that the
+:class:`InferenceServerManager` either spawns or attaches to. When the
+device is not capable enough (per the Gemma 4 guidance) the service stays
+healthy=False so the bus falls back to a hosted LLM provider.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict, List, Optional, Tuple, Type
+
+from pydantic import BaseModel
+
+from ciris_engine.logic.services.base_service import BaseService
+from ciris_engine.protocols.services import LLMService as LLMServiceProtocol
+from ciris_engine.protocols.services.runtime.llm import MessageDict
+from ciris_engine.schemas.runtime.enums import ServiceType
+from ciris_engine.schemas.runtime.resources import ResourceUsage
+from ciris_engine.schemas.services.core import ServiceCapabilities, ServiceStatus
+
+from .capability import DeviceCapabilityReport, probe_device_capability
+from .config import MobileLocalLLMConfig, DeviceTier, ModelVariant
+from .inference_server import InferenceServerError, InferenceServerManager
+
+logger = logging.getLogger(__name__)
+
+
+class MobileLocalLLMService(BaseService, LLMServiceProtocol):
+    """Structured LLM provider backed by a local on-device server.
+
+    Why subclass :class:`BaseService`? We get consistent metrics, health
+    bookkeeping, and ``get_status()`` implementation for free, matching the
+    production LLM service and the mock LLM service.
+    """
+
+    def __init__(
+        self,
+        config: MobileLocalLLMConfig,
+        *,
+        server_manager: Optional[InferenceServerManager] = None,
+        capability_report: Optional[DeviceCapabilityReport] = None,
+    ) -> None:
+        super().__init__(service_name="MobileLocalLLMService", version="1.0.0")
+        self._config = config
+        self._server = server_manager or InferenceServerManager(config)
+        self._capability: Optional[DeviceCapabilityReport] = capability_report
+        self._available = False  # flips to True once server is up and variant is supported
+        self._started_at: Optional[float] = None
+
+        # Rollup metrics (reported via get_metrics()).
+        self._total_requests = 0
+        self._total_errors = 0
+        self._total_input_tokens = 0
+        self._total_output_tokens = 0
+
+    # ------------------------------------------------------------------
+    # BaseService wiring
+    # ------------------------------------------------------------------
+
+    def get_service_type(self) -> ServiceType:
+        return ServiceType.LLM
+
+    def _get_actions(self) -> List[str]:
+        return ["call_llm_structured"]
+
+    def _check_dependencies(self) -> bool:
+        # The only hard dependency is the inference server process; everything
+        # else is probed lazily during start().
+        return True
+
+    def _collect_custom_metrics(self) -> Dict[str, float]:
+        return {
+            "total_requests": float(self._total_requests),
+            "total_errors": float(self._total_errors),
+            "total_input_tokens": float(self._total_input_tokens),
+            "total_output_tokens": float(self._total_output_tokens),
+            "available": 1.0 if self._available else 0.0,
+        }
+
+    # ------------------------------------------------------------------
+    # Capability / configuration
+    # ------------------------------------------------------------------
+
+    @property
+    def capability_report(self) -> Optional[DeviceCapabilityReport]:
+        return self._capability
+
+    @property
+    def config(self) -> MobileLocalLLMConfig:
+        return self._config
+
+    @property
+    def available(self) -> bool:
+        """True when the local server is running and handling requests."""
+        return self._available
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Probe device capability, start the server, and become available.
+
+        This never raises on capability failure — it just stays unavailable.
+        That keeps the adapter safe to load on every device: weak phones
+        silently fall back to the hosted LLM bus provider.
+        """
+        await super().start()
+        self._started_at = time.time()
+
+        if not self._config.enabled:
+            logger.info("MobileLocalLLM: adapter disabled by config; staying unavailable")
+            return
+
+        if self._capability is None:
+            self._capability = probe_device_capability(self._config)
+
+        logger.info("MobileLocalLLM capability probe: %s", self._capability.summary())
+        for reason in self._capability.reasons:
+            logger.info("MobileLocalLLM capability reason: %s", reason)
+
+        if not self._capability.capable:
+            logger.warning(
+                "MobileLocalLLM: device not capable of local Gemma 4 inference; "
+                "the LLM bus will use hosted providers instead."
+            )
+            return
+
+        if not self._capability.can_run(self._config.model_variant):
+            logger.warning(
+                "MobileLocalLLM: device tier %s cannot safely run %s; staying unavailable",
+                self._capability.tier.value,
+                self._config.model_variant.value,
+            )
+            return
+
+        try:
+            await self._server.start()
+        except InferenceServerError as exc:
+            logger.error("MobileLocalLLM: failed to start local inference server: %s", exc)
+            self._available = False
+            return
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("MobileLocalLLM: unexpected error starting server: %s", exc)
+            self._available = False
+            return
+
+        self._available = True
+        logger.info(
+            "MobileLocalLLM ready: variant=%s tier=%s endpoint=%s",
+            self._config.model_variant.value,
+            self._capability.tier.value,
+            self._config.base_url(),
+        )
+
+    async def stop(self) -> None:
+        """Tear down the local server and mark ourselves unavailable."""
+        self._available = False
+        try:
+            await self._server.stop()
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("MobileLocalLLM: error stopping inference server: %s", exc)
+        await super().stop()
+
+    # ------------------------------------------------------------------
+    # Health / status
+    # ------------------------------------------------------------------
+
+    async def is_healthy(self) -> bool:
+        """Healthy only when we are available AND the server responds."""
+        if not self._available:
+            return False
+        try:
+            ok = await self._server.health_check()
+        except Exception:  # pragma: no cover - defensive
+            ok = False
+        if not ok:
+            # Health probe failed — mark unavailable so the LLM bus routes away
+            # from us until the adapter's lifecycle loop restarts the server.
+            self._available = False
+        return ok
+
+    def get_capabilities(self) -> ServiceCapabilities:
+        return ServiceCapabilities(
+            service_name="MobileLocalLLMService",
+            actions=["call_llm_structured"],
+            version="1.0.0",
+        )
+
+    def get_status(self) -> ServiceStatus:
+        uptime = time.time() - self._started_at if self._started_at else 0.0
+        return ServiceStatus(
+            service_name="MobileLocalLLMService",
+            service_type="llm",
+            is_healthy=self._available,
+            uptime_seconds=uptime,
+        )
+
+    async def get_metrics(self) -> Dict[str, float]:
+        """v1.4.3-compliant LLM metrics."""
+        uptime = time.time() - self._started_at if self._started_at else 0.0
+        total_tokens = self._total_input_tokens + self._total_output_tokens
+        return {
+            "uptime_seconds": uptime,
+            "request_count": float(self._total_requests),
+            "error_count": float(self._total_errors),
+            "error_rate": self._total_errors / max(1, self._total_requests),
+            "llm_requests_total": float(self._total_requests),
+            "llm_tokens_input": float(self._total_input_tokens),
+            "llm_tokens_output": float(self._total_output_tokens),
+            "llm_tokens_total": float(total_tokens),
+            # Local inference has no cloud cost; carbon/energy are left to
+            # the on-device telemetry collector which knows the actual SoC.
+            "llm_cost_cents": 0.0,
+            "llm_errors_total": float(self._total_errors),
+            "llm_uptime_seconds": uptime,
+            "local_inference_available": 1.0 if self._available else 0.0,
+        }
+
+    # ------------------------------------------------------------------
+    # LLM protocol
+    # ------------------------------------------------------------------
+
+    async def call_llm_structured(
+        self,
+        messages: List[MessageDict],
+        response_model: Type[BaseModel],
+        max_tokens: int = 1024,
+        temperature: float = 0.0,
+        thought_id: Optional[str] = None,
+        task_id: Optional[str] = None,
+    ) -> Tuple[BaseModel, ResourceUsage]:
+        """Run a structured LLM call against the on-device server.
+
+        Uses ``instructor`` + an OpenAI-compatible ``AsyncOpenAI`` client so
+        that the rest of CIRIS does not have to care where the model lives.
+        """
+        if not self._available:
+            raise RuntimeError(
+                "MobileLocalLLMService is not available; LLM bus should route to the next provider"
+            )
+
+        self._total_requests += 1
+        try:
+            parsed = await self._dispatch_structured(
+                messages=messages,
+                response_model=response_model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+            )
+        except Exception:
+            self._total_errors += 1
+            # Any inference failure means the server is suspect; drop to
+            # unavailable and let the bus retry against the next provider.
+            self._available = False
+            raise
+
+        # Cheap token estimate for resource accounting. Real servers return
+        # usage details but we do not require them — the LLM bus only needs
+        # token counts for budgeting / telemetry.
+        input_tokens = _estimate_input_tokens(messages)
+        output_tokens = max(1, max_tokens // 4)
+        self._total_input_tokens += input_tokens
+        self._total_output_tokens += output_tokens
+
+        usage = ResourceUsage(
+            tokens_used=input_tokens + output_tokens,
+            tokens_input=input_tokens,
+            tokens_output=output_tokens,
+            cost_cents=0.0,  # local inference is free at the billing layer
+            energy_kwh=_estimate_energy_kwh(input_tokens + output_tokens),
+            carbon_grams=_estimate_carbon_grams(input_tokens + output_tokens),
+            model_used=f"{self._config.model_variant.value} (mobile-local)",
+        )
+        return parsed, usage
+
+    async def _dispatch_structured(
+        self,
+        *,
+        messages: List[MessageDict],
+        response_model: Type[BaseModel],
+        max_tokens: int,
+        temperature: float,
+    ) -> BaseModel:
+        """Actually call the on-device OpenAI-compatible server.
+
+        We import ``openai`` and ``instructor`` lazily so that devices that
+        never load this adapter do not pay the import cost.
+        """
+        try:
+            import instructor  # type: ignore[import-not-found]
+            from openai import AsyncOpenAI  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover - dependency guard
+            raise RuntimeError(
+                "MobileLocalLLMService requires the 'openai' and 'instructor' packages"
+            ) from exc
+
+        client = AsyncOpenAI(
+            base_url=self._config.base_url(),
+            api_key="local",  # loopback server ignores the token
+            timeout=self._config.request_timeout_seconds,
+        )
+        patched = instructor.patch(client)
+
+        response = await patched.chat.completions.create(
+            model=self._config.model_variant.value,
+            messages=list(messages),
+            response_model=response_model,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        return response
+
+
+# ---------------------------------------------------------------------------
+# Small helpers (kept module-level to simplify testing)
+# ---------------------------------------------------------------------------
+
+
+def _estimate_input_tokens(messages: List[MessageDict]) -> int:
+    """Rough ~1.3 tokens / word heuristic, matching MockLLMService."""
+    words = 0
+    for msg in messages:
+        content: Any = msg.get("content", "")
+        if isinstance(content, str):
+            words += len(content.split())
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    words += len(str(block.get("text", "")).split())
+    return max(1, int(words * 1.3))
+
+
+def _estimate_energy_kwh(total_tokens: int) -> float:
+    # Mobile SoC inference is more efficient than datacenter inference per
+    # token; ~0.00002 kWh/1k tokens is a reasonable Gemma-4-E2B estimate.
+    return total_tokens * 0.00002 / 1000.0
+
+
+def _estimate_carbon_grams(total_tokens: int) -> float:
+    # Using the same on-device factor; callers can refine with the real
+    # grid intensity reported by the mobile telemetry collector.
+    return _estimate_energy_kwh(total_tokens) * 500.0
+
+
+__all__ = ["MobileLocalLLMService"]

--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -3,11 +3,11 @@
 from pathlib import Path
 
 # Version information
-CIRIS_VERSION = "2.4.3-stable"
+CIRIS_VERSION = "2.4.4-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
 CIRIS_VERSION_MINOR = 4
-CIRIS_VERSION_PATCH = 3
+CIRIS_VERSION_PATCH = 4
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/ciris_engine/logic/adapters/api/routes/setup/complete.py
+++ b/ciris_engine/logic/adapters/api/routes/setup/complete.py
@@ -547,9 +547,15 @@ def _save_setup_config(setup: SetupCompleteRequest) -> Path:
         Path where config was saved
     """
     llm_base_url = _get_provider_base_url(setup.llm_provider, setup.llm_base_url) or ""
+
+    # For local providers, use "local" as placeholder API key if none provided
+    llm_api_key = setup.llm_api_key
+    if not llm_api_key and setup.llm_provider in ("local", "local_inference"):
+        llm_api_key = "local"
+
     config_path = create_env_file(
         llm_provider=setup.llm_provider,
-        llm_api_key=setup.llm_api_key,
+        llm_api_key=llm_api_key,
         llm_base_url=llm_base_url,
         llm_model=setup.llm_model or "",
         agent_port=setup.agent_port,

--- a/ciris_engine/logic/adapters/api/routes/setup/llm_discovery.py
+++ b/ciris_engine/logic/adapters/api/routes/setup/llm_discovery.py
@@ -191,3 +191,184 @@ def _detect_server_type_from_response(url: str, data: Dict[str, Any]) -> str:
 
     # Default to generic llama.cpp/OpenAI-compatible
     return "llama_cpp"
+
+
+async def start_local_llm_server(
+    server_type: str = "llama_cpp",
+    model: str = "gemma-4-e2b",
+    port: int = 8080,
+) -> Dict[str, Any]:
+    """Start a local LLM inference server.
+
+    Attempts to start llama.cpp or Ollama in the background with the
+    specified model. The server runs with keepalive enabled.
+
+    Args:
+        server_type: "llama_cpp" or "ollama"
+        model: Model to load (e.g., "gemma-4-e2b")
+        port: Port to listen on
+
+    Returns:
+        Dict with success, server_url, pid, message, estimated_ready_seconds
+    """
+    import os
+    import shutil
+    import subprocess
+
+    logger.info(f"[START_LOCAL_SERVER] Starting {server_type} on port {port} with model {model}")
+
+    # Find the server binary
+    if server_type == "ollama":
+        binary = shutil.which("ollama")
+        if not binary:
+            return {
+                "success": False,
+                "message": "Ollama not found. Install from https://ollama.ai",
+                "estimated_ready_seconds": 0,
+            }
+
+        # Start Ollama serve in background
+        try:
+            env = os.environ.copy()
+            env["OLLAMA_HOST"] = f"127.0.0.1:{port}"
+
+            process = subprocess.Popen(
+                [binary, "serve"],
+                env=env,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,  # Detach from parent
+            )
+
+            return {
+                "success": True,
+                "server_url": f"http://127.0.0.1:{port}",
+                "pid": process.pid,
+                "message": f"Ollama server started on port {port}. Pull model with: ollama pull {model}",
+                "estimated_ready_seconds": 30,
+            }
+        except Exception as e:
+            logger.error(f"[START_LOCAL_SERVER] Failed to start Ollama: {e}")
+            return {
+                "success": False,
+                "message": f"Failed to start Ollama: {str(e)}",
+                "estimated_ready_seconds": 0,
+            }
+
+    elif server_type == "llama_cpp":
+        # Try common llama.cpp server binary names
+        binary = None
+        for name in ["llama-server", "llama.cpp-server", "server"]:
+            binary = shutil.which(name)
+            if binary:
+                break
+
+        # Also check common installation paths
+        if not binary:
+            common_paths = [
+                "/usr/local/bin/llama-server",
+                "/opt/llama.cpp/build/bin/llama-server",
+                os.path.expanduser("~/.local/bin/llama-server"),
+            ]
+            for path in common_paths:
+                if os.path.isfile(path) and os.access(path, os.X_OK):
+                    binary = path
+                    break
+
+        if not binary:
+            return {
+                "success": False,
+                "message": "llama.cpp server not found. Build from https://github.com/ggerganov/llama.cpp",
+                "estimated_ready_seconds": 0,
+            }
+
+        # Find model file
+        model_file = _find_model_file(model)
+        if not model_file:
+            return {
+                "success": False,
+                "message": f"Model file for '{model}' not found. Download GGUF from HuggingFace.",
+                "estimated_ready_seconds": 0,
+            }
+
+        # Start llama.cpp server
+        try:
+            cmd = [
+                binary,
+                "--model", model_file,
+                "--host", "127.0.0.1",
+                "--port", str(port),
+                "--ctx-size", "8192",  # Reasonable context for Gemma4
+                "--n-gpu-layers", "99",  # Use GPU if available
+            ]
+
+            process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,  # Detach from parent
+            )
+
+            return {
+                "success": True,
+                "server_url": f"http://127.0.0.1:{port}",
+                "pid": process.pid,
+                "message": f"llama.cpp server started with {model}. Loading model...",
+                "estimated_ready_seconds": 60,  # Model loading takes time
+            }
+        except Exception as e:
+            logger.error(f"[START_LOCAL_SERVER] Failed to start llama.cpp: {e}")
+            return {
+                "success": False,
+                "message": f"Failed to start llama.cpp: {str(e)}",
+                "estimated_ready_seconds": 0,
+            }
+
+    else:
+        return {
+            "success": False,
+            "message": f"Unknown server type: {server_type}. Use 'llama_cpp' or 'ollama'.",
+            "estimated_ready_seconds": 0,
+        }
+
+
+def _find_model_file(model: str) -> Optional[str]:
+    """Find a GGUF model file on disk.
+
+    Searches common model directories for the specified model.
+    """
+    import os
+    from pathlib import Path
+
+    # Map model names to file patterns
+    model_patterns = {
+        "gemma-4-e2b": ["gemma-4*-e2b*.gguf", "gemma-2*-e2b*.gguf", "gemma*e2b*.gguf"],
+        "gemma-4-e4b": ["gemma-4*-e4b*.gguf", "gemma-2*-e4b*.gguf", "gemma*e4b*.gguf"],
+    }
+
+    patterns = model_patterns.get(model, [f"*{model}*.gguf"])
+
+    # Common model directories
+    search_dirs = [
+        Path.home() / ".cache" / "llama.cpp",
+        Path.home() / ".local" / "share" / "llama.cpp" / "models",
+        Path.home() / "models",
+        Path("/usr/share/llama.cpp/models"),
+        Path("/opt/models"),
+    ]
+
+    # Add CIRIS model directory
+    ciris_home = os.environ.get("CIRIS_HOME")
+    if ciris_home:
+        search_dirs.insert(0, Path(ciris_home) / "models")
+
+    for search_dir in search_dirs:
+        if not search_dir.exists():
+            continue
+        for pattern in patterns:
+            matches = list(search_dir.glob(pattern))
+            if matches:
+                # Return the first match
+                return str(matches[0])
+
+    return None

--- a/ciris_engine/logic/adapters/api/routes/setup/llm_discovery.py
+++ b/ciris_engine/logic/adapters/api/routes/setup/llm_discovery.py
@@ -1,0 +1,193 @@
+"""Local LLM Server discovery via hostname probing and port scanning.
+
+Discovers local inference servers (Ollama, llama.cpp, vLLM, LM Studio, LocalAI)
+on the network by probing common hostnames and ports.
+"""
+
+import asyncio
+import logging
+import socket
+from typing import Any, Dict, List, Optional, Tuple
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Hostnames to probe with their likely ports
+PROBE_HOSTNAMES: List[Tuple[str, List[int]]] = [
+    ("jetson.local", [8080, 11434]),  # NVIDIA Jetson with llama.cpp or Ollama
+    ("ollama.local", [11434]),  # Dedicated Ollama server
+    ("inference.local", [8080, 8000]),  # Generic inference server
+    ("llm.local", [11434, 8080]),  # Generic LLM server
+    ("lmstudio.local", [1234]),  # LM Studio server
+    ("vllm.local", [8000]),  # vLLM server
+    ("localai.local", [8080]),  # LocalAI server
+]
+
+# Localhost ports to scan (always checked)
+LOCALHOST_PORTS: List[Tuple[int, str]] = [
+    (11434, "ollama"),  # Ollama default
+    (1234, "lmstudio"),  # LM Studio default
+    (8000, "vllm"),  # vLLM default
+    (8080, "llama_cpp"),  # llama.cpp / LocalAI default
+]
+
+# Timeout for individual probes
+PROBE_TIMEOUT = 2.0
+
+
+async def discover_local_llm_servers(
+    timeout_seconds: float = 5.0,
+    include_localhost: bool = True,
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Discover local LLM inference servers on the network.
+
+    Uses hostname probing and port scanning to find running LLM servers.
+
+    Args:
+        timeout_seconds: Total timeout for all discovery operations
+        include_localhost: Whether to probe localhost ports
+
+    Returns:
+        Tuple of (discovered_servers, discovery_methods_used)
+    """
+    discovered: List[Dict[str, Any]] = []
+    methods_used: List[str] = []
+    seen_urls: set[str] = set()
+
+    async def add_if_valid(url: str, hostname: str, port: int) -> None:
+        """Probe a URL and add to discovered if it's a valid LLM server."""
+        if url in seen_urls:
+            return
+        seen_urls.add(url)
+
+        result = await _probe_llm_endpoint(url)
+        if result:
+            server_type, model_count, models = result
+            # Resolve hostname to IP for reliability
+            try:
+                ip = socket.gethostbyname(hostname)
+            except socket.gaierror:
+                ip = hostname
+
+            server_id = f"{ip}_{port}"
+            label = f"{hostname}:{port}"
+            if models:
+                label += f" ({models[0]})" if len(models) == 1 else f" ({len(models)} models)"
+
+            discovered.append({
+                "id": server_id,
+                "label": label,
+                "url": f"http://{ip}:{port}",
+                "server_type": server_type,
+                "model_count": model_count,
+                "models": models,
+                "metadata": {
+                    "hostname": hostname,
+                    "ip": ip,
+                    "port": port,
+                    "source": "hostname_probe" if hostname != "localhost" else "localhost_scan",
+                },
+            })
+
+    # Probe hostnames in parallel
+    tasks = []
+    for hostname, ports in PROBE_HOSTNAMES:
+        for port in ports:
+            url = f"http://{hostname}:{port}"
+            tasks.append(add_if_valid(url, hostname, port))
+    methods_used.append("hostname_probe")
+
+    # Probe localhost ports
+    if include_localhost:
+        for port, _ in LOCALHOST_PORTS:
+            url = f"http://localhost:{port}"
+            tasks.append(add_if_valid(url, "localhost", port))
+        methods_used.append("localhost_scan")
+
+    # Run all probes with overall timeout
+    try:
+        await asyncio.wait_for(
+            asyncio.gather(*tasks, return_exceptions=True),
+            timeout=timeout_seconds,
+        )
+    except asyncio.TimeoutError:
+        logger.warning("[LLM_DISCOVERY] Overall timeout reached during discovery")
+
+    logger.info(f"[LLM_DISCOVERY] Discovered {len(discovered)} LLM servers")
+    return discovered, methods_used
+
+
+async def _probe_llm_endpoint(url: str) -> Optional[Tuple[str, int, List[str]]]:
+    """Probe an endpoint to determine if it's an LLM server.
+
+    Returns:
+        Tuple of (server_type, model_count, model_names) if valid, None otherwise
+    """
+    async with httpx.AsyncClient(timeout=PROBE_TIMEOUT) as client:
+        # Try Ollama /api/tags first
+        try:
+            response = await client.get(f"{url}/api/tags")
+            if response.status_code == 200:
+                data = response.json()
+                models = data.get("models", [])
+                model_names = [m.get("name", "unknown") for m in models]
+                return ("ollama", len(models), model_names)
+        except Exception:
+            pass
+
+        # Try OpenAI-compatible /v1/models
+        try:
+            response = await client.get(f"{url}/v1/models")
+            if response.status_code == 200:
+                data = response.json()
+                models = data.get("data", [])
+                model_names = [m.get("id", "unknown") for m in models]
+
+                # Detect server type by response characteristics
+                server_type = _detect_server_type_from_response(url, data)
+                return (server_type, len(models), model_names)
+        except Exception:
+            pass
+
+        # Try /models (some servers use this)
+        try:
+            response = await client.get(f"{url}/models")
+            if response.status_code == 200:
+                data = response.json()
+                if isinstance(data, list):
+                    model_names = [m.get("id", str(m)) if isinstance(m, dict) else str(m) for m in data]
+                    return ("openai_compatible", len(data), model_names)
+                elif isinstance(data, dict) and "data" in data:
+                    models = data.get("data", [])
+                    model_names = [m.get("id", "unknown") for m in models]
+                    return ("openai_compatible", len(models), model_names)
+        except Exception:
+            pass
+
+    return None
+
+
+def _detect_server_type_from_response(url: str, data: Dict[str, Any]) -> str:
+    """Detect server type from response data and URL patterns."""
+    # Check URL port for hints
+    if ":11434" in url:
+        return "ollama"
+    if ":1234" in url:
+        return "lmstudio"
+    if ":8000" in url:
+        return "vllm"
+
+    # Check response for hints
+    models = data.get("data", [])
+    if models:
+        first_model = models[0] if models else {}
+        # vLLM includes 'max_model_len' in model info
+        if "max_model_len" in first_model:
+            return "vllm"
+        # LM Studio includes 'publisher' field
+        if "publisher" in first_model:
+            return "lmstudio"
+
+    # Default to generic llama.cpp/OpenAI-compatible
+    return "llama_cpp"

--- a/ciris_engine/logic/adapters/api/routes/setup/llm_routes.py
+++ b/ciris_engine/logic/adapters/api/routes/setup/llm_routes.py
@@ -15,7 +15,14 @@ from .._common import RESPONSES_404_500, RESPONSES_500
 from .dependencies import SetupOnlyDep
 from .helpers import _is_setup_allowed_without_auth
 from .llm_validation import _list_models_for_provider, _validate_llm_connection
-from .models import ListModelsResponse, LLMValidationRequest, LLMValidationResponse
+from .models import (
+    DiscoverLocalLLMRequest,
+    DiscoverLocalLLMResponse,
+    DiscoveredLLMServer,
+    ListModelsResponse,
+    LLMValidationRequest,
+    LLMValidationResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -170,3 +177,52 @@ async def list_models(config: LLMValidationRequest) -> SuccessResponse[ListModel
     """
     result = await _list_models_for_provider(config)
     return SuccessResponse(data=result)
+
+
+@router.post("/discover-local-llm", dependencies=[SetupOrAuthDep])
+async def discover_local_llm(
+    request: DiscoverLocalLLMRequest = DiscoverLocalLLMRequest(),
+) -> SuccessResponse[DiscoverLocalLLMResponse]:
+    """Discover local LLM inference servers on the network.
+
+    Uses hostname probing and localhost port scanning to find running
+    LLM servers (Ollama, llama.cpp, vLLM, LM Studio, LocalAI).
+
+    Probes common hostnames:
+    - jetson.local (NVIDIA Jetson with Ollama/llama.cpp)
+    - ollama.local, llm.local, inference.local, lmstudio.local, vllm.local
+
+    Probes localhost ports:
+    - 11434 (Ollama), 1234 (LM Studio), 8000 (vLLM), 8080 (llama.cpp/LocalAI)
+
+    Returns discovered servers with model counts and names.
+    Accessible without auth during first-run, or with auth after setup.
+    """
+    from .llm_discovery import discover_local_llm_servers
+
+    try:
+        servers_data, methods = await discover_local_llm_servers(
+            timeout_seconds=request.timeout_seconds,
+            include_localhost=request.include_localhost,
+        )
+
+        # Convert to Pydantic models
+        servers = [DiscoveredLLMServer(**s) for s in servers_data]
+
+        return SuccessResponse(
+            data=DiscoverLocalLLMResponse(
+                servers=servers,
+                total_count=len(servers),
+                discovery_methods=methods,
+            )
+        )
+    except Exception as e:
+        logger.error(f"[DISCOVER_LOCAL_LLM] Discovery failed: {e}")
+        return SuccessResponse(
+            data=DiscoverLocalLLMResponse(
+                servers=[],
+                total_count=0,
+                discovery_methods=[],
+                error=str(e),
+            )
+        )

--- a/ciris_engine/logic/adapters/api/routes/setup/llm_routes.py
+++ b/ciris_engine/logic/adapters/api/routes/setup/llm_routes.py
@@ -22,6 +22,8 @@ from .models import (
     ListModelsResponse,
     LLMValidationRequest,
     LLMValidationResponse,
+    StartLocalServerRequest,
+    StartLocalServerResponse,
 )
 
 logger = logging.getLogger(__name__)
@@ -224,5 +226,56 @@ async def discover_local_llm(
                 total_count=0,
                 discovery_methods=[],
                 error=str(e),
+            )
+        )
+
+
+@router.post("/start-local-server", dependencies=[SetupOrAuthDep])
+async def start_local_server(
+    request: StartLocalServerRequest = StartLocalServerRequest(),
+) -> SuccessResponse[StartLocalServerResponse]:
+    """Start a local LLM inference server.
+
+    Used when the device is capable of running local inference but no server
+    is currently detected. Starts llama.cpp or Ollama in the background.
+
+    This operation may take 30-90 seconds as the model loads into memory.
+    The server runs with a keepalive and will stay running until shutdown.
+
+    After starting, call /discover-local-llm to find the running server.
+
+    Accessible without auth during first-run, or with auth after setup.
+    """
+    from .llm_discovery import start_local_llm_server
+
+    try:
+        result = await start_local_llm_server(
+            server_type=request.server_type,
+            model=request.model,
+            port=request.port,
+        )
+
+        return SuccessResponse(
+            data=StartLocalServerResponse(
+                success=result.get("success", False),
+                server_url=result.get("server_url"),
+                server_type=request.server_type,
+                model=request.model,
+                pid=result.get("pid"),
+                message=result.get("message", "Unknown status"),
+                estimated_ready_seconds=result.get("estimated_ready_seconds", 60),
+            )
+        )
+    except Exception as e:
+        logger.error(f"[START_LOCAL_SERVER] Failed to start server: {e}")
+        return SuccessResponse(
+            data=StartLocalServerResponse(
+                success=False,
+                server_url=None,
+                server_type=request.server_type,
+                model=request.model,
+                pid=None,
+                message=f"Failed to start server: {str(e)}",
+                estimated_ready_seconds=0,
             )
         )

--- a/ciris_engine/logic/adapters/api/routes/setup/llm_validation.py
+++ b/ciris_engine/logic/adapters/api/routes/setup/llm_validation.py
@@ -158,7 +158,7 @@ def _validate_api_key_for_provider(config: LLMValidationRequest) -> Optional[LLM
                 message="Invalid API key",
                 error="OpenAI requires a valid API key starting with 'sk-'",
             )
-    elif config.provider != "local" and not config.api_key:
+    elif config.provider not in ("local", "local_inference") and not config.api_key:
         # Other non-local providers need API key
         return LLMValidationResponse(valid=False, message="API key required", error="This provider requires an API key")
     return None

--- a/ciris_engine/logic/adapters/api/routes/setup/models.py
+++ b/ciris_engine/logic/adapters/api/routes/setup/models.py
@@ -283,6 +283,44 @@ class DiscoverLocalLLMResponse(BaseModel):
     error: Optional[str] = Field(None, description="Error message if discovery partially failed")
 
 
+class StartLocalServerRequest(BaseModel):
+    """Request to start a local LLM inference server.
+
+    Used when the device is capable of running local inference but no server
+    is currently detected. The server will be started in the background.
+    """
+
+    server_type: str = Field(
+        default="llama_cpp",
+        description="Server type to start: llama_cpp, ollama",
+    )
+    model: str = Field(
+        default="gemma-4-e2b",
+        description="Model to load: gemma-4-e2b, gemma-4-e4b",
+    )
+    port: int = Field(
+        default=8080,
+        ge=1024,
+        le=65535,
+        description="Port for the server to listen on",
+    )
+
+
+class StartLocalServerResponse(BaseModel):
+    """Response from starting a local LLM server."""
+
+    success: bool = Field(..., description="Whether the server started successfully")
+    server_url: Optional[str] = Field(None, description="URL of the running server")
+    server_type: str = Field(..., description="Type of server started")
+    model: str = Field(..., description="Model loaded")
+    pid: Optional[int] = Field(None, description="Process ID of the server")
+    message: str = Field(..., description="Status message")
+    estimated_ready_seconds: int = Field(
+        default=60,
+        description="Estimated seconds until server is ready for requests",
+    )
+
+
 class SetupCompleteRequest(BaseModel):
     """Request to complete setup."""
 

--- a/ciris_engine/logic/adapters/api/routes/setup/models.py
+++ b/ciris_engine/logic/adapters/api/routes/setup/models.py
@@ -3,9 +3,10 @@
 This module contains all request/response schemas used by the setup endpoints.
 """
 
+import os
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from ciris_engine.config.model_capabilities import ModelCapabilities
 
@@ -254,6 +255,34 @@ class ListModelsResponse(BaseModel):
     )
 
 
+class DiscoveredLLMServer(BaseModel):
+    """A discovered local LLM inference server."""
+
+    id: str = Field(..., description="Unique server ID (ip_port format)")
+    label: str = Field(..., description="Display label (e.g., 'jetson.local:8080 (Gemma 4)')")
+    url: str = Field(..., description="Server URL (http://ip:port)")
+    server_type: str = Field(..., description="Server type: ollama, llama_cpp, vllm, lmstudio, localai, openai_compatible")
+    model_count: int = Field(default=0, description="Number of models available")
+    models: List[str] = Field(default_factory=list, description="Model names available on server")
+    metadata: Dict[str, Any] = Field(default_factory=dict, description="Additional metadata (hostname, ip, port, source)")
+
+
+class DiscoverLocalLLMRequest(BaseModel):
+    """Request to discover local LLM servers."""
+
+    timeout_seconds: float = Field(default=5.0, ge=1.0, le=30.0, description="Discovery timeout")
+    include_localhost: bool = Field(default=True, description="Include localhost port scanning")
+
+
+class DiscoverLocalLLMResponse(BaseModel):
+    """Response from local LLM server discovery."""
+
+    servers: List[DiscoveredLLMServer] = Field(default_factory=list, description="Discovered servers")
+    total_count: int = Field(default=0, description="Total servers found")
+    discovery_methods: List[str] = Field(default_factory=list, description="Methods used (hostname_probe, localhost_scan)")
+    error: Optional[str] = Field(None, description="Error message if discovery partially failed")
+
+
 class SetupCompleteRequest(BaseModel):
     """Request to complete setup."""
 
@@ -276,7 +305,7 @@ class SetupCompleteRequest(BaseModel):
     adapter_config: Dict[str, Any] = Field(default_factory=dict, description="Adapter-specific configuration")
 
     # User Configuration - Dual Password Support
-    admin_username: str = Field(default="admin", description="New user's username")
+    admin_username: str = Field(default="owner", description="New user's username")
     admin_password: Optional[str] = Field(
         None,
         description="New user's password (min 8 characters). Optional for OAuth users - if not provided, a random password is generated and password auth is disabled for this user.",
@@ -353,6 +382,18 @@ class SetupCompleteRequest(BaseModel):
     # CIRISVerify (optional, set by node flow)
     verify_binary_path: Optional[str] = Field(None, description="Path to CIRISVerify binary")
     verify_require_hardware: bool = Field(default=False, description="Require hardware attestation for CIRISVerify")
+
+    @field_validator("admin_username")
+    @classmethod
+    def validate_admin_username(cls, v: str) -> str:
+        """Block 'admin' username in production - reserved for testing only."""
+        if v.lower() == "admin":
+            testing_mode = os.environ.get("CIRIS_TESTING_MODE", "").lower() in ("true", "1", "yes")
+            if not testing_mode:
+                raise ValueError(
+                    "Username 'admin' is reserved for testing. Please choose a different username."
+                )
+        return v
 
 
 class SetupConfigResponse(BaseModel):

--- a/ciris_engine/logic/adapters/api/routes/system/adapters.py
+++ b/ciris_engine/logic/adapters/api/routes/system/adapters.py
@@ -7,11 +7,19 @@ Provides functionality for listing, loading, unloading, and managing adapters.
 import logging
 import re
 from datetime import datetime, timezone
-from typing import Annotated, Any, Dict, List, Optional
+from typing import Annotated, Any, Dict, List, Optional, Union
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Request
 from pydantic import ValidationError
 
+from ciris_engine.schemas.adapters.discovery import (
+    AdapterDiscoveryReport,
+    EnrichmentCacheResponse,
+    EnrichmentCacheStats,
+    InstallRequest,
+    InstallResponse,
+    RecheckEligibilityResponse,
+)
 from ciris_engine.schemas.api.responses import SuccessResponse
 from ciris_engine.schemas.runtime.adapter_management import (
     AdapterConfig,
@@ -352,7 +360,7 @@ async def remove_persisted_configuration(
 async def list_available_adapters(
     request: Request,
     auth: Annotated[AuthContext, Depends(require_observer)],
-) -> SuccessResponse[Dict[str, Any]]:
+) -> SuccessResponse[AdapterDiscoveryReport]:
     """
     List all discovered adapters with eligibility status.
 
@@ -365,7 +373,7 @@ async def list_available_adapters(
         discovery = AdapterDiscoveryService()
         report = await discovery.get_discovery_report()
 
-        return SuccessResponse(data=report.model_dump())
+        return SuccessResponse(data=report)
 
     except Exception as e:
         logger.error(f"Error getting adapter availability: {e}")
@@ -383,8 +391,8 @@ async def install_adapter_dependencies(
     adapter_name: str,
     request: Request,
     auth: Annotated[AuthContext, Depends(require_admin)],
-    body: Annotated[Dict[str, Any], Body()] = {},
-) -> SuccessResponse[Dict[str, Any]]:
+    body: Annotated[Optional[InstallRequest], Body()] = None,
+) -> SuccessResponse[InstallResponse]:
     """
     Install missing dependencies for an adapter.
 
@@ -395,11 +403,11 @@ async def install_adapter_dependencies(
     """
     from ciris_engine.logic.services.tool.discovery_service import AdapterDiscoveryService
     from ciris_engine.logic.services.tool.installer import ToolInstaller
-    from ciris_engine.schemas.adapters.discovery import InstallResponse
 
     try:
-        dry_run = body.get("dry_run", False)
-        install_step_id = body.get("install_step_id")
+        # Handle None body (default empty request)
+        if body is None:
+            body = InstallRequest()
 
         discovery = AdapterDiscoveryService()
         status = await discovery.get_adapter_eligibility(adapter_name)
@@ -414,7 +422,7 @@ async def install_adapter_dependencies(
                     message=f"Adapter '{adapter_name}' is already eligible",
                     now_eligible=True,
                     eligibility=status,
-                ).model_dump()
+                )
             )
 
         if not status.can_install or not status.install_hints:
@@ -424,24 +432,24 @@ async def install_adapter_dependencies(
                     message=f"No installation hints available for '{adapter_name}'",
                     now_eligible=False,
                     eligibility=status,
-                ).model_dump()
+                )
             )
 
         # Find specific step if requested, otherwise use all hints
         hints = status.install_hints
-        if install_step_id:
-            hints = [h for h in hints if h.id == install_step_id]
+        if body.install_step_id:
+            hints = [h for h in hints if h.id == body.install_step_id]
             if not hints:
                 return SuccessResponse(
                     data=InstallResponse(
                         success=False,
-                        message=f"Install step '{install_step_id}' not found",
+                        message=f"Install step '{body.install_step_id}' not found",
                         now_eligible=False,
-                    ).model_dump()
+                    )
                 )
 
         # Run installation
-        installer = ToolInstaller(dry_run=dry_run)
+        installer = ToolInstaller(dry_run=body.dry_run)
         install_result = await installer.install_first_applicable(hints)
 
         # Recheck eligibility after installation
@@ -454,7 +462,7 @@ async def install_adapter_dependencies(
                 installed_binaries=install_result.binaries_installed or [],
                 now_eligible=new_status.eligible if new_status else False,
                 eligibility=new_status,
-            ).model_dump()
+            )
         )
 
     except HTTPException:
@@ -475,7 +483,7 @@ async def recheck_adapter_eligibility(
     adapter_name: str,
     request: Request,
     auth: Annotated[AuthContext, Depends(require_observer)],
-) -> SuccessResponse[Dict[str, Any]]:
+) -> SuccessResponse[RecheckEligibilityResponse]:
     """
     Recheck eligibility for an adapter.
 
@@ -483,7 +491,6 @@ async def recheck_adapter_eligibility(
     adapter is now eligible.
     """
     from ciris_engine.logic.services.tool.discovery_service import AdapterDiscoveryService
-    from ciris_engine.schemas.adapters.discovery import RecheckEligibilityResponse
 
     try:
         discovery = AdapterDiscoveryService()
@@ -501,7 +508,7 @@ async def recheck_adapter_eligibility(
                 missing_env_vars=status.missing_env_vars,
                 missing_config=status.missing_config,
                 can_install=status.can_install,
-            ).model_dump()
+            )
         )
 
     except HTTPException:
@@ -742,7 +749,7 @@ async def get_context_enrichment_cache(
     request: Request,
     auth: Annotated[AuthContext, Depends(require_observer)],
     refresh: bool = False,
-) -> SuccessResponse[Dict[str, Any]]:
+) -> SuccessResponse[EnrichmentCacheResponse]:
     """
     Get context enrichment cache data from adapters.
 
@@ -769,16 +776,16 @@ async def get_context_enrichment_cache(
         cache_stats = cache.stats
 
         return SuccessResponse(
-            data={
-                "entries": enrichment_data,
-                "stats": {
-                    "entry_count": cache_stats.get("entries", 0),
-                    "hits": cache_stats.get("hits", 0),
-                    "misses": cache_stats.get("misses", 0),
-                    "hit_rate_pct": cache_stats.get("hit_rate_pct", 0.0),
-                    "startup_populated": cache_stats.get("startup_populated", False),
-                },
-            }
+            data=EnrichmentCacheResponse(
+                entries=enrichment_data,
+                stats=EnrichmentCacheStats(
+                    entry_count=cache_stats.get("entries", 0),
+                    hits=cache_stats.get("hits", 0),
+                    misses=cache_stats.get("misses", 0),
+                    hit_rate_pct=cache_stats.get("hit_rate_pct", 0.0),
+                    startup_populated=cache_stats.get("startup_populated", False),
+                ),
+            )
         )
 
     except Exception as e:

--- a/ciris_engine/logic/adapters/api/services/auth_service.py
+++ b/ciris_engine/logic/adapters/api/services/auth_service.py
@@ -6,6 +6,7 @@ Manages API keys, OAuth users, and authentication state.
 import base64
 import hashlib
 import logging
+import os
 import secrets
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -124,17 +125,20 @@ class APIAuthService:
             # Generate a secure random password
             cls._fallback_admin_password = secrets.token_urlsafe(24)
 
-            # Print it ONCE so operator can see it during first-run
+            # Print it ONCE so operator can see it during first-run or testing
             # Use print() not logger to avoid duplicate outputs from multiple log handlers
-            # Only print if this is actually first-run (no .env configured yet)
             if not cls._fallback_password_logged:
                 cls._fallback_password_logged = True
-                # Check if this is first-run before printing credentials
+                # Check if this is first-run or testing mode before printing credentials
                 from ciris_engine.logic.setup.first_run import is_first_run
 
-                if is_first_run():
+                testing_mode = os.environ.get("CIRIS_TESTING_MODE", "").lower() in ("true", "1", "yes")
+                if is_first_run() or testing_mode:
                     print("=" * 70)
-                    print("FIRST-RUN FALLBACK ADMIN CREDENTIALS (use to complete setup wizard):")
+                    if testing_mode:
+                        print("TESTING MODE FALLBACK ADMIN CREDENTIALS:")
+                    else:
+                        print("FIRST-RUN FALLBACK ADMIN CREDENTIALS (use to complete setup wizard):")
                     print("  Username: admin")
                     print(f"  Password: {cls._fallback_admin_password}")
                     print("This password is randomly generated and valid only until setup completes.")
@@ -169,20 +173,27 @@ class APIAuthService:
         # Instead, we'll load lazily on first access
         if not self._auth_service:
             # Fallback: Initialize with system admin user if no auth service
-            # SECURITY: Use randomly generated password, not hardcoded
-            now = datetime.now(timezone.utc)
-            admin_user = User(
-                wa_id="wa-system-admin",
-                name="admin",
-                auth_type="password",
-                api_role=APIRole.SYSTEM_ADMIN,
-                wa_role=None,  # System admin is not a WA by default
-                created_at=now,
-                is_active=True,
-                password_hash=self._hash_password(self._get_fallback_admin_password()),
-            )
-            self._users[admin_user.wa_id] = admin_user
-            self._users_loaded = True
+            # Only in testing mode - production requires setup wizard
+            # Skip if CIRIS_FORCE_FIRST_RUN is set (setup wizard will create the user)
+            testing_mode = os.environ.get("CIRIS_TESTING_MODE", "").lower() in ("true", "1", "yes")
+            first_run_mode = os.environ.get("CIRIS_FORCE_FIRST_RUN", "").lower() in ("true", "1", "yes")
+            if testing_mode and not first_run_mode:
+                # SECURITY: Use randomly generated password, not hardcoded
+                now = datetime.now(timezone.utc)
+                admin_user = User(
+                    wa_id="wa-system-admin",
+                    name="admin",
+                    auth_type="password",
+                    api_role=APIRole.SYSTEM_ADMIN,
+                    wa_role=None,  # System admin is not a WA by default
+                    created_at=now,
+                    is_active=True,
+                    password_hash=self._hash_password(self._get_fallback_admin_password()),
+                )
+                self._users[admin_user.wa_id] = admin_user
+                self._users_loaded = True
+            else:
+                logger.debug("[AUTH SERVICE] No auth_service and not in testing mode - no fallback admin")
 
     # ==========================================================================
     # Attestation Methods (delegate to infrastructure AuthenticationService)
@@ -346,8 +357,17 @@ class APIAuthService:
             logger.info(f"CIRIS_USER_CREATE: Check default admin: has_admin={has_admin_user}, has_root={has_root_user}")
 
             if not has_admin_user and not has_root_user:
-                logger.info("CIRIS_USER_CREATE: No admin/ROOT user found - will create default admin")
-                await self._create_default_admin()
+                # Only create default admin in testing mode AND not in first-run mode
+                # First-run mode means setup wizard will create the user
+                testing_mode = os.environ.get("CIRIS_TESTING_MODE", "").lower() in ("true", "1", "yes")
+                first_run_mode = os.environ.get("CIRIS_FORCE_FIRST_RUN", "").lower() in ("true", "1", "yes")
+                if testing_mode and not first_run_mode:
+                    logger.info("CIRIS_USER_CREATE: No admin/ROOT user found - creating default admin (TESTING MODE)")
+                    await self._create_default_admin()
+                elif first_run_mode:
+                    logger.info("CIRIS_USER_CREATE: No admin/ROOT user found - skipping default admin (FIRST RUN MODE - setup will create user)")
+                else:
+                    logger.info("CIRIS_USER_CREATE: No admin/ROOT user found - setup wizard required (production mode)")
             else:
                 logger.info("CIRIS_USER_CREATE: Skipping default admin creation - admin or ROOT already exists")
 

--- a/ciris_engine/logic/context/batch_context.py
+++ b/ciris_engine/logic/context/batch_context.py
@@ -729,9 +729,10 @@ async def build_system_snapshot_with_batch(
                         user_id=name,
                         display_name=graphql_profile.nick or name,
                         created_at=datetime.now(timezone.utc),
-                        preferred_language="en",
-                        timezone="UTC",
-                        communication_style="formal",
+                        # Read language/timezone from GraphQL attrs, don't hardcode
+                        preferred_language=consent_attrs.get("preferred_language", consent_attrs.get("language", "en")),
+                        timezone=consent_attrs.get("timezone", "UTC"),
+                        communication_style=consent_attrs.get("communication_style", "formal"),
                         trust_level=graphql_profile.trust_score or 0.5,
                         last_interaction=(
                             datetime.fromisoformat(graphql_profile.last_seen) if graphql_profile.last_seen else None

--- a/ciris_engine/logic/context/system_snapshot_helpers.py
+++ b/ciris_engine/logic/context/system_snapshot_helpers.py
@@ -1490,6 +1490,58 @@ def _create_user_memory_query(user_id: str) -> MemoryQuery:
     )
 
 
+def _create_preferences_memory_query(user_id: str) -> MemoryQuery:
+    """Create memory query for user preferences node.
+
+    The setup wizard stores user preferences (language, location, timezone)
+    in a separate 'preferences/{user_id}' node. This query retrieves those
+    preferences for merging into the user profile.
+    """
+    return MemoryQuery(
+        node_id=f"preferences/{user_id}",
+        scope=GraphScope.LOCAL,
+        type=NodeType.CONCEPT,  # Preferences are stored as CONCEPT nodes
+        include_edges=False,
+        depth=1,
+    )
+
+
+async def _query_user_preferences(
+    user_id: str, memory_service: LocalGraphMemoryService
+) -> JSONDict:
+    """Query the preferences/{user_id} node for user settings.
+
+    The setup wizard and settings page store user preferences in a separate
+    node. This function retrieves those preferences for merging into the
+    user profile.
+
+    Args:
+        user_id: The user ID to query preferences for
+        memory_service: The memory service to query
+
+    Returns:
+        Dict of preference attributes (may be empty)
+    """
+    try:
+        prefs_query = _create_preferences_memory_query(user_id)
+        prefs_results = await memory_service.recall(prefs_query)
+
+        if prefs_results:
+            prefs_node = prefs_results[0]
+            attrs = _extract_node_attributes(prefs_node)
+            logger.debug(
+                f"[USER PREFS] Found preferences for {user_id}: {list(attrs.keys())}"
+            )
+            return attrs
+
+        logger.debug(f"[USER PREFS] No preferences node found for {user_id}")
+        return {}
+
+    except Exception as e:
+        logger.warning(f"[USER PREFS] Failed to query preferences for {user_id}: {e}")
+        return {}
+
+
 def _determine_if_admin_user(user_id: str) -> bool:
     """Determine if a user_id represents an admin or system user."""
     # Check for admin patterns
@@ -1598,6 +1650,10 @@ async def _enrich_single_user_profile(
 
     If no user node exists, creates one automatically with appropriate defaults.
     This ensures user_profiles is never empty in system snapshots.
+
+    IMPORTANT: This function queries BOTH the user/{user_id} node AND the
+    preferences/{user_id} node. The setup wizard stores language/location
+    preferences in the preferences node, so we must query both and merge.
     """
     try:
         # Query user node with ALL attributes
@@ -1608,21 +1664,78 @@ async def _enrich_single_user_profile(
             f"[USER EXTRACTION] Query returned {len(user_results) if user_results else 0} results for user {user_id}"
         )
 
+        # Also query preferences node - setup wizard stores language/location here
+        prefs_attrs = await _query_user_preferences(user_id, memory_service)
+
         if user_results:
             user_node = user_results[0]
-            return await _process_user_node_for_profile(user_node, user_id, memory_service, channel_id)
+            profile = await _process_user_node_for_profile(user_node, user_id, memory_service, channel_id)
+
+            # Merge preferences into profile (preferences take priority)
+            if prefs_attrs:
+                profile = _merge_preferences_into_profile(profile, prefs_attrs)
+
+            return profile
 
         # No user node exists - create one automatically
         logger.info(f"[USER EXTRACTION] No node found for user/{user_id}, creating new user node with defaults")
         new_user_node = await _create_default_user_node(user_id, memory_service, channel_id)
 
         if new_user_node:
-            return await _process_user_node_for_profile(new_user_node, user_id, memory_service, channel_id)
+            profile = await _process_user_node_for_profile(new_user_node, user_id, memory_service, channel_id)
+
+            # Merge preferences into profile (preferences take priority)
+            if prefs_attrs:
+                profile = _merge_preferences_into_profile(profile, prefs_attrs)
+
+            return profile
 
     except Exception as e:
         logger.warning(f"Failed to enrich user {user_id}: {e}")
 
     return None
+
+
+def _merge_preferences_into_profile(profile: UserProfile, prefs_attrs: JSONDict) -> UserProfile:
+    """Merge preferences node attributes into a user profile.
+
+    The setup wizard stores user preferences (language, location, timezone)
+    in a separate preferences/{user_id} node. This function merges those
+    preferences into the user profile, with preferences taking priority.
+
+    Args:
+        profile: The user profile to update
+        prefs_attrs: Attributes from the preferences node
+
+    Returns:
+        Updated user profile with merged preferences
+    """
+    # Language - critical for localization
+    if prefs_attrs.get("preferred_language") and prefs_attrs.get("preferred_language") != "en":
+        profile.preferred_language = str(prefs_attrs["preferred_language"])
+        logger.debug(f"[PREFS MERGE] Set language to '{profile.preferred_language}' from preferences node")
+
+    # Timezone
+    if prefs_attrs.get("timezone") and prefs_attrs.get("timezone") != "UTC":
+        profile.timezone = str(prefs_attrs["timezone"])
+
+    # Location
+    if prefs_attrs.get("location"):
+        profile.location = str(prefs_attrs["location"])
+    if prefs_attrs.get("location_country"):
+        # Build location string if not already set
+        if not profile.location:
+            parts = []
+            if prefs_attrs.get("location_city"):
+                parts.append(str(prefs_attrs["location_city"]))
+            if prefs_attrs.get("location_region"):
+                parts.append(str(prefs_attrs["location_region"]))
+            if prefs_attrs.get("location_country"):
+                parts.append(str(prefs_attrs["location_country"]))
+            if parts:
+                profile.location = ", ".join(parts)
+
+    return profile
 
 
 async def _enrich_user_profiles(
@@ -1631,18 +1744,59 @@ async def _enrich_user_profiles(
     channel_id: Optional[str],
     existing_profiles: List[UserProfile],
 ) -> List[UserProfile]:
-    """Enrich user profiles from memory graph with comprehensive data."""
-    existing_user_ids = {p.user_id for p in existing_profiles}
+    """Enrich user profiles from memory graph with comprehensive data.
+
+    IMPORTANT: For users that already exist in existing_profiles (e.g., from GraphQL),
+    we MERGE memory graph data into them rather than skipping. This ensures that
+    user preferences like preferred_language stored in the memory graph are always
+    reflected in the final profile.
+    """
+    # Build lookup for existing profiles by user_id
+    existing_by_id = {p.user_id: p for p in existing_profiles}
 
     for user_id in user_ids:
         logger.debug(f"[USER EXTRACTION] Processing user {user_id}")
 
-        if _should_skip_user_enrichment(user_id, existing_user_ids):
+        # Get enriched profile from memory graph
+        memory_profile = await _enrich_single_user_profile(user_id, memory_service, channel_id)
+
+        if not memory_profile:
             continue
 
-        user_profile = await _enrich_single_user_profile(user_id, memory_service, channel_id)
-        if user_profile:
-            existing_profiles.append(user_profile)
+        if user_id in existing_by_id:
+            # User already exists - MERGE memory graph data into existing profile
+            # This is critical for localization: memory graph has the real preferred_language
+            existing = existing_by_id[user_id]
+            logger.debug(f"[USER EXTRACTION] Merging memory graph data into existing profile for {user_id}")
+
+            # Update fields from memory graph that may have been hardcoded or missing
+            # Only update if memory graph has non-default values
+            if memory_profile.preferred_language and memory_profile.preferred_language != "en":
+                existing.preferred_language = memory_profile.preferred_language
+            if memory_profile.timezone and memory_profile.timezone != "UTC":
+                existing.timezone = memory_profile.timezone
+            if memory_profile.communication_style and memory_profile.communication_style != "formal":
+                existing.communication_style = memory_profile.communication_style
+            if memory_profile.user_preferred_name:
+                existing.user_preferred_name = memory_profile.user_preferred_name
+            if memory_profile.location:
+                existing.location = memory_profile.location
+            if memory_profile.interaction_preferences:
+                existing.interaction_preferences = memory_profile.interaction_preferences
+            if memory_profile.oauth_name:
+                existing.oauth_name = memory_profile.oauth_name
+            # Merge memorized_attributes
+            if memory_profile.memorized_attributes:
+                if not existing.memorized_attributes:
+                    existing.memorized_attributes = {}
+                existing.memorized_attributes.update(memory_profile.memorized_attributes)
+            # Append notes
+            if memory_profile.notes:
+                existing.notes = (existing.notes or "") + "\n" + memory_profile.notes
+        else:
+            # New user - add to profiles
+            existing_profiles.append(memory_profile)
+            existing_by_id[user_id] = memory_profile
 
     return existing_profiles
 

--- a/ciris_engine/logic/dma/csdma.py
+++ b/ciris_engine/logic/dma/csdma.py
@@ -1,5 +1,8 @@
 import logging
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from ciris_engine.schemas.dma.prompts import PromptCollection
 
 from ciris_engine.logic.formatters import (
     format_parent_task_chain,
@@ -18,7 +21,7 @@ from ciris_engine.schemas.runtime.models import ImageContent
 from ciris_engine.schemas.types import JSONDict
 
 from .base_dma import BaseDMA
-from .prompt_loader import get_prompt_loader
+from .prompt_loader import DMAPromptLoader, get_prompt_loader
 
 logger = logging.getLogger(__name__)
 
@@ -54,9 +57,8 @@ class CSDMAEvaluator(BaseDMA[ProcessingQueueItem, CSDMAResult], CSDMAProtocol):
             **kwargs,
         )
 
-        # Load prompts from YAML file
-        self.prompt_loader = get_prompt_loader()
-        self.prompt_template_data = self.prompt_loader.load_prompt_template("csdma_common_sense")
+        # Get prompt loader (do NOT cache template - language may change at runtime)
+        self._prompt_template_name = "csdma_common_sense"
 
         # Store last prompts for debugging/streaming
         self.last_user_prompt: Optional[str] = None
@@ -68,6 +70,21 @@ class CSDMAEvaluator(BaseDMA[ProcessingQueueItem, CSDMAResult], CSDMAProtocol):
         self.task_kg = task_specific_kg  # Placeholder for now
         # Log the final client type being used
         logger.info(f"CSDMAEvaluator initialized with model: {self.model_name}")
+
+    @property
+    def prompt_loader(self) -> DMAPromptLoader:
+        """Get prompt loader fresh each time to respect language changes."""
+        return get_prompt_loader()
+
+    @property
+    def prompt_template_data(self) -> "PromptCollection":
+        """Load prompt template fresh each time to respect language changes.
+
+        IMPORTANT: Do NOT cache this value. The user's preferred language may
+        change at runtime via the settings page, and we need to load the
+        correct localized template for each request.
+        """
+        return self.prompt_loader.load_prompt_template(self._prompt_template_name)
 
     def _create_csdma_messages_for_instructor(
         self,

--- a/ciris_engine/logic/dma/dsdma_base.py
+++ b/ciris_engine/logic/dma/dsdma_base.py
@@ -14,12 +14,13 @@ from ciris_engine.logic.registries.base import ServiceRegistry
 from ciris_engine.logic.utils.constants import get_accord_text
 from ciris_engine.protocols.dma.base import DSDMAProtocol
 from ciris_engine.schemas.dma.core import DMAInputData
+from ciris_engine.schemas.dma.prompts import PromptCollection
 from ciris_engine.schemas.dma.results import DSDMAResult
 from ciris_engine.schemas.runtime.system_context import SystemSnapshot
 from ciris_engine.schemas.types import JSONDict
 
 from .base_dma import BaseDMA
-from .prompt_loader import get_prompt_loader
+from .prompt_loader import DMAPromptLoader, get_prompt_loader
 
 logger = logging.getLogger(__name__)
 
@@ -59,39 +60,43 @@ class BaseDSDMA(BaseDMA[DMAInputData, DSDMAResult], DSDMAProtocol):
         self.domain_name = domain_name
         self.domain_specific_knowledge = domain_specific_knowledge if domain_specific_knowledge else {}
 
-        self.prompt_loader = get_prompt_loader()
-        try:
-            prompt_collection = self.prompt_loader.load_prompt_template("dsdma_base")
-            self.prompt_template_data = prompt_collection
-            # Get system guidance header from the collection
-            system_guidance = prompt_collection.get_prompt("system_guidance_header")
-            if prompt_template is not None:
-                self.prompt_template = prompt_template
-            elif system_guidance:
-                self.prompt_template = system_guidance  # get_prompt returns a string
-            else:
-                self.prompt_template = ""
-        except FileNotFoundError:
-            logger.warning(f"DSDMA base prompt template not found for domain '{domain_name}', using fallback")
-            # Create a PromptCollection with fallback data
-            from ciris_engine.schemas.dma.prompts import PromptCollection
-
-            self.prompt_template_data = PromptCollection(
-                component_name="dsdma_base_fallback",
-                description="Fallback DSDMA prompt collection",
-                system_guidance_header=self.DEFAULT_TEMPLATE if self.DEFAULT_TEMPLATE else "",
-            )
-            self.prompt_template = (
-                prompt_template
-                if prompt_template is not None
-                else (self.DEFAULT_TEMPLATE if self.DEFAULT_TEMPLATE else "")
-            )
+        # Do NOT cache template - language may change at runtime
+        self._prompt_template_name = "dsdma_base"
+        self._custom_prompt_template = prompt_template  # User-provided override
 
         # Store last prompts for debugging/streaming
         self.last_user_prompt: Optional[str] = None
         self.last_system_prompt: Optional[str] = None
 
         logger.info(f"BaseDSDMA '{self.domain_name}' initialized with model: {self.model_name}")
+
+    @property
+    def prompt_loader(self) -> DMAPromptLoader:
+        """Get prompt loader fresh each time to respect language changes."""
+        return get_prompt_loader()
+
+    @property
+    def prompt_template_data(self) -> PromptCollection:
+        """Load prompt template fresh each time to respect language changes."""
+        try:
+            return self.prompt_loader.load_prompt_template(self._prompt_template_name)
+        except FileNotFoundError:
+            logger.warning(f"DSDMA base prompt template not found for domain '{self.domain_name}', using fallback")
+            return PromptCollection(
+                component_name="dsdma_base_fallback",
+                description="Fallback DSDMA prompt collection",
+                system_guidance_header=self.DEFAULT_TEMPLATE if self.DEFAULT_TEMPLATE else "",
+            )
+
+    @property
+    def prompt_template(self) -> str:
+        """Get system guidance header, respecting language changes."""
+        if self._custom_prompt_template is not None:
+            return self._custom_prompt_template
+        system_guidance = self.prompt_template_data.get_prompt("system_guidance_header")
+        if system_guidance:
+            return system_guidance
+        return self.DEFAULT_TEMPLATE if self.DEFAULT_TEMPLATE else ""
 
     class LLMOutputForDSDMA(BaseModel):
         score: float = Field(..., ge=0.0, le=1.0)

--- a/ciris_engine/logic/dma/idma.py
+++ b/ciris_engine/logic/dma/idma.py
@@ -13,7 +13,10 @@ This is a semantic/LLM-based implementation - no hardware dependencies.
 """
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from ciris_engine.schemas.dma.prompts import PromptCollection
 
 from ciris_engine.logic.formatters import format_system_prompt_blocks, format_system_snapshot, format_user_profiles
 from ciris_engine.logic.processors.support.processing_queue import ProcessingQueueItem
@@ -25,7 +28,7 @@ from ciris_engine.schemas.runtime.models import ImageContent
 from ciris_engine.schemas.types import JSONDict
 
 from .base_dma import BaseDMA
-from .prompt_loader import get_prompt_loader
+from .prompt_loader import DMAPromptLoader, get_prompt_loader
 
 logger = logging.getLogger(__name__)
 
@@ -59,15 +62,24 @@ class IDMAEvaluator(BaseDMA[ProcessingQueueItem, IDMAResult], IDMAProtocol):
             **kwargs,
         )
 
-        # Load prompts from YAML file
-        self.prompt_loader = get_prompt_loader()
-        self.prompt_template_data = self.prompt_loader.load_prompt_template("idma")
+        # Do NOT cache template - language may change at runtime
+        self._prompt_template_name = "idma"
 
         # Store last prompts for debugging/streaming
         self.last_user_prompt: Optional[str] = None
         self.last_system_prompt: Optional[str] = None
 
         logger.info(f"IDMAEvaluator initialized with model: {self.model_name}")
+
+    @property
+    def prompt_loader(self) -> DMAPromptLoader:
+        """Get prompt loader fresh each time to respect language changes."""
+        return get_prompt_loader()
+
+    @property
+    def prompt_template_data(self) -> "PromptCollection":
+        """Load prompt template fresh each time to respect language changes."""
+        return self.prompt_loader.load_prompt_template(self._prompt_template_name)
 
     def _create_idma_messages(
         self,

--- a/ciris_engine/logic/dma/pdma.py
+++ b/ciris_engine/logic/dma/pdma.py
@@ -1,5 +1,8 @@
 import logging
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from ciris_engine.schemas.dma.prompts import PromptCollection
 
 from ciris_engine.constants import DEFAULT_OPENAI_MODEL_NAME
 from ciris_engine.logic.formatters import format_system_snapshot, format_user_profiles
@@ -11,7 +14,7 @@ from ciris_engine.schemas.dma.results import EthicalDMAResult
 from ciris_engine.schemas.types import JSONDict
 
 from .base_dma import BaseDMA
-from .prompt_loader import get_prompt_loader
+from .prompt_loader import DMAPromptLoader, get_prompt_loader
 
 logger = logging.getLogger(__name__)
 
@@ -38,14 +41,24 @@ class EthicalPDMAEvaluator(BaseDMA[ProcessingQueueItem, EthicalDMAResult], PDMAP
             **kwargs,
         )
 
-        self.prompt_loader = get_prompt_loader()
-        self.prompt_template_data = self.prompt_loader.load_prompt_template("pdma_ethical")
+        # Do NOT cache template - language may change at runtime
+        self._prompt_template_name = "pdma_ethical"
 
         # Store last prompts for debugging/streaming
         self.last_user_prompt: Optional[str] = None
         self.last_system_prompt: Optional[str] = None
 
         logger.info(f"EthicalPDMAEvaluator initialized with model: {self.model_name}")
+
+    @property
+    def prompt_loader(self) -> DMAPromptLoader:
+        """Get prompt loader fresh each time to respect language changes."""
+        return get_prompt_loader()
+
+    @property
+    def prompt_template_data(self) -> "PromptCollection":
+        """Load prompt template fresh each time to respect language changes."""
+        return self.prompt_loader.load_prompt_template(self._prompt_template_name)
 
     def _build_context_strings(self, context: Any) -> tuple[str, str]:
         """Extract system snapshot and user profile context strings.

--- a/ciris_engine/logic/dma/tsaspdma.py
+++ b/ciris_engine/logic/dma/tsaspdma.py
@@ -10,7 +10,10 @@ TSASPDMA returns ActionSelectionDMAResult (same as ASPDMA) for transparent integ
 """
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from ciris_engine.schemas.dma.prompts import PromptCollection
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -26,7 +29,7 @@ from ciris_engine.schemas.runtime.enums import HandlerActionType
 from ciris_engine.schemas.types import JSONDict
 
 from .base_dma import BaseDMA
-from .prompt_loader import get_prompt_loader
+from .prompt_loader import DMAPromptLoader, get_prompt_loader
 
 
 class TSASPDMALLMResult(BaseModel):
@@ -100,14 +103,23 @@ class TSASPDMAEvaluator(BaseDMA[ProcessingQueueItem, ActionSelectionDMAResult], 
             **kwargs,
         )
 
-        # Load prompts from YAML file
-        self.prompt_loader = get_prompt_loader()
-        self.prompt_template_data = self.prompt_loader.load_prompt_template("tsaspdma")
+        # Do NOT cache template - language may change at runtime
+        self._prompt_template_name = "tsaspdma"
 
         # Store last user prompt for debugging/streaming
         self.last_user_prompt: Optional[str] = None
 
         logger.info(f"TSASPDMAEvaluator initialized with model: {self.model_name}")
+
+    @property
+    def prompt_loader(self) -> DMAPromptLoader:
+        """Get prompt loader fresh each time to respect language changes."""
+        return get_prompt_loader()
+
+    @property
+    def prompt_template_data(self) -> "PromptCollection":
+        """Load prompt template fresh each time to respect language changes."""
+        return self.prompt_loader.load_prompt_template(self._prompt_template_name)
 
     def _sync_language_from_context(self, context: Optional[Any]) -> None:
         """Sync user's language preference from context to prompt loader."""

--- a/ciris_engine/logic/services/infrastructure/database_maintenance/service.py
+++ b/ciris_engine/logic/services/infrastructure/database_maintenance/service.py
@@ -25,6 +25,9 @@ from ciris_engine.protocols.services.infrastructure.database_maintenance import 
 from ciris_engine.protocols.services.lifecycle.time import TimeServiceProtocol
 from ciris_engine.schemas.runtime.enums import ServiceType, TaskStatus, ThoughtStatus
 
+if TYPE_CHECKING:
+    from ciris_engine.logic.audit import MigrationResult
+
 logger = logging.getLogger(__name__)
 
 
@@ -1164,7 +1167,7 @@ class DatabaseMaintenanceService(BaseScheduledService, DatabaseMaintenanceServic
 
         return metrics
 
-    async def migrate_audit_key_to_ed25519(self, backup: bool = True) -> Dict[str, Any]:
+    async def migrate_audit_key_to_ed25519(self, backup: bool = True) -> "MigrationResult":
         """Migrate audit signing key from RSA-2048 to Ed25519.
 
         This is a one-time migration operation that:
@@ -1178,7 +1181,7 @@ class DatabaseMaintenanceService(BaseScheduledService, DatabaseMaintenanceServic
             backup: Create backup before migration (recommended)
 
         Returns:
-            Dict with migration result details
+            MigrationResult with migration details
         """
         from ciris_engine.logic.audit import migrate_audit_key_to_ed25519
 
@@ -1193,18 +1196,8 @@ class DatabaseMaintenanceService(BaseScheduledService, DatabaseMaintenanceServic
 
             db_path = get_sqlite_db_full_path()
 
-        result = await migrate_audit_key_to_ed25519(
+        return await migrate_audit_key_to_ed25519(
             db_path=str(db_path),
             time_service=self.time_service,
             backup=backup,
         )
-
-        return {
-            "success": result.success,
-            "message": result.message,
-            "entries_migrated": result.entries_migrated,
-            "old_key_id": result.old_key_id,
-            "new_key_id": result.new_key_id,
-            "backup_path": result.backup_path,
-            "errors": result.errors,
-        }

--- a/ciris_engine/logic/services/runtime/llm_service/service.py
+++ b/ciris_engine/logic/services/runtime/llm_service/service.py
@@ -50,32 +50,32 @@ from ciris_engine.schemas.services.llm import (
     EndpointStats,
     ExtractedJSONData,
     JSONExtractionResult,
+    LLMErrorContext,
     LLMRequestMetadata,
+    MultiEndpointStatus,
+    OpenRouterProviderConfig,
     RetryState,
 )
 
 from .pricing_calculator import LLMPricingCalculator
 
-# Type alias for error context dict - contains arbitrary debugging info for logging
-ErrorContext = Dict[str, Any]
-
 
 def _build_ciris_proxy_metadata(
     task_id: Optional[str],
     thought_id: Optional[str],
-    retry_state: Dict[str, Any],
+    retry_state: RetryState,
     resp_model_name: str,
-) -> Dict[str, Any]:
-    """Build metadata dict for CIRIS proxy requests.
+) -> LLMRequestMetadata:
+    """Build metadata for CIRIS proxy requests.
 
     Args:
         task_id: Task ID for billing (required for CIRIS proxy)
         thought_id: Optional thought ID for tracing
-        retry_state: Dict tracking retry count/error/request_id
+        retry_state: State tracking retry count/error/request_id
         resp_model_name: Name of the response model for logging
 
     Returns:
-        Dict with metadata including interaction_id and retry info
+        LLMRequestMetadata with interaction_id and retry info
 
     Raises:
         RuntimeError: If task_id is None (required for billing)
@@ -90,32 +90,33 @@ def _build_ciris_proxy_metadata(
         )
     interaction_id = hashlib.sha256(task_id.encode()).hexdigest()[:32]
 
-    metadata: Dict[str, Any] = {"interaction_id": interaction_id}
-
-    if retry_state["count"] > 0:
-        metadata["retry_count"] = retry_state["count"]
-        if retry_state["previous_error"]:
-            metadata["previous_error"] = retry_state["previous_error"]
-        if retry_state["original_request_id"]:
-            metadata["original_request_id"] = retry_state["original_request_id"]
+    if retry_state.count > 0:
         logger.info(
-            f"[LLM_RETRY] attempt={retry_state['count']} "
-            f"prev_error={retry_state['previous_error']} "
+            f"[LLM_RETRY] attempt={retry_state.count} "
+            f"prev_error={retry_state.previous_error} "
             f"interaction_id={interaction_id}"
         )
+        return LLMRequestMetadata(
+            interaction_id=interaction_id,
+            retry_count=retry_state.count,
+            previous_error=retry_state.previous_error,
+            original_request_id=retry_state.original_request_id,
+        )
     else:
-        retry_state["original_request_id"] = uuid.uuid4().hex[:12]
-        metadata["request_id"] = retry_state["original_request_id"]
+        request_id = uuid.uuid4().hex[:12]
+        retry_state.original_request_id = request_id
         logger.info(
             f"[LLM_REQUEST] interaction_id={interaction_id} "
-            f"request_id={retry_state['original_request_id']} "
+            f"request_id={request_id} "
             f"thought_id={thought_id} model={resp_model_name}"
         )
+        return LLMRequestMetadata(
+            interaction_id=interaction_id,
+            original_request_id=request_id,
+        )
 
-    return metadata
 
-
-def _build_openrouter_provider_config() -> Dict[str, Any]:
+def _build_openrouter_provider_config() -> OpenRouterProviderConfig:
     """Build provider config for OpenRouter requests from environment variables.
 
     Environment variables:
@@ -123,22 +124,24 @@ def _build_openrouter_provider_config() -> Dict[str, Any]:
         OPENROUTER_IGNORE_PROVIDERS: comma-separated providers to skip
 
     Returns:
-        Dict with provider ordering/ignore preferences, empty if none configured
+        OpenRouterProviderConfig with provider ordering/ignore preferences
     """
-    provider_config: Dict[str, Any] = {}
+    order: List[str] = []
+    ignore: List[str] = []
 
     provider_order = os.environ.get("OPENROUTER_PROVIDER_ORDER", "")
     if provider_order:
-        provider_config["order"] = [p.strip() for p in provider_order.split(",") if p.strip()]
+        order = [p.strip() for p in provider_order.split(",") if p.strip()]
 
     ignore_providers = os.environ.get("OPENROUTER_IGNORE_PROVIDERS", "")
     if ignore_providers:
-        provider_config["ignore"] = [p.strip() for p in ignore_providers.split(",") if p.strip()]
+        ignore = [p.strip() for p in ignore_providers.split(",") if p.strip()]
 
-    if provider_config:
-        logger.info(f"[OPENROUTER] Using provider config: {provider_config}")
+    config = OpenRouterProviderConfig(order=order, ignore=ignore)
+    if order or ignore:
+        logger.info(f"[OPENROUTER] Using provider config: order={order}, ignore={ignore}")
 
-    return provider_config
+    return config
 
 
 def _count_images_in_content(content: Any) -> Tuple[int, int]:
@@ -188,7 +191,7 @@ def _log_multimodal_content(
 
 def _handle_instructor_retry_exception(
     error: Exception,
-    error_context: ErrorContext,
+    error_context: LLMErrorContext,
     circuit_breaker: "CircuitBreaker",
 ) -> None:
     """Handle InstructorRetryException with detailed error categorization.
@@ -198,7 +201,7 @@ def _handle_instructor_retry_exception(
 
     Args:
         error: The InstructorRetryException
-        error_context: Dict with model, provider, response_model, etc.
+        error_context: Context with model, provider, response_model, etc.
         circuit_breaker: The circuit breaker instance for recording failures
 
     Raises:
@@ -221,10 +224,10 @@ def _handle_instructor_retry_exception(
     # Schema validation errors
     if _is_validation_error(error_str):
         _log_instructor_error(
-            "SCHEMA VALIDATION", error_context, full_error, extra=f"Expected Schema: {error_context['response_model']}"
+            "SCHEMA VALIDATION", error_context, full_error, extra=f"Expected Schema: {error_context.response_model}"
         )
         raise RuntimeError(
-            f"LLM response validation failed for {error_context['response_model']} - "
+            f"LLM response validation failed for {error_context.response_model} - "
             "circuit breaker activated for failover"
         ) from error
 
@@ -242,9 +245,9 @@ def _handle_instructor_retry_exception(
     if is_rate_limit:
         logger.warning(
             f"LLM RATE LIMIT (429) - Provider quota exceeded (NOT counting as CB failure).\n"
-            f"  Model: {error_context['model']}\n"
-            f"  Provider: {error_context['provider']}\n"
-            f"  CB State: {error_context['circuit_breaker_state']} "
+            f"  Model: {error_context.model}\n"
+            f"  Provider: {error_context.provider}\n"
+            f"  CB State: {error_context.circuit_breaker_state} "
             f"(not incrementing - rate limits are transient)\n"
             f"  Error: {full_error[:300]}"
         )
@@ -296,7 +299,7 @@ def _is_content_filter_error(error_str: str) -> bool:
 
 def _log_instructor_error(
     error_type: str,
-    error_context: ErrorContext,
+    error_context: LLMErrorContext,
     full_error: str,
     extra: Optional[str] = None,
 ) -> None:
@@ -304,17 +307,17 @@ def _log_instructor_error(
 
     Args:
         error_type: Type label for the error (e.g., "TIMEOUT", "VALIDATION")
-        error_context: Dict with model, provider, response_model, etc.
+        error_context: Context with model, provider, response_model, etc.
         full_error: Full error message string
         extra: Optional extra line to include in log
     """
     extra_line = f"\n  {extra}" if extra else ""
     logger.error(
         f"LLM {error_type} - Error occurred.\n"
-        f"  Model: {error_context['model']}\n"
-        f"  Provider: {error_context['provider']}{extra_line}\n"
-        f"  CB State: {error_context['circuit_breaker_state']} "
-        f"({error_context['consecutive_failures']} consecutive failures)\n"
+        f"  Model: {error_context.model}\n"
+        f"  Provider: {error_context.provider}{extra_line}\n"
+        f"  CB State: {error_context.circuit_breaker_state} "
+        f"({error_context.consecutive_failures} consecutive failures)\n"
         f"  Error: {full_error[:500]}"
     )
 
@@ -672,15 +675,15 @@ class OpenAICompatibleClient(BaseService, LLMServiceProtocol):
             self._update_client_base_url(self._endpoint_urls[0])
             logger.info(f"[MULTI_ENDPOINT] Reset to primary endpoint: {self._endpoint_urls[0]}")
 
-    def get_endpoint_stats(self) -> Dict[str, Any]:
+    def get_endpoint_stats(self) -> MultiEndpointStatus:
         """Get statistics about endpoint usage and failures."""
-        return {
-            "endpoints": self._endpoint_urls,
-            "current_index": self._current_endpoint_index,
-            "current_endpoint": self._get_current_endpoint(),
-            "failure_counts": self._endpoint_failure_counts.copy(),
-            "total_endpoints": len(self._endpoint_urls),
-        }
+        return MultiEndpointStatus(
+            endpoints=self._endpoint_urls,
+            current_index=self._current_endpoint_index,
+            current_endpoint=self._get_current_endpoint(),
+            failure_counts=self._endpoint_failure_counts.copy(),
+            total_endpoints=len(self._endpoint_urls),
+        )
 
     def _init_openai_client(
         self, api_key: str, base_url: Optional[str], model_name: str, timeout: int, instructor_mode: str
@@ -1105,7 +1108,7 @@ class OpenAICompatibleClient(BaseService, LLMServiceProtocol):
         logger.debug(f"Structured LLM call for {response_model.__name__}")
         self.circuit_breaker.check_and_raise()
 
-        retry_state: Dict[str, Any] = {"count": 0, "previous_error": None, "original_request_id": None}
+        retry_state = RetryState()
 
         async def _make_structured_call(
             msg_list: List[MessageDict],
@@ -1194,7 +1197,7 @@ class OpenAICompatibleClient(BaseService, LLMServiceProtocol):
                         f"[MULTI_ENDPOINT] Timeout on {current_endpoint}, "
                         f"trying next endpoint (attempt {endpoints_tried + 1}/{max_endpoint_attempts})"
                     )
-                    retry_state = {"count": 0, "previous_error": None, "original_request_id": None}
+                    retry_state = RetryState()
                     continue
                 logger.warning("LLM structured service timeout, no more endpoints to try")
                 raise
@@ -1211,7 +1214,7 @@ class OpenAICompatibleClient(BaseService, LLMServiceProtocol):
                         f"[MULTI_ENDPOINT] Error on {current_endpoint}, "
                         f"trying next endpoint (attempt {endpoints_tried + 1}/{max_endpoint_attempts})"
                     )
-                    retry_state = {"count": 0, "previous_error": None, "original_request_id": None}
+                    retry_state = RetryState()
                     continue
                 raise
 
@@ -1225,7 +1228,7 @@ class OpenAICompatibleClient(BaseService, LLMServiceProtocol):
         task_id: Optional[str],
         thought_id: Optional[str],
         resp_model_name: str,
-        retry_state: Dict[str, Any],
+        retry_state: RetryState,
     ) -> Dict[str, Any]:
         """Build extra kwargs for the LLM API call based on provider."""
         extra_kwargs: Dict[str, Any] = {}
@@ -1233,12 +1236,12 @@ class OpenAICompatibleClient(BaseService, LLMServiceProtocol):
 
         if "ciris.ai" in base_url or "ciris-services" in base_url:
             metadata = _build_ciris_proxy_metadata(task_id, thought_id, retry_state, resp_model_name)
-            extra_kwargs["extra_body"] = {"metadata": metadata}
+            extra_kwargs["extra_body"] = {"metadata": metadata.model_dump()}
         elif "openrouter.ai" in base_url:
             extra_body: Dict[str, Any] = {}
             provider_config = _build_openrouter_provider_config()
-            if provider_config:
-                extra_body["provider"] = provider_config
+            if provider_config.order or provider_config.ignore:
+                extra_body["provider"] = provider_config.model_dump(exclude_defaults=True)
             # CRITICAL: Disable reasoning/thinking mode for faster responses
             # Models like Kimi K2.5 have thinking enabled by default (60-90s latency)
             # OpenRouter format: {"reasoning": {"enabled": false}}
@@ -1392,13 +1395,13 @@ class OpenAICompatibleClient(BaseService, LLMServiceProtocol):
             if isinstance(e, instructor.exceptions.InstructorRetryException):
                 self._track_error(e)
                 self._total_errors += 1
-                error_context: ErrorContext = {
-                    "model": self.model_name,
-                    "provider": self.openai_config.base_url or "default",
-                    "response_model": resp_model_name,
-                    "circuit_breaker_state": self.circuit_breaker.state.value,
-                    "consecutive_failures": self.circuit_breaker.consecutive_failures,
-                }
+                error_context = LLMErrorContext(
+                    model=self.model_name,
+                    provider=self.openai_config.base_url or "default",
+                    response_model=resp_model_name,
+                    circuit_breaker_state=self.circuit_breaker.state.value,
+                    consecutive_failures=self.circuit_breaker.consecutive_failures,
+                )
                 _handle_instructor_retry_exception(e, error_context, self.circuit_breaker)
 
         # Generic exception handling
@@ -1437,7 +1440,7 @@ class OpenAICompatibleClient(BaseService, LLMServiceProtocol):
         response_model: Type[BaseModel],
         max_tokens: int,
         temperature: float,
-        retry_state: Optional[Dict[str, Any]] = None,
+        retry_state: Optional[RetryState] = None,
     ) -> Tuple[BaseModel, ResourceUsage]:
         """Retry with exponential backoff (private method).
 
@@ -1447,8 +1450,7 @@ class OpenAICompatibleClient(BaseService, LLMServiceProtocol):
             response_model: Pydantic response model
             max_tokens: Max tokens
             temperature: Temperature
-            retry_state: Optional dict to track retry info for CIRIS proxy metadata
-                         {"count": int, "previous_error": str, "original_request_id": str}
+            retry_state: Optional RetryState to track retry info for CIRIS proxy metadata
         """
         last_exception = None
         for attempt in range(self.max_retries):
@@ -1462,8 +1464,8 @@ class OpenAICompatibleClient(BaseService, LLMServiceProtocol):
 
                 # Update retry state for next attempt's metadata
                 if retry_state is not None:
-                    retry_state["count"] = attempt + 1
-                    retry_state["previous_error"] = error_category
+                    retry_state.count = attempt + 1
+                    retry_state.previous_error = error_category
 
                 if attempt < self.max_retries - 1:
                     delay = min(self.base_delay * (2**attempt), self.max_delay)

--- a/ciris_engine/logic/services/skill_import/builder.py
+++ b/ciris_engine/logic/services/skill_import/builder.py
@@ -354,8 +354,7 @@ class SkillBuilder:
         if parsed.metadata and parsed.metadata.install:
             from .converter import _build_install_steps
 
-            step_dicts = _build_install_steps(parsed.metadata.install)
-            install.steps = [InstallStep(**s) for s in step_dicts]
+            install.steps = _build_install_steps(parsed.metadata.install)
 
         return SkillDraft(
             identity=identity,

--- a/ciris_engine/logic/services/skill_import/converter.py
+++ b/ciris_engine/logic/services/skill_import/converter.py
@@ -14,6 +14,8 @@ import textwrap
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from ciris_engine.schemas.adapters.tools import InstallStep
+
 from .parser import ParsedSkill, SkillInstallSpec
 
 logger = logging.getLogger(__name__)
@@ -46,40 +48,45 @@ def _map_install_kind(kind: str) -> str:
     return mapping.get(kind, "manual")
 
 
-def _build_install_steps(specs: List[SkillInstallSpec]) -> List[Dict[str, Any]]:
-    """Convert OpenClaw install specs to CIRIS InstallStep dicts.
+def _build_install_steps(specs: List[SkillInstallSpec]) -> List[InstallStep]:
+    """Convert OpenClaw install specs to CIRIS InstallStep models.
 
     Maps all OpenClaw install fields to CIRIS InstallStep fields.
     For 'download' kind specs, the URL is stored in the 'url' field
     and a manual command is generated.
     """
-    steps = []
+    steps: List[InstallStep] = []
     for i, spec in enumerate(specs):
         label = getattr(spec, "label", None) or f"Install via {spec.kind}"
         step_id = getattr(spec, "id", None) or f"install_{i}"
-        step: Dict[str, Any] = {
-            "id": step_id,
-            "kind": _map_install_kind(spec.kind),
-            "label": label,
-            "provides_binaries": spec.bins,
-        }
-        if spec.formula:
-            step["formula"] = spec.formula
-        if spec.package:
-            step["package"] = spec.package
+        kind = _map_install_kind(spec.kind)
+        formula: Optional[str] = spec.formula if spec.formula else None
+        package: Optional[str] = spec.package if spec.package else None
+        command: Optional[str] = None
+        url: Optional[str] = getattr(spec, "url", None)
+
         # Handle download-type specs: url, archive, stripComponents, targetDir
-        url = getattr(spec, "url", None)
         if url:
-            step["url"] = url
-            # Build a manual command for download specs
             archive = getattr(spec, "archive", None)
             target_dir = getattr(spec, "targetDir", None) or getattr(spec, "target_dir", None)
             strip = getattr(spec, "stripComponents", None) or getattr(spec, "strip_components", None)
             if archive and target_dir:
                 strip_flag = f" --strip-components={strip}" if strip else ""
-                step["command"] = f"curl -L {url} | tar xz{strip_flag} -C {target_dir}"
-                step["kind"] = "manual"
-        steps.append(step)
+                command = f"curl -L {url} | tar xz{strip_flag} -C {target_dir}"
+                kind = "manual"
+
+        steps.append(
+            InstallStep(
+                id=step_id,
+                kind=kind,
+                label=label,
+                formula=formula,
+                package=package,
+                command=command,
+                url=url,
+                provides_binaries=spec.bins,
+            )
+        )
     return steps
 
 

--- a/ciris_engine/schemas/adapters/discovery.py
+++ b/ciris_engine/schemas/adapters/discovery.py
@@ -104,3 +104,22 @@ class RecheckEligibilityResponse(BaseModel):
     missing_env_vars: List[str] = Field(default_factory=list)
     missing_config: List[str] = Field(default_factory=list)
     can_install: bool = Field(False, description="Whether install hints are available")
+
+
+class EnrichmentCacheStats(BaseModel):
+    """Statistics about the context enrichment cache."""
+
+    model_config = ConfigDict(defer_build=True, extra="forbid")
+    entry_count: int = Field(0, description="Number of cache entries")
+    hits: int = Field(0, description="Cache hits")
+    misses: int = Field(0, description="Cache misses")
+    hit_rate_pct: float = Field(0.0, description="Cache hit rate percentage")
+    startup_populated: bool = Field(False, description="Whether cache was populated at startup")
+
+
+class EnrichmentCacheResponse(BaseModel):
+    """Response containing context enrichment cache data."""
+
+    model_config = ConfigDict(defer_build=True, extra="forbid")
+    entries: Dict[str, Any] = Field(default_factory=dict, description="Cache entries by tool name")
+    stats: EnrichmentCacheStats = Field(default_factory=EnrichmentCacheStats, description="Cache statistics")

--- a/ciris_engine/schemas/services/llm.py
+++ b/ciris_engine/schemas/services/llm.py
@@ -224,3 +224,38 @@ class EndpointStats(BaseModel):
     circuit_breaker_state: Optional[str] = Field(None, description="Current circuit breaker state")
 
     model_config = ConfigDict(extra="forbid", defer_build=True)
+
+
+class LLMErrorContext(BaseModel):
+    """Context information for LLM service error handling and logging."""
+
+    model: str = Field(..., description="LLM model name")
+    provider: str = Field(..., description="Provider name (openai, anthropic, etc.)")
+    response_model: str = Field(..., description="Expected response model class name")
+    circuit_breaker_state: str = Field(..., description="Circuit breaker state when error occurred")
+    consecutive_failures: int = Field(0, description="Number of consecutive failures")
+    thought_id: Optional[str] = Field(None, description="Thought ID if available")
+    task_id: Optional[str] = Field(None, description="Task ID if available")
+
+    model_config = ConfigDict(extra="forbid", defer_build=True)
+
+
+class OpenRouterProviderConfig(BaseModel):
+    """Configuration for OpenRouter provider routing preferences."""
+
+    order: List[str] = Field(default_factory=list, description="Preferred provider order")
+    ignore: List[str] = Field(default_factory=list, description="Providers to skip")
+
+    model_config = ConfigDict(extra="forbid", defer_build=True)
+
+
+class MultiEndpointStatus(BaseModel):
+    """Status of multi-endpoint configuration for failover."""
+
+    endpoints: List[str] = Field(default_factory=list, description="List of endpoint URLs")
+    current_index: int = Field(0, description="Index of currently active endpoint")
+    current_endpoint: Optional[str] = Field(None, description="Currently active endpoint URL")
+    failure_counts: Dict[str, int] = Field(default_factory=dict, description="Failure count per endpoint")
+    total_endpoints: int = Field(0, description="Total number of configured endpoints")
+
+    model_config = ConfigDict(extra="forbid", defer_build=True)

--- a/docs/QUALITY_REMEDIATION_PLAN.md
+++ b/docs/QUALITY_REMEDIATION_PLAN.md
@@ -1,0 +1,172 @@
+# CIRIS Quality Remediation Plan v2.4.4
+
+## Executive Summary
+
+**Key Insight**: The schemas already exist. The problem is inconsistent usage.
+
+The quality analysis shows 424 `Dict[str, Any]` occurrences across 135 files, but investigation reveals:
+- `RetryState`, `EndpointStats`, `ErrorContext` schemas exist in `schemas/services/llm.py`
+- `AdapterConfig`, `RuntimeAdapterStatus`, etc. exist in `schemas/runtime/adapter_management.py`
+- Services are defining local `Dict[str, Any]` aliases instead of importing existing schemas
+
+**Strategy**: Start with the crux (hardest problems) because fixing core abstractions automatically simplifies downstream fixes.
+
+---
+
+## Level 1: The Crux (Hardest - Do First)
+
+### 1.1 LLM Service Schema Alignment
+**File**: `ciris_engine/logic/services/runtime/llm_service/service.py`
+**Issues**: 17 Dict[str,Any], 238 complexity
+**Root Cause**: Defines local `ErrorContext = Dict[str, Any]` and `retry_state: Dict[str, Any]` instead of using existing schemas
+
+**Action Items**:
+- [ ] Replace `ErrorContext = Dict[str, Any]` (line 60) with import from `schemas/processors/error.py`
+- [ ] Replace `retry_state: Dict[str, Any]` with `RetryState` from `schemas/services/llm.py` (already imported!)
+- [ ] Replace `get_endpoint_stats() -> Dict[str, Any]` with `-> EndpointStats` (schema exists)
+- [ ] Replace `_build_openrouter_provider_config() -> Dict[str, Any]` with typed `ProviderConfig`
+- [ ] Type `extra_kwargs` and `extra_body` as `Dict[str, Union[str, int, float, bool, None]]` or create `LLMExtraParams` schema
+
+**Impact**: Eliminates ~10 Dict[str,Any] in the most critical service
+
+### 1.2 Adapter Manager Refactoring
+**File**: `ciris_engine/logic/runtime/adapter_manager.py`
+**Issues**: 4 Dict[str,Any], 398 complexity, 19.4% coverage
+**Root Cause**: Complex orchestration logic spread across one file
+
+**Action Items**:
+- [ ] Use `AdapterConfig` schema consistently (it exists at `schemas/runtime/adapter_management.py`)
+- [ ] Replace internal `AdapterInstance` class with proper Pydantic model
+- [ ] Extract adapter discovery logic to separate module
+- [ ] Extract adapter lifecycle management to separate module
+- [ ] Add unit tests for each extracted module
+
+**Impact**: Reduces complexity by ~50%, improves testability
+
+---
+
+## Level 2: Core Infrastructure
+
+### 2.1 Authentication Service
+**File**: `ciris_engine/logic/services/infrastructure/authentication/service.py`
+**Issues**: 5 Dict[str,Any], 364 complexity, 39.5% coverage
+
+**Action Items**:
+- [ ] Identify each Dict usage and map to existing schemas
+- [ ] Create missing schemas for auth-specific types (if any)
+- [ ] Extract token management to separate module
+- [ ] Extract OAuth flow handling to separate module
+- [ ] Increase test coverage to 60%+
+
+### 2.2 Database Maintenance Service
+**File**: `ciris_engine/logic/services/infrastructure/database_maintenance/service.py`
+**Issues**: 8 Dict[str,Any], 187 complexity
+
+**Action Items**:
+- [ ] Replace `all_configs: Dict[str, Any]` with typed config schemas
+- [ ] Replace `adapter_instances: Dict[str, Dict[str, Any]]` with `Dict[str, AdapterConfig]`
+- [ ] Type `migrate_audit_key_to_ed25519() -> Dict[str, Any]` return value
+
+---
+
+## Level 3: Supporting Systems
+
+### 3.1 Tool Bus
+**File**: `ciris_engine/logic/buses/tool_bus.py`
+**Issues**: 1 Dict[str,Any], 145 complexity, 20.4% coverage
+
+**Action Items**:
+- [ ] Replace tool parameters Dict with existing `ToolParameters` schema
+- [ ] Add tests for tool routing logic
+- [ ] Add tests for tool execution flow
+
+### 3.2 Communication Bus
+**File**: `ciris_engine/logic/buses/communication_bus.py`
+**Issues**: 0 Dict[str,Any], 152 complexity, 21.0% coverage
+
+**Action Items**:
+- [ ] Focus on test coverage (no type issues)
+- [ ] Extract message routing logic to testable units
+
+### 3.3 Skill Import Converter
+**File**: `ciris_engine/logic/services/skill_import/converter.py`
+**Issues**: 7 Dict[str,Any], 68 complexity
+
+**Action Items**:
+- [ ] Create `SkillInstallStep` schema for `_build_install_steps()` return type
+- [ ] Create `SkillManifest` schema for manifest dict
+- [ ] Type tool validation parameters
+
+---
+
+## Level 4: Quick Wins (Easy Fixes)
+
+### 4.1 Schema Files (Internal Dict Cleanup)
+These files have Dict[str,Any] in their own type definitions:
+
+- [ ] `schemas/runtime/adapter_management.py` (3 Dict) - Line 43, 202: Required for flexibility, document why
+- [ ] `schemas/types.py` (3 Dict) - Review if typed alternatives exist
+- [ ] `schemas/identity.py` (3 Dict) - Review if typed alternatives exist
+- [ ] `schemas/services/runtime_control.py` (3 Dict)
+- [ ] `logic/persistence/stores/authentication_store.py` (3 Dict)
+
+### 4.2 Small Protocol Files Needing Tests
+Add simple unit tests to these small files:
+
+- [ ] `protocols/adapters/configurable.py` (14 lines)
+- [ ] `protocols/services/runtime/tool.py` (25 lines)
+- [ ] `protocols/adapters/message.py` (32 lines)
+- [ ] `protocols/consent.py` (19 lines)
+- [ ] `protocols/faculties.py` (10 lines)
+
+---
+
+## Implementation Order
+
+### Phase 1: Schema Usage Enforcement (Est. 8-10 hours)
+1. LLM Service - Use existing RetryState, EndpointStats, ErrorContext
+2. Adapter Manager - Use existing AdapterConfig, RuntimeAdapterStatus
+3. Database Maintenance - Use existing adapter schemas
+
+### Phase 2: Complexity Reduction (Est. 15-20 hours)
+4. Extract adapter_manager.py into modules
+5. Extract authentication service into modules
+6. Extract main_processor.py logic into testable units
+
+### Phase 3: Test Coverage Push (Est. 30-40 hours)
+7. Add tests for extracted modules
+8. Add tests for bus implementations
+9. Add tests for protocol definitions
+
+### Phase 4: Quick Wins & Cleanup (Est. 5-8 hours)
+10. Schema file internal cleanup
+11. Small file tests
+12. Documentation updates
+
+---
+
+## Success Metrics
+
+| Metric | Current | Target | Phase |
+|--------|---------|--------|-------|
+| Dict[str,Any] count | 424 | <200 | Phase 1 |
+| Test coverage | ~45% | >60% | Phase 3 |
+| High complexity files | 92 | <60 | Phase 2 |
+| Tech debt hours | 65.9h | <40h | Phase 2 |
+
+---
+
+## Anti-Patterns to Avoid
+
+1. **Creating new schemas when they exist** - ALWAYS search first
+2. **Creating SchemaV2** - Fix the original schema
+3. **Over-abstracting** - Simple direct usage beats clever indirection
+4. **Backwards-compat hacks** - Delete unused code, don't rename to `_unused`
+
+---
+
+## Notes
+
+- Many Dict[str,Any] in schema files (line 43, 202 of adapter_management.py) are intentional for dynamic adapter configs
+- Some complexity in adapter_manager.py is inherent to the domain
+- Focus on type safety at boundaries, trust internal code

--- a/mobile/androidApp/build.gradle
+++ b/mobile/androidApp/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 35
-        versionCode 87
-        versionName "2.4.3"
+        versionCode 88
+        versionName "2.4.4"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/mobile/androidApp/src/main/kotlin/ai/ciris/mobile/MainActivity.kt
+++ b/mobile/androidApp/src/main/kotlin/ai/ciris/mobile/MainActivity.kt
@@ -18,6 +18,7 @@ import ai.ciris.mobile.shared.config.CIRISConfig
 import ai.ciris.mobile.shared.platform.AppRestarter
 import ai.ciris.mobile.shared.platform.PythonRuntime
 import ai.ciris.mobile.shared.localization.LocalizationResourceLoader
+import ai.ciris.mobile.shared.platform.initLocalInferenceProbe
 import ai.ciris.mobile.shared.platform.initUrlOpener
 import ai.ciris.mobile.shared.diagnostics.NetworkDiagnosticsAndroid
 import ai.ciris.mobile.shared.testing.AndroidTestAutomationServer
@@ -91,6 +92,10 @@ class MainActivity : ComponentActivity() {
 
         // Initialize URL opener for browser links
         initUrlOpener(this)
+
+        // Initialize local-inference capability probe (needs app context to
+        // query ActivityManager for RAM size).
+        initLocalInferenceProbe(this)
 
         // Initialize Python runtime (Chaquopy)
         if (!Python.isStarted()) {

--- a/mobile/androidApp/src/main/python/version.py
+++ b/mobile/androidApp/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.4.3"
+__version__ = "android-2.4.4"
 
 
 def get_version() -> str:

--- a/mobile/iosApp/iosApp/Info.plist
+++ b/mobile/iosApp/iosApp/Info.plist
@@ -21,7 +21,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>2.4.4</string>
 	<key>CFBundleVersion</key>
-	<string>226</string>
+	<string>227</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/mobile/iosApp/iosApp/Info.plist
+++ b/mobile/iosApp/iosApp/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.3</string>
+	<string>2.4.4</string>
 	<key>CFBundleVersion</key>
-	<string>225</string>
+	<string>226</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/mobile/shared/src/androidMain/kotlin/ai/ciris/mobile/shared/platform/LocalInferenceCapability.android.kt
+++ b/mobile/shared/src/androidMain/kotlin/ai/ciris/mobile/shared/platform/LocalInferenceCapability.android.kt
@@ -1,0 +1,88 @@
+package ai.ciris.mobile.shared.platform
+
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Build
+import android.util.Log
+
+/**
+ * Android implementation of the local-inference capability probe.
+ *
+ * Mirrors the thresholds used by the Python `mobile_local_llm` adapter:
+ *
+ * - Total RAM ≥ 8 GB → [LocalInferenceTier.CAPABLE_E4B]
+ * - Total RAM ≥ 6 GB → [LocalInferenceTier.CAPABLE_E2B]
+ * - arm64 required; 32-bit devices are reported as [LocalInferenceTier.INCAPABLE]
+ *
+ * We do not consult free disk here — the Python adapter owns the model
+ * download path and re-checks disk before spawning the inference server.
+ * The wizard just needs to know whether to show the option.
+ */
+
+private const val ANDROID_E2B_MIN_RAM_GB = 6.0
+private const val ANDROID_E4B_MIN_RAM_GB = 8.0
+private const val BYTES_PER_GB = 1024.0 * 1024.0 * 1024.0
+
+/**
+ * Application context stash populated by [initLocalInferenceProbe].
+ * Reuses the same pattern as `initUrlOpener` in Platform.android.kt so
+ * that probes never need to traipse through static Android globals.
+ */
+private var probeContext: Context? = null
+
+/** Call once during app startup to enable the capability probe. */
+fun initLocalInferenceProbe(context: Context) {
+    probeContext = context.applicationContext
+}
+
+actual fun probeLocalInferenceCapability(): LocalInferenceCapability {
+    val context = probeContext
+    if (context == null) {
+        Log.w("LocalInference", "probeLocalInferenceCapability: context not initialized")
+        return LocalInferenceCapability(
+            tier = LocalInferenceTier.INCAPABLE,
+            totalRamGb = 0.0,
+            reason = "capability probe not initialised; call initLocalInferenceProbe() at startup",
+        )
+    }
+
+    val abi = Build.SUPPORTED_ABIS.firstOrNull().orEmpty()
+    if (abi != "arm64-v8a") {
+        return LocalInferenceCapability(
+            tier = LocalInferenceTier.INCAPABLE,
+            totalRamGb = 0.0,
+            reason = "local Gemma 4 builds require arm64-v8a; this device is $abi",
+        )
+    }
+
+    val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+    if (activityManager == null) {
+        return LocalInferenceCapability(
+            tier = LocalInferenceTier.INCAPABLE,
+            totalRamGb = 0.0,
+            reason = "ActivityManager unavailable; cannot determine device RAM",
+        )
+    }
+
+    val memInfo = ActivityManager.MemoryInfo()
+    activityManager.getMemoryInfo(memInfo)
+    val totalRamGb = memInfo.totalMem.toDouble() / BYTES_PER_GB
+
+    return when {
+        totalRamGb >= ANDROID_E4B_MIN_RAM_GB -> LocalInferenceCapability(
+            tier = LocalInferenceTier.CAPABLE_E4B,
+            totalRamGb = totalRamGb,
+            reason = "Android device with %.1f GB RAM — can run Gemma 4 E4B on-device".format(totalRamGb),
+        )
+        totalRamGb >= ANDROID_E2B_MIN_RAM_GB -> LocalInferenceCapability(
+            tier = LocalInferenceTier.CAPABLE_E2B,
+            totalRamGb = totalRamGb,
+            reason = "Android device with %.1f GB RAM — can run Gemma 4 E2B on-device".format(totalRamGb),
+        )
+        else -> LocalInferenceCapability(
+            tier = LocalInferenceTier.INCAPABLE,
+            totalRamGb = totalRamGb,
+            reason = "Android device has %.1f GB RAM; on-device Gemma 4 requires at least %.1f GB".format(totalRamGb, ANDROID_E2B_MIN_RAM_GB),
+        )
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/api/CIRISApiClient.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/api/CIRISApiClient.kt
@@ -5,6 +5,7 @@ import ai.ciris.mobile.shared.platform.PlatformLogger
 import ai.ciris.mobile.shared.viewmodels.AgentTemplateInfo
 import ai.ciris.mobile.shared.viewmodels.CheckDetail
 import ai.ciris.mobile.shared.viewmodels.ConfigItemData
+import ai.ciris.mobile.shared.viewmodels.DiscoveredLlmServer
 import ai.ciris.mobile.shared.viewmodels.LlmValidationResult
 import ai.ciris.mobile.shared.viewmodels.ModelInfo
 import ai.ciris.mobile.shared.viewmodels.SetupCompletionResult
@@ -1172,6 +1173,106 @@ class CIRISApiClient(
         @SerialName("ciris_compatible") val cirisCompatible: Boolean? = null,
         @SerialName("ciris_recommended") val cirisRecommended: Boolean? = null,
         @SerialName("context_window") val contextWindow: Int? = null
+    )
+
+    /**
+     * Discover local LLM inference servers on the network.
+     * Uses hostname probing and port scanning to find servers like:
+     * - Ollama (port 11434)
+     * - llama.cpp (port 8080)
+     * - vLLM (port 8000)
+     * - LM Studio (port 1234)
+     *
+     * @param timeoutSeconds Total timeout for discovery (default 5.0)
+     * @param includeLocalhost Whether to probe localhost ports (default true)
+     * @return List of discovered servers with their available models
+     */
+    suspend fun discoverLocalLlmServers(
+        timeoutSeconds: Float = 5.0f,
+        includeLocalhost: Boolean = true
+    ): List<DiscoveredLlmServer> {
+        val method = "discoverLocalLlmServers"
+        logInfo(method, "Discovering local LLM servers (timeout=${timeoutSeconds}s, localhost=$includeLocalhost)")
+
+        return try {
+            val client = HttpClient {
+                install(ContentNegotiation) {
+                    json(Json {
+                        ignoreUnknownKeys = true
+                        isLenient = true
+                    })
+                }
+            }
+
+            val response = client.post("${this.baseUrl}/v1/setup/discover-local-llm") {
+                authHeader()?.let { header("Authorization", it) }
+                contentType(io.ktor.http.ContentType.Application.Json)
+                setBody(DiscoverLlmRequest(timeoutSeconds, includeLocalhost))
+            }
+
+            logDebug(method, "Response: status=${response.status}")
+            client.close()
+
+            if (response.status.value !in 200..299) {
+                logError(method, "API returned error status: ${response.status}")
+                return emptyList()
+            }
+
+            val body = response.body<DiscoverLlmApiResponse>()
+            val data = body.data ?: return emptyList()
+
+            val servers = data.servers?.map { server ->
+                DiscoveredLlmServer(
+                    id = server.id ?: "",
+                    label = server.label ?: server.url ?: "Unknown",
+                    url = server.url ?: "",
+                    serverType = server.serverType ?: "unknown",
+                    modelCount = server.modelCount ?: 0,
+                    models = server.models ?: emptyList()
+                )
+            } ?: emptyList()
+
+            logInfo(method, "Discovered ${servers.size} servers via ${data.discoveryMethods?.joinToString() ?: "unknown"}")
+            servers
+        } catch (e: Exception) {
+            logException(method, e)
+            emptyList()
+        }
+    }
+
+    /**
+     * Response wrapper for /v1/setup/discover-local-llm endpoint
+     */
+    @Serializable
+    private data class DiscoverLlmRequest(
+        @SerialName("timeout_seconds") val timeoutSeconds: Float,
+        @SerialName("include_localhost") val includeLocalhost: Boolean
+    )
+
+    @Serializable
+    private data class DiscoverLlmApiResponse(
+        val status: String? = null,
+        val data: DiscoverLlmData? = null,
+        val metadata: JsonObject? = null  // SuccessResponse wrapper metadata
+    )
+
+    @Serializable
+    private data class DiscoverLlmData(
+        val servers: List<DiscoveredLlmServerApi>? = null,
+        @SerialName("total_count") val totalCount: Int? = null,
+        @SerialName("discovery_methods") val discoveryMethods: List<String>? = null,
+        val error: String? = null
+    )
+
+    @Serializable
+    private data class DiscoveredLlmServerApi(
+        val id: String? = null,
+        val label: String? = null,
+        val url: String? = null,
+        @SerialName("server_type") val serverType: String? = null,
+        @SerialName("model_count") val modelCount: Int? = null,
+        val models: List<String>? = null,
+        val metadata: JsonObject? = null  // Server metadata (hostname, ip, port, source)
     )
 
     /**

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/api/CIRISApiClient.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/api/CIRISApiClient.kt
@@ -7,6 +7,7 @@ import ai.ciris.mobile.shared.viewmodels.CheckDetail
 import ai.ciris.mobile.shared.viewmodels.ConfigItemData
 import ai.ciris.mobile.shared.viewmodels.DiscoveredLlmServer
 import ai.ciris.mobile.shared.viewmodels.LlmValidationResult
+import ai.ciris.mobile.shared.viewmodels.StartLocalServerResult
 import ai.ciris.mobile.shared.viewmodels.ModelInfo
 import ai.ciris.mobile.shared.viewmodels.SetupCompletionResult
 import ai.ciris.mobile.shared.viewmodels.StateTransitionResult
@@ -1273,6 +1274,112 @@ class CIRISApiClient(
         @SerialName("model_count") val modelCount: Int? = null,
         val models: List<String>? = null,
         val metadata: JsonObject? = null  // Server metadata (hostname, ip, port, source)
+    )
+
+    /**
+     * Start a local LLM inference server (llama.cpp or Ollama).
+     *
+     * Used when the device is capable of local inference but no server is
+     * currently running. This starts the server in the background with a
+     * keepalive. After starting, call discoverLocalLlmServers() to find it.
+     *
+     * @param serverType Server to start: "llama_cpp" or "ollama"
+     * @param model Model to load: "gemma-4-e2b" or "gemma-4-e4b"
+     * @param port Port for the server (default 8080)
+     * @return StartLocalServerResult with success status and server info
+     */
+    suspend fun startLocalLlmServer(
+        serverType: String = "llama_cpp",
+        model: String = "gemma-4-e2b",
+        port: Int = 8080
+    ): StartLocalServerResult {
+        val method = "startLocalLlmServer"
+        logInfo(method, "Starting local LLM server (type=$serverType, model=$model, port=$port)")
+
+        return try {
+            val client = HttpClient {
+                install(ContentNegotiation) {
+                    json(Json {
+                        ignoreUnknownKeys = true
+                        isLenient = true
+                    })
+                }
+                install(HttpTimeout) {
+                    requestTimeoutMillis = 120_000  // Starting server can take time
+                    connectTimeoutMillis = 10_000
+                }
+            }
+
+            val response = client.post("${this.baseUrl}/v1/setup/start-local-server") {
+                authHeader()?.let { header("Authorization", it) }
+                contentType(io.ktor.http.ContentType.Application.Json)
+                setBody(StartLocalServerRequest(serverType, model, port))
+            }
+
+            logDebug(method, "Response: status=${response.status}")
+            client.close()
+
+            if (response.status.value !in 200..299) {
+                logError(method, "API returned error status: ${response.status}")
+                return StartLocalServerResult(
+                    success = false,
+                    message = "Server returned error: ${response.status}"
+                )
+            }
+
+            val body = response.body<StartLocalServerApiResponse>()
+            val data = body.data ?: return StartLocalServerResult(
+                success = false,
+                message = "Invalid response from server"
+            )
+
+            val result = StartLocalServerResult(
+                success = data.success ?: false,
+                serverUrl = data.serverUrl,
+                serverType = data.serverType ?: serverType,
+                model = data.model ?: model,
+                pid = data.pid,
+                message = data.message ?: "Unknown status",
+                estimatedReadySeconds = data.estimatedReadySeconds ?: 60
+            )
+
+            logInfo(method, "Start server result: success=${result.success}, message=${result.message}")
+            result
+        } catch (e: Exception) {
+            logException(method, e)
+            StartLocalServerResult(
+                success = false,
+                message = "Failed to start server: ${e.message ?: "Unknown error"}"
+            )
+        }
+    }
+
+    /**
+     * Request for starting a local LLM server
+     */
+    @Serializable
+    private data class StartLocalServerRequest(
+        @SerialName("server_type") val serverType: String,
+        val model: String,
+        val port: Int
+    )
+
+    @Serializable
+    private data class StartLocalServerApiResponse(
+        val status: String? = null,
+        val data: StartLocalServerData? = null,
+        val metadata: JsonObject? = null
+    )
+
+    @Serializable
+    private data class StartLocalServerData(
+        val success: Boolean? = null,
+        @SerialName("server_url") val serverUrl: String? = null,
+        @SerialName("server_type") val serverType: String? = null,
+        val model: String? = null,
+        val pid: Int? = null,
+        val message: String? = null,
+        @SerialName("estimated_ready_seconds") val estimatedReadySeconds: Int? = null
     )
 
     /**

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/models/SetupMode.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/models/SetupMode.kt
@@ -12,6 +12,12 @@ import kotlinx.serialization.Serializable
  *
  * - BYOK: Bring Your Own Key
  *   User provides their own API key from OpenAI/Anthropic/etc
+ *
+ * - LOCAL_ON_DEVICE: Run Gemma 4 via the `mobile_local_llm` adapter
+ *   directly on the phone. Only offered in the wizard when the
+ *   [ai.ciris.mobile.shared.platform.probeLocalInferenceCapability]
+ *   probe reports a capable device. On iOS this option is shown
+ *   as "coming soon" until an adequate LiteRT-LM model ships.
  */
 @Serializable
 enum class SetupMode {
@@ -25,5 +31,14 @@ enum class SetupMode {
      * Bring Your Own Key - user provides their own LLM API key.
      * Supports OpenAI, Anthropic, Azure OpenAI, LocalAI, etc.
      */
-    BYOK
+    BYOK,
+
+    /**
+     * On-device inference via the Mobile Local LLM adapter.
+     * Only available on phones whose capability probe returns a
+     * CAPABLE_E2B or CAPABLE_E4B tier. Selecting this mode sets
+     * `CIRIS_MOBILE_LOCAL_LLM_ENABLED=true` so the Python runtime
+     * spawns the on-device inference server on next restart.
+     */
+    LOCAL_ON_DEVICE
 }

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/models/SetupMode.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/models/SetupMode.kt
@@ -29,8 +29,14 @@ enum class SetupMode {
 
     /**
      * Bring Your Own Key - user provides their own LLM API key.
-     * Supports OpenAI, Anthropic, Azure OpenAI, LocalAI, on-device
-     * Gemma 4 (via the mobile_local_llm adapter), etc.
+     * Supports OpenAI, Anthropic, Azure OpenAI, LocalAI, etc.
      */
-    BYOK
+    BYOK,
+
+    /**
+     * Local on-device inference using Gemma 4 via the mobile_local_llm adapter.
+     * No API key required - runs entirely on-device using LiteRT-LM.
+     * Available on capable Android devices (6GB+ RAM, arm64) and desktops (6GB+ RAM).
+     */
+    LOCAL_ON_DEVICE
 }

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/models/SetupMode.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/models/SetupMode.kt
@@ -11,13 +11,13 @@ import kotlinx.serialization.Serializable
  *   Uses Google ID token with llm01.ciris-services-* proxy
  *
  * - BYOK: Bring Your Own Key
- *   User provides their own API key from OpenAI/Anthropic/etc
+ *   User provides their own API key from OpenAI/Anthropic/etc/on-device
  *
- * - LOCAL_ON_DEVICE: Run Gemma 4 via the `mobile_local_llm` adapter
- *   directly on the phone. Only offered in the wizard when the
- *   [ai.ciris.mobile.shared.platform.probeLocalInferenceCapability]
- *   probe reports a capable device. On iOS this option is shown
- *   as "coming soon" until an adequate LiteRT-LM model ships.
+ * On-device Gemma 4 inference lives under BYOK as the "mobile_local"
+ * provider so it can coexist with other providers: the Python
+ * LLMBus picks between installed providers by priority, which means a
+ * capable phone can run local-first with cloud fallback (or vice versa)
+ * simply by having both adapters loaded.
  */
 @Serializable
 enum class SetupMode {
@@ -29,16 +29,8 @@ enum class SetupMode {
 
     /**
      * Bring Your Own Key - user provides their own LLM API key.
-     * Supports OpenAI, Anthropic, Azure OpenAI, LocalAI, etc.
+     * Supports OpenAI, Anthropic, Azure OpenAI, LocalAI, on-device
+     * Gemma 4 (via the mobile_local_llm adapter), etc.
      */
-    BYOK,
-
-    /**
-     * On-device inference via the Mobile Local LLM adapter.
-     * Only available on phones whose capability probe returns a
-     * CAPABLE_E2B or CAPABLE_E4B tier. Selecting this mode sets
-     * `CIRIS_MOBILE_LOCAL_LLM_ENABLED=true` so the Python runtime
-     * spawns the on-device inference server on next restart.
-     */
-    LOCAL_ON_DEVICE
+    BYOK
 }

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/platform/LocalInferenceCapability.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/platform/LocalInferenceCapability.kt
@@ -1,0 +1,66 @@
+package ai.ciris.mobile.shared.platform
+
+/**
+ * Device capability tier for the on-device Gemma 4 inference adapter.
+ *
+ * Mirrors the Python-side `DeviceTier` enum in
+ * `ciris_adapters/mobile_local_llm/config.py`. Keeping the set of values
+ * aligned lets the wizard map the backend capability probe straight onto
+ * UI states without translation.
+ */
+enum class LocalInferenceTier {
+    /** Device has ≥ 8 GB RAM and an arm64 mobile CPU — can run E2B and E4B. */
+    CAPABLE_E4B,
+    /** Device has ≥ 6 GB RAM and an arm64 mobile CPU — can run E2B. */
+    CAPABLE_E2B,
+    /**
+     * iOS hardware looks capable but no Gemma 4 model bundle is shipped
+     * yet. The wizard shows this as "Coming soon" and disables selection.
+     */
+    IOS_STUB,
+    /** Device cannot safely run local inference. The wizard hides the option. */
+    INCAPABLE
+}
+
+/**
+ * Minimal capability snapshot the wizard uses to decide whether — and
+ * how — to offer the local on-device LLM option.
+ *
+ * @property tier The coarse-grained bucket the device falls into.
+ * @property totalRamGb Total device RAM in GB (0.0 when unknown).
+ * @property reason Human-readable explanation, shown in the UI as a tooltip / subtitle.
+ */
+data class LocalInferenceCapability(
+    val tier: LocalInferenceTier,
+    val totalRamGb: Double,
+    val reason: String,
+) {
+    /** True when the wizard should offer the local option as a normal choice. */
+    val isReady: Boolean get() = tier == LocalInferenceTier.CAPABLE_E2B || tier == LocalInferenceTier.CAPABLE_E4B
+
+    /** True when the wizard should show the option but mark it "coming soon". */
+    val isComingSoon: Boolean get() = tier == LocalInferenceTier.IOS_STUB
+
+    /** True when the wizard should hide the local option entirely. */
+    val isHidden: Boolean get() = tier == LocalInferenceTier.INCAPABLE
+}
+
+/**
+ * Probe the current device and report whether it can run local inference.
+ *
+ * This is intentionally pure UI-side: the wizard uses it to decide
+ * whether to surface the on-device option. The actual inference server
+ * is owned by the Python `mobile_local_llm` adapter, which runs its own
+ * capability probe and owns the subprocess lifecycle.
+ *
+ * Platform expectations:
+ *
+ * - Android: read RAM via `ActivityManager`, verify ABI is `arm64-v8a`,
+ *   apply the same 6 GB / 8 GB thresholds the Python probe uses.
+ * - iOS: read RAM via `NSProcessInfo.processInfo.physicalMemory`, verify
+ *   arm64, return `IOS_STUB` because no LiteRT-LM iOS model is shipped
+ *   yet (the user will need to install one before `isReady` flips true).
+ * - Desktop: always return `INCAPABLE` — desktop dev opt-in is handled
+ *   via the Python config flag, not the wizard.
+ */
+expect fun probeLocalInferenceCapability(): LocalInferenceCapability

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/platform/LocalInferenceCapability.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/platform/LocalInferenceCapability.kt
@@ -13,6 +13,8 @@ enum class LocalInferenceTier {
     CAPABLE_E4B,
     /** Device has ≥ 6 GB RAM and an arm64 mobile CPU — can run E2B. */
     CAPABLE_E2B,
+    /** Desktop system with enough RAM/disk to run llama.cpp with Gemma4. */
+    DESKTOP_CAPABLE,
     /**
      * iOS hardware looks capable but no Gemma 4 model bundle is shipped
      * yet. The wizard shows this as "Coming soon" and disables selection.
@@ -36,7 +38,9 @@ data class LocalInferenceCapability(
     val reason: String,
 ) {
     /** True when the wizard should offer the local option as a normal choice. */
-    val isReady: Boolean get() = tier == LocalInferenceTier.CAPABLE_E2B || tier == LocalInferenceTier.CAPABLE_E4B
+    val isReady: Boolean get() = tier == LocalInferenceTier.CAPABLE_E2B ||
+                                  tier == LocalInferenceTier.CAPABLE_E4B ||
+                                  tier == LocalInferenceTier.DESKTOP_CAPABLE
 
     /** True when the wizard should show the option but mark it "coming soon". */
     val isComingSoon: Boolean get() = tier == LocalInferenceTier.IOS_STUB

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/components/LocalLlmDiscovery.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/components/LocalLlmDiscovery.kt
@@ -1,0 +1,229 @@
+package ai.ciris.mobile.shared.ui.components
+
+import ai.ciris.mobile.shared.api.CIRISApiClient
+import ai.ciris.mobile.shared.platform.PlatformLogger
+import ai.ciris.mobile.shared.platform.testableClickable
+import ai.ciris.mobile.shared.viewmodels.DiscoveredLlmServer
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+private const val TAG = "LocalLlmDiscovery"
+
+/**
+ * State holder for Local LLM Server Discovery.
+ * Can be used by any screen that needs to discover local inference servers.
+ */
+class LocalLlmDiscoveryState {
+    var isDiscovering by mutableStateOf(false)
+    var discoveredServers by mutableStateOf<List<DiscoveredLlmServer>>(emptyList())
+    var selectedServer by mutableStateOf<DiscoveredLlmServer?>(null)
+    var errorMessage by mutableStateOf<String?>(null)
+}
+
+@Composable
+fun rememberLocalLlmDiscoveryState(): LocalLlmDiscoveryState {
+    return remember { LocalLlmDiscoveryState() }
+}
+
+/**
+ * Reusable composable for discovering and selecting local LLM inference servers.
+ *
+ * @param state The discovery state holder
+ * @param apiClient The API client to use for discovery
+ * @param onServerSelected Callback when a server is selected (provides URL and models)
+ * @param primaryColor Primary theme color for buttons/highlights
+ * @param surfaceColor Surface color for cards
+ * @param textColor Primary text color
+ * @param secondaryTextColor Secondary text color
+ * @param modifier Modifier for the container
+ */
+@Composable
+fun LocalLlmServerDiscovery(
+    state: LocalLlmDiscoveryState,
+    apiClient: CIRISApiClient,
+    onServerSelected: (server: DiscoveredLlmServer) -> Unit,
+    primaryColor: Color = MaterialTheme.colorScheme.primary,
+    surfaceColor: Color = MaterialTheme.colorScheme.surfaceVariant,
+    textColor: Color = MaterialTheme.colorScheme.onSurface,
+    secondaryTextColor: Color = MaterialTheme.colorScheme.onSurfaceVariant,
+    modifier: Modifier = Modifier
+) {
+    val coroutineScope = rememberCoroutineScope()
+
+    fun discoverServers() {
+        if (state.isDiscovering) return
+
+        state.isDiscovering = true
+        state.errorMessage = null
+        state.discoveredServers = emptyList()
+
+        coroutineScope.launch(Dispatchers.IO) {
+            try {
+                PlatformLogger.i(TAG, "Starting local LLM server discovery...")
+                val servers = apiClient.discoverLocalLlmServers(
+                    timeoutSeconds = 5.0f,
+                    includeLocalhost = true
+                )
+
+                withContext(Dispatchers.Main) {
+                    state.discoveredServers = servers
+                    state.isDiscovering = false
+                    PlatformLogger.i(TAG, "Discovered ${servers.size} servers")
+
+                    // Auto-select if only one server found
+                    if (servers.size == 1) {
+                        state.selectedServer = servers.first()
+                        onServerSelected(servers.first())
+                    }
+                }
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    state.errorMessage = e.message ?: "Discovery failed"
+                    state.isDiscovering = false
+                    PlatformLogger.e(TAG, "Discovery failed: ${e.message}")
+                }
+            }
+        }
+    }
+
+    // Auto-discover on first composition
+    LaunchedEffect(Unit) {
+        if (state.discoveredServers.isEmpty() && !state.isDiscovering) {
+            discoverServers()
+        }
+    }
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        // Discover button
+        OutlinedButton(
+            onClick = { discoverServers() },
+            enabled = !state.isDiscovering,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testableClickable("btn_discover_servers") { discoverServers() },
+            colors = ButtonDefaults.outlinedButtonColors(
+                contentColor = primaryColor
+            )
+        ) {
+            if (state.isDiscovering) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(16.dp),
+                    strokeWidth = 2.dp,
+                    color = primaryColor
+                )
+                Spacer(Modifier.width(8.dp))
+                Text("Discovering...", color = primaryColor)
+            } else {
+                Icon(
+                    imageVector = Icons.Filled.Refresh,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(Modifier.width(8.dp))
+                Text("Discover Servers", color = primaryColor)
+            }
+        }
+
+        // Error message
+        state.errorMessage?.let { error ->
+            Text(
+                text = error,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error
+            )
+        }
+
+        // Discovered servers list
+        if (state.discoveredServers.isNotEmpty()) {
+            Text(
+                text = "Found ${state.discoveredServers.size} server(s):",
+                style = MaterialTheme.typography.labelMedium,
+                color = secondaryTextColor
+            )
+
+            state.discoveredServers.forEach { server ->
+                val isSelected = state.selectedServer?.id == server.id
+
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            state.selectedServer = server
+                            onServerSelected(server)
+                        }
+                        .testableClickable("server_${server.id}") {
+                            state.selectedServer = server
+                            onServerSelected(server)
+                        },
+                    colors = CardDefaults.cardColors(
+                        containerColor = if (isSelected) primaryColor.copy(alpha = 0.15f) else surfaceColor
+                    ),
+                    border = if (isSelected) BorderStroke(2.dp, primaryColor) else null
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(12.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = server.label,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = textColor
+                            )
+                            Text(
+                                text = server.url,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = secondaryTextColor.copy(alpha = 0.7f)
+                            )
+                            if (server.models.isNotEmpty()) {
+                                Text(
+                                    text = "${server.modelCount} model(s): ${server.models.take(2).joinToString()}${if (server.models.size > 2) "..." else ""}",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = secondaryTextColor.copy(alpha = 0.7f)
+                                )
+                            }
+                        }
+                        // Server type badge
+                        Surface(
+                            color = MaterialTheme.colorScheme.tertiaryContainer,
+                            shape = RoundedCornerShape(4.dp)
+                        ) {
+                            Text(
+                                text = server.serverType.uppercase(),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onTertiaryContainer,
+                                modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+                            )
+                        }
+                    }
+                }
+            }
+        } else if (!state.isDiscovering && state.discoveredServers.isEmpty() && state.errorMessage == null) {
+            Text(
+                text = "No servers found. Ensure your LLM server is running on the network.",
+                style = MaterialTheme.typography.bodySmall,
+                color = secondaryTextColor
+            )
+        }
+    }
+}

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/components/LocalLlmDiscovery.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/components/LocalLlmDiscovery.kt
@@ -1,23 +1,29 @@
 package ai.ciris.mobile.shared.ui.components
 
 import ai.ciris.mobile.shared.api.CIRISApiClient
+import ai.ciris.mobile.shared.platform.LocalInferenceCapability
 import ai.ciris.mobile.shared.platform.PlatformLogger
 import ai.ciris.mobile.shared.platform.testableClickable
 import ai.ciris.mobile.shared.viewmodels.DiscoveredLlmServer
+import ai.ciris.mobile.shared.viewmodels.StartLocalServerResult
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -32,6 +38,10 @@ class LocalLlmDiscoveryState {
     var discoveredServers by mutableStateOf<List<DiscoveredLlmServer>>(emptyList())
     var selectedServer by mutableStateOf<DiscoveredLlmServer?>(null)
     var errorMessage by mutableStateOf<String?>(null)
+    // Server start state
+    var isStartingServer by mutableStateOf(false)
+    var serverStartResult by mutableStateOf<StartLocalServerResult?>(null)
+    var serverStartProgress by mutableStateOf<String?>(null)
 }
 
 @Composable
@@ -45,6 +55,7 @@ fun rememberLocalLlmDiscoveryState(): LocalLlmDiscoveryState {
  * @param state The discovery state holder
  * @param apiClient The API client to use for discovery
  * @param onServerSelected Callback when a server is selected (provides URL and models)
+ * @param localInferenceCapability Optional device capability for showing "Start Server" option
  * @param primaryColor Primary theme color for buttons/highlights
  * @param surfaceColor Surface color for cards
  * @param textColor Primary text color
@@ -56,6 +67,7 @@ fun LocalLlmServerDiscovery(
     state: LocalLlmDiscoveryState,
     apiClient: CIRISApiClient,
     onServerSelected: (server: DiscoveredLlmServer) -> Unit,
+    localInferenceCapability: LocalInferenceCapability? = null,
     primaryColor: Color = MaterialTheme.colorScheme.primary,
     surfaceColor: Color = MaterialTheme.colorScheme.surfaceVariant,
     textColor: Color = MaterialTheme.colorScheme.onSurface,
@@ -100,6 +112,67 @@ fun LocalLlmServerDiscovery(
         }
     }
 
+    fun startLocalServer() {
+        if (state.isStartingServer) return
+
+        state.isStartingServer = true
+        state.serverStartResult = null
+        state.serverStartProgress = "Starting local inference server..."
+        state.errorMessage = null
+
+        coroutineScope.launch(Dispatchers.IO) {
+            try {
+                PlatformLogger.i(TAG, "Starting local LLM server...")
+
+                val result = apiClient.startLocalLlmServer(
+                    serverType = "llama_cpp",
+                    model = "gemma-4-e2b",
+                    port = 8080
+                )
+
+                withContext(Dispatchers.Main) {
+                    state.serverStartResult = result
+                    state.isStartingServer = false
+
+                    if (result.success) {
+                        state.serverStartProgress = "Server started! Loading model (this may take ${result.estimatedReadySeconds}s)..."
+                        PlatformLogger.i(TAG, "Server started successfully, waiting for readiness...")
+
+                        // Wait for the server to be ready, then re-discover
+                        coroutineScope.launch(Dispatchers.IO) {
+                            // Wait for estimated ready time (in chunks so we can update UI)
+                            val waitSeconds = result.estimatedReadySeconds.coerceIn(10, 120)
+                            repeat(waitSeconds / 5) {
+                                delay(5000)
+                                withContext(Dispatchers.Main) {
+                                    val remaining = waitSeconds - ((it + 1) * 5)
+                                    state.serverStartProgress = "Loading model (~${remaining}s remaining)..."
+                                }
+                            }
+
+                            // Re-discover to find the new server
+                            withContext(Dispatchers.Main) {
+                                state.serverStartProgress = null
+                                discoverServers()
+                            }
+                        }
+                    } else {
+                        state.serverStartProgress = null
+                        state.errorMessage = result.message
+                        PlatformLogger.e(TAG, "Failed to start server: ${result.message}")
+                    }
+                }
+            } catch (e: Exception) {
+                withContext(Dispatchers.Main) {
+                    state.isStartingServer = false
+                    state.serverStartProgress = null
+                    state.errorMessage = "Failed to start server: ${e.message}"
+                    PlatformLogger.e(TAG, "Server start failed: ${e.message}")
+                }
+            }
+        }
+    }
+
     // Auto-discover on first composition
     LaunchedEffect(Unit) {
         if (state.discoveredServers.isEmpty() && !state.isDiscovering) {
@@ -114,7 +187,7 @@ fun LocalLlmServerDiscovery(
         // Discover button
         OutlinedButton(
             onClick = { discoverServers() },
-            enabled = !state.isDiscovering,
+            enabled = !state.isDiscovering && !state.isStartingServer,
             modifier = Modifier
                 .fillMaxWidth()
                 .testableClickable("btn_discover_servers") { discoverServers() },
@@ -219,11 +292,123 @@ fun LocalLlmServerDiscovery(
                 }
             }
         } else if (!state.isDiscovering && state.discoveredServers.isEmpty() && state.errorMessage == null) {
-            Text(
-                text = "No servers found. Ensure your LLM server is running on the network.",
-                style = MaterialTheme.typography.bodySmall,
-                color = secondaryTextColor
-            )
+            // No servers found - show "Start Local Server" option if device is capable
+            val isCapable = localInferenceCapability?.isReady == true
+
+            if (isCapable && !state.isStartingServer && state.serverStartProgress == null) {
+                // Show start server card
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testableClickable("card_start_local_server") { startLocalServer() },
+                    colors = CardDefaults.cardColors(
+                        containerColor = primaryColor.copy(alpha = 0.1f)
+                    ),
+                    border = BorderStroke(1.dp, primaryColor.copy(alpha = 0.3f))
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp)
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.PlayArrow,
+                                contentDescription = null,
+                                tint = primaryColor,
+                                modifier = Modifier.size(24.dp)
+                            )
+                            Spacer(Modifier.width(12.dp))
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = "Start Local Inference",
+                                    style = MaterialTheme.typography.titleSmall,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = textColor
+                                )
+                                Text(
+                                    text = "Your device can run local AI inference",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = secondaryTextColor
+                                )
+                            }
+                        }
+
+                        Spacer(Modifier.height(12.dp))
+
+                        Text(
+                            text = "No LLM server detected, but this device has enough resources to run one. " +
+                                    "Click below to start a local llama.cpp server with Gemma 4. " +
+                                    "This may take 30-60 seconds to load the model.",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = secondaryTextColor,
+                            fontSize = 12.sp
+                        )
+
+                        Spacer(Modifier.height(12.dp))
+
+                        Button(
+                            onClick = { startLocalServer() },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .testableClickable("btn_start_local_server") { startLocalServer() },
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = primaryColor
+                            )
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.PlayArrow,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp)
+                            )
+                            Spacer(Modifier.width(8.dp))
+                            Text("Start Local Server")
+                        }
+                    }
+                }
+            } else if (state.isStartingServer || state.serverStartProgress != null) {
+                // Show starting progress
+                Card(
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = surfaceColor
+                    )
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(32.dp),
+                            strokeWidth = 3.dp,
+                            color = primaryColor
+                        )
+                        Spacer(Modifier.height(12.dp))
+                        Text(
+                            text = state.serverStartProgress ?: "Starting server...",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = textColor
+                        )
+                        Text(
+                            text = "Please wait while the model loads",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = secondaryTextColor
+                        )
+                    }
+                }
+            } else {
+                // Device not capable or hasn't probed capability yet
+                Text(
+                    text = "No servers found. Ensure your LLM server is running on the network.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = secondaryTextColor
+                )
+            }
         }
     }
 }

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/screens/SettingsScreen.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/screens/SettingsScreen.kt
@@ -8,6 +8,7 @@ import ai.ciris.mobile.shared.localization.localizedString
 import ai.ciris.mobile.shared.ui.theme.BrightnessPreference
 import ai.ciris.mobile.shared.ui.theme.ColorTheme
 import ai.ciris.mobile.shared.ui.theme.SemanticColors
+import ai.ciris.mobile.shared.viewmodels.DiscoveredLlmServer
 import ai.ciris.mobile.shared.viewmodels.SettingsViewModel
 import ai.ciris.mobile.shared.viewmodels.VerifyStatusResponse
 import ai.ciris.mobile.shared.viewmodels.SUPPORTED_CURRENCIES
@@ -17,6 +18,7 @@ import ai.ciris.mobile.shared.platform.testable
 import ai.ciris.mobile.shared.platform.testableClickable
 import ai.ciris.mobile.shared.platform.testableWithHandler
 import androidx.compose.foundation.background
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -89,6 +91,11 @@ fun SettingsScreen(
     val apiKey by viewModel.apiKey.collectAsState()
     val apiKeyMasked by viewModel.apiKeyMasked.collectAsState()
     val availableModels by viewModel.availableModels.collectAsState()
+
+    // Local inference server discovery state
+    val discoveredServers by viewModel.discoveredServers.collectAsState()
+    val selectedServer by viewModel.selectedServer.collectAsState()
+    val isDiscovering by viewModel.isDiscovering.collectAsState()
 
     // Operation state
     val isSaving by viewModel.isSaving.collectAsState()
@@ -247,6 +254,9 @@ fun SettingsScreen(
                         apiKey = apiKey,
                         apiKeyMasked = apiKeyMasked,
                         availableModels = availableModels,
+                        discoveredServers = discoveredServers,
+                        selectedServer = selectedServer,
+                        isDiscovering = isDiscovering,
                         showApiKey = showApiKey,
                         isEditing = isEditing,
                         isSaving = isSaving,
@@ -556,6 +566,9 @@ private fun ByokConfigSection(
     apiKey: String,
     apiKeyMasked: String,
     availableModels: List<String>,
+    discoveredServers: List<DiscoveredLlmServer>,
+    selectedServer: DiscoveredLlmServer?,
+    isDiscovering: Boolean,
     showApiKey: Boolean,
     isEditing: Boolean,
     isSaving: Boolean,
@@ -628,43 +641,155 @@ private fun ByokConfigSection(
         }
     }
 
-    // Model selection
-    var modelExpanded by remember { mutableStateOf(false) }
-
-    ExposedDropdownMenuBox(
-        expanded = modelExpanded,
-        onExpandedChange = { modelExpanded = it }
-    ) {
-        OutlinedTextField(
-            value = llmModel.ifEmpty { localizedString("mobile.settings_select_model") },
-            onValueChange = {},
-            readOnly = true,
-            label = { Text(localizedString("mobile.settings_model")) },
-            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = modelExpanded) },
+    // Local Inference Server Discovery UI (only when local_inference provider selected)
+    if (llmProvider == "local_inference") {
+        // Discover servers button
+        OutlinedButton(
+            onClick = { viewModel.discoverLocalServers() },
+            enabled = !isDiscovering,
             modifier = Modifier
                 .fillMaxWidth()
-                .menuAnchor()
-                .testable("input_llm_model")
-        )
-
-        ExposedDropdownMenu(
-            expanded = modelExpanded,
-            onDismissRequest = { modelExpanded = false }
+                .testableClickable("btn_discover_servers") { viewModel.discoverLocalServers() }
         ) {
-            availableModels.forEach { model ->
-                DropdownMenuItem(
-                    text = { Text(model) },
-                    onClick = {
-                        viewModel.onModelChanged(model)
-                        modelExpanded = false
-                        onEditingChange(true)
-                    },
-                    modifier = Modifier.testableClickable("menu_model_$model") {
-                        viewModel.onModelChanged(model)
-                        modelExpanded = false
-                        onEditingChange(true)
-                    }
+            if (isDiscovering) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(16.dp),
+                    strokeWidth = 2.dp
                 )
+                Spacer(Modifier.width(8.dp))
+                Text("Discovering...")
+            } else {
+                Icon(
+                    imageVector = Icons.Filled.Refresh,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(Modifier.width(8.dp))
+                Text("Discover Servers")
+            }
+        }
+
+        // Show discovered servers
+        if (discoveredServers.isNotEmpty()) {
+            Text(
+                text = "Found ${discoveredServers.size} server(s):",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+
+            discoveredServers.forEach { server ->
+                val isSelected = selectedServer?.id == server.id
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            viewModel.selectServer(server)
+                            onEditingChange(true)
+                        }
+                        .testableClickable("server_${server.id}") {
+                            viewModel.selectServer(server)
+                            onEditingChange(true)
+                        },
+                    colors = CardDefaults.cardColors(
+                        containerColor = if (isSelected)
+                            MaterialTheme.colorScheme.primaryContainer
+                        else
+                            MaterialTheme.colorScheme.surfaceVariant
+                    ),
+                    border = if (isSelected)
+                        BorderStroke(2.dp, MaterialTheme.colorScheme.primary)
+                    else
+                        null
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(12.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = server.label,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = if (isSelected)
+                                    MaterialTheme.colorScheme.onPrimaryContainer
+                                else
+                                    MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Text(
+                                text = server.url,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = if (isSelected)
+                                    MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
+                                else
+                                    MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+                            )
+                        }
+                        // Server type badge
+                        Surface(
+                            color = MaterialTheme.colorScheme.tertiaryContainer,
+                            shape = RoundedCornerShape(4.dp)
+                        ) {
+                            Text(
+                                text = server.serverType.uppercase(),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onTertiaryContainer,
+                                modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp)
+                            )
+                        }
+                    }
+                }
+            }
+        } else if (!isDiscovering && discoveredServers.isEmpty()) {
+            // No servers found message
+            Text(
+                text = "No servers found. Ensure your LLM server is running.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+
+    // Model selection (only show if not local_inference OR if a server is selected)
+    if (llmProvider != "local_inference" || selectedServer != null) {
+        var modelExpanded by remember { mutableStateOf(false) }
+
+        ExposedDropdownMenuBox(
+            expanded = modelExpanded,
+            onExpandedChange = { modelExpanded = it }
+        ) {
+            OutlinedTextField(
+                value = llmModel.ifEmpty { localizedString("mobile.settings_select_model") },
+                onValueChange = {},
+                readOnly = true,
+                label = { Text(localizedString("mobile.settings_model")) },
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = modelExpanded) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .menuAnchor()
+                    .testable("input_llm_model")
+            )
+
+            ExposedDropdownMenu(
+                expanded = modelExpanded,
+                onDismissRequest = { modelExpanded = false }
+            ) {
+                availableModels.forEach { model ->
+                    DropdownMenuItem(
+                        text = { Text(model) },
+                        onClick = {
+                            viewModel.onModelChanged(model)
+                            modelExpanded = false
+                            onEditingChange(true)
+                        },
+                        modifier = Modifier.testableClickable("menu_model_$model") {
+                            viewModel.onModelChanged(model)
+                            modelExpanded = false
+                            onEditingChange(true)
+                        }
+                    )
+                }
             }
         }
     }

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/screens/SetupScreen.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/screens/SetupScreen.kt
@@ -1486,6 +1486,7 @@ private fun LlmConfigurationStep(
                 LocalLlmServerDiscovery(
                     state = discoveryState,
                     apiClient = apiClient,
+                    localInferenceCapability = localInference,
                     onServerSelected = { server ->
                         // Set base URL from discovered server
                         val baseUrl = when (server.serverType) {
@@ -1552,8 +1553,8 @@ private fun LlmConfigurationStep(
             // - mobile_local (on-device Gemma 4)
             val isMobileLocalProvider = state.llmProvider == SetupViewModel.LOCAL_ON_DEVICE_PROVIDER_ID ||
                 state.llmProvider == SetupViewModel.LOCAL_ON_DEVICE_DISPLAY_NAME
-            val isLocalProvider = state.llmProvider in listOf("local", "local_inference", "LocalAI")
-            if (!isLocalProvider && !isMobileLocalProvider) {
+            val isKeylessProvider = state.llmProvider in listOf("local", "local_inference", "LocalAI")
+            if (!isKeylessProvider && !isMobileLocalProvider) {
                 val apiKeyLabel = if (state.llmProvider == "OpenAI Compatible") {
                     "API Key (optional)"
                 } else {

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/screens/SetupScreen.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/screens/SetupScreen.kt
@@ -6,7 +6,6 @@ import ai.ciris.mobile.shared.models.Platform
 import ai.ciris.mobile.shared.models.SetupMode
 import ai.ciris.mobile.shared.models.filterAdaptersForPlatform
 import ai.ciris.mobile.shared.platform.LocalInferenceCapability
-import ai.ciris.mobile.shared.platform.LocalInferenceTier
 import ai.ciris.mobile.shared.platform.PlatformLogger
 import ai.ciris.mobile.shared.platform.getOAuthProviderName
 import ai.ciris.mobile.shared.platform.getPlatform
@@ -1282,19 +1281,6 @@ private fun LlmConfigurationStep(
             modifier = Modifier.padding(bottom = 24.dp)
         )
 
-        // On-device Gemma 4 option. Shown only when the device capability
-        // probe reports a capable mobile phone, or when the platform is iOS
-        // with capable hardware but no model bundle installed yet (stub).
-        // Hidden entirely on desktop and low-spec devices so the wizard is
-        // not cluttered with options that cannot run.
-        if (!localInference.isHidden) {
-            LocalInferenceOptionCard(
-                capability = localInference,
-                isSelected = state.setupMode == SetupMode.LOCAL_ON_DEVICE,
-                onSelect = { viewModel.setSetupMode(SetupMode.LOCAL_ON_DEVICE) },
-            )
-        }
-
         // CIRIS Proxy card (for Google users in CIRIS_PROXY mode)
         if (state.isGoogleAuth && state.setupMode == SetupMode.CIRIS_PROXY) {
             Surface(
@@ -1385,12 +1371,8 @@ private fun LlmConfigurationStep(
             }
         }
 
-        // BYOK configuration (shown when in BYOK mode or for non-Google
-        // users). Hidden when the user picked on-device inference —
-        // that mode owns its entire card above and needs no API key,
-        // base URL, or model text input.
-        if (state.setupMode != SetupMode.LOCAL_ON_DEVICE &&
-            (state.setupMode == SetupMode.BYOK || !state.isGoogleAuth)) {
+        // BYOK configuration (shown when in BYOK mode or for non-Google users)
+        if (state.setupMode == SetupMode.BYOK || !state.isGoogleAuth) {
             // Provider selection
             Text(
                 text = localizedString("mobile.setup_provider"),
@@ -1401,8 +1383,16 @@ private fun LlmConfigurationStep(
             )
 
             var providerExpanded by remember { mutableStateOf(false) }
-            // Use dynamic provider list from ViewModel
+
+            // Dynamic provider list from ViewModel - includes:
+            // - Cloud/hosted providers (OpenAI, Anthropic, etc.)
+            // - Discovered local servers (Ollama, llama.cpp, etc.)
+            // - On-device Gemma 4 (when localInference.isReady or .isComingSoon)
             val providers = viewModel.availableProviders
+
+            // Add on-device option if capable (mobile or desktop with sufficient resources)
+            val showOnDeviceProvider = localInference.isReady || localInference.isComingSoon
+            val onDeviceEntry = SetupViewModel.LOCAL_ON_DEVICE_DISPLAY_NAME
 
             // Get display name for current provider
             val currentProviderDisplay = providers.find { it.first == state.llmProvider }?.second ?: state.llmProvider
@@ -1442,6 +1432,44 @@ private fun LlmConfigurationStep(
                             modifier = Modifier.testableClickable("menu_provider_$key") {
                                 viewModel.setLlmProvider(key)
                                 providerExpanded = false
+                            }
+                        )
+                    }
+
+                    // Show on-device option if capable (includes DESKTOP_CAPABLE)
+                    if (showOnDeviceProvider) {
+                        val isStub = localInference.isComingSoon
+                        // iOS-stub devices still advertise the option so
+                        // users know it exists, but the click is disabled
+                        // until a model bundle is installed.
+                        DropdownMenuItem(
+                            text = {
+                                Column {
+                                    Text(
+                                        text = if (isStub) {
+                                            "$onDeviceEntry — Coming Soon"
+                                        } else {
+                                            onDeviceEntry
+                                        },
+                                        color = if (isStub) SetupColors.TextSecondary else SetupColors.TextPrimary,
+                                    )
+                                    Text(
+                                        text = localInference.reason,
+                                        color = SetupColors.TextSecondary,
+                                        fontSize = 11.sp,
+                                    )
+                                }
+                            },
+                            enabled = !isStub,
+                            onClick = {
+                                viewModel.selectLocalOnDeviceProvider()
+                                providerExpanded = false
+                            },
+                            modifier = Modifier.testableClickable("menu_provider_mobile_local") {
+                                if (!isStub) {
+                                    viewModel.selectLocalOnDeviceProvider()
+                                    providerExpanded = false
+                                }
                             }
                         )
                     }
@@ -1518,9 +1546,15 @@ private fun LlmConfigurationStep(
                 Spacer(modifier = Modifier.height(16.dp))
             }
 
-            // API Key input (optional for local providers)
-            if (state.llmProvider !in listOf("local", "local_inference")) {
-                val apiKeyLabel = if (isLocalProvider) {
+            // API Key input: skip for local/keyless providers
+            // - LocalAI (uses Ollama with no key)
+            // - local, local_inference (discovered local servers)
+            // - mobile_local (on-device Gemma 4)
+            val isMobileLocalProvider = state.llmProvider == SetupViewModel.LOCAL_ON_DEVICE_PROVIDER_ID ||
+                state.llmProvider == SetupViewModel.LOCAL_ON_DEVICE_DISPLAY_NAME
+            val isLocalProvider = state.llmProvider in listOf("local", "local_inference", "LocalAI")
+            if (!isLocalProvider && !isMobileLocalProvider) {
+                val apiKeyLabel = if (state.llmProvider == "OpenAI Compatible") {
                     "API Key (optional)"
                 } else {
                     localizedString("mobile.setup_api_key_label")
@@ -1776,7 +1810,7 @@ private fun LlmConfigurationStep(
                     }
                 },
                 modifier = Modifier.fillMaxWidth().testable("btn_test_connection"),
-                enabled = !isTesting && (isLocalProvider || state.llmApiKey.isNotEmpty()),
+                enabled = !isTesting && (isLocalProvider || isMobileLocalProvider || state.llmApiKey.isNotEmpty()),
                 colors = ButtonDefaults.outlinedButtonColors(
                     contentColor = SetupColors.Primary
                 )
@@ -1830,99 +1864,6 @@ private fun LlmConfigurationStep(
                         }
                     }
                 }
-            }
-        }
-    }
-}
-
-/**
- * Card for selecting on-device Gemma 4 inference during setup.
- *
- * Three visible states, driven by [LocalInferenceCapability]:
- *
- * 1. Capable (E2B or E4B) — card is selectable and, when selected,
- *    highlighted. Shows the tier so the user knows which model will run.
- * 2. iOS stub — card is shown but disabled, labelled "Coming soon".
- *    Lets the user know the path exists without offering a broken click.
- * 3. Incapable — card is not rendered (handled by the caller via
- *    [LocalInferenceCapability.isHidden]).
- */
-@Composable
-private fun LocalInferenceOptionCard(
-    capability: LocalInferenceCapability,
-    isSelected: Boolean,
-    onSelect: () -> Unit,
-) {
-    val isStub = capability.isComingSoon
-    val backgroundColor = when {
-        isSelected -> SetupColors.SuccessLight
-        isStub -> SetupColors.InfoLight
-        else -> SetupColors.InfoLight
-    }
-    val titleColor = if (isStub) SetupColors.InfoDark else SetupColors.SuccessDark
-    val bodyColor = if (isStub) SetupColors.InfoText else SetupColors.SuccessText
-
-    val tierLabel = when (capability.tier) {
-        LocalInferenceTier.CAPABLE_E4B -> "Gemma 4 E4B"
-        LocalInferenceTier.CAPABLE_E2B -> "Gemma 4 E2B"
-        LocalInferenceTier.IOS_STUB -> "Coming soon"
-        LocalInferenceTier.INCAPABLE -> "Unavailable"
-    }
-
-    val titleText = if (isStub) {
-        "On-Device (Coming Soon)"
-    } else {
-        "On-Device Local — $tierLabel"
-    }
-
-    val cardModifier = Modifier
-        .fillMaxWidth()
-        .padding(bottom = 16.dp)
-        .then(
-            if (!isStub) {
-                Modifier.testableClickable("btn_select_local_on_device") { onSelect() }
-            } else {
-                Modifier.testable("card_local_on_device_stub")
-            }
-        )
-
-    Surface(
-        shape = RoundedCornerShape(12.dp),
-        color = backgroundColor,
-        modifier = cardModifier,
-    ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.padding(bottom = 8.dp),
-            ) {
-                Text(
-                    text = if (isSelected) "✓" else if (isStub) "⏳" else "📱",
-                    color = titleColor,
-                    fontSize = 20.sp,
-                    modifier = Modifier.padding(end = 8.dp),
-                )
-                Text(
-                    text = titleText,
-                    color = titleColor,
-                    fontSize = 16.sp,
-                    fontWeight = FontWeight.Bold,
-                )
-            }
-            Text(
-                text = capability.reason,
-                color = bodyColor,
-                fontSize = 13.sp,
-                lineHeight = 18.sp,
-                modifier = Modifier.padding(bottom = 4.dp),
-            )
-            if (capability.totalRamGb > 0.0) {
-                val rounded = (capability.totalRamGb * 10).toLong() / 10.0
-                Text(
-                    text = "Detected device RAM: $rounded GB",
-                    color = bodyColor,
-                    fontSize = 12.sp,
-                )
             }
         }
     }

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/screens/SetupScreen.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/screens/SetupScreen.kt
@@ -18,6 +18,8 @@ import ai.ciris.mobile.shared.models.ConfigStepResultData
 import ai.ciris.mobile.shared.models.DiscoveredItemData
 import ai.ciris.mobile.shared.models.LoadableAdaptersData
 import ai.ciris.mobile.shared.ui.components.AdapterWizardDialog
+import ai.ciris.mobile.shared.ui.components.LocalLlmServerDiscovery
+import ai.ciris.mobile.shared.ui.components.rememberLocalLlmDiscoveryState
 import ai.ciris.mobile.shared.viewmodels.DeviceAuthStatus
 import ai.ciris.mobile.shared.viewmodels.LlmValidationResult
 import ai.ciris.mobile.shared.viewmodels.ModelInfo
@@ -1249,6 +1251,9 @@ private fun LlmConfigurationStep(
     var availableModels by remember { mutableStateOf<List<ModelInfo>>(emptyList()) }
     val coroutineScope = rememberCoroutineScope()
 
+    // State for local LLM server discovery
+    val discoveryState = rememberLocalLlmDiscoveryState()
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -1372,14 +1377,18 @@ private fun LlmConfigurationStep(
             )
 
             var providerExpanded by remember { mutableStateOf(false) }
-            val providers = listOf("OpenAI", "Anthropic", "Google AI", "OpenRouter", "Groq", "Together AI", "LocalAI", "OpenAI Compatible")
+            // Use dynamic provider list from ViewModel
+            val providers = viewModel.availableProviders
+
+            // Get display name for current provider
+            val currentProviderDisplay = providers.find { it.first == state.llmProvider }?.second ?: state.llmProvider
 
             ExposedDropdownMenuBox(
                 expanded = providerExpanded,
                 onExpandedChange = { providerExpanded = it }
             ) {
                 OutlinedTextField(
-                    value = state.llmProvider,
+                    value = currentProviderDisplay,
                     onValueChange = {},
                     readOnly = true,
                     modifier = Modifier
@@ -1399,15 +1408,15 @@ private fun LlmConfigurationStep(
                     expanded = providerExpanded,
                     onDismissRequest = { providerExpanded = false }
                 ) {
-                    providers.forEach { provider ->
+                    providers.forEach { (key, label) ->
                         DropdownMenuItem(
-                            text = { Text(provider) },
+                            text = { Text(label) },
                             onClick = {
-                                viewModel.setLlmProvider(provider)
+                                viewModel.setLlmProvider(key)
                                 providerExpanded = false
                             },
-                            modifier = Modifier.testableClickable("menu_provider_${provider.lowercase().replace(" ", "_")}") {
-                                viewModel.setLlmProvider(provider)
+                            modifier = Modifier.testableClickable("menu_provider_$key") {
+                                viewModel.setLlmProvider(key)
                                 providerExpanded = false
                             }
                         )
@@ -1417,8 +1426,48 @@ private fun LlmConfigurationStep(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            // Endpoint URL for LocalAI and OpenAI Compatible
-            if (state.llmProvider == "LocalAI" || state.llmProvider == "OpenAI Compatible") {
+            // Local providers that need endpoint URL
+            val isLocalProvider = state.llmProvider in listOf("local", "local_inference", "openai_compatible", "other")
+
+            // Local Inference Server Discovery UI
+            if (state.llmProvider == "local_inference") {
+                LocalLlmServerDiscovery(
+                    state = discoveryState,
+                    apiClient = apiClient,
+                    onServerSelected = { server ->
+                        // Set base URL from discovered server
+                        val baseUrl = when (server.serverType) {
+                            "ollama" -> "${server.url}/v1"
+                            else -> "${server.url}/v1"
+                        }
+                        viewModel.setLlmBaseUrl(baseUrl)
+
+                        // Populate availableModels from discovered server
+                        if (server.models.isNotEmpty()) {
+                            availableModels = server.models.map { modelId ->
+                                ModelInfo(
+                                    id = modelId,
+                                    displayName = modelId,
+                                    contextWindow = null,
+                                    cirisCompatible = true,
+                                    cirisRecommended = false
+                                )
+                            }
+                            // Auto-select first model
+                            viewModel.setLlmModel(server.models.first())
+                        }
+                    },
+                    primaryColor = SetupColors.Primary,
+                    surfaceColor = SetupColors.Background,
+                    textColor = SetupColors.TextPrimary,
+                    secondaryTextColor = SetupColors.TextSecondary
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+
+            // Endpoint URL for local providers (show for all local providers)
+            if (isLocalProvider) {
                 Text(
                     text = "Endpoint URL (optional)",
                     color = SetupColors.TextPrimary,
@@ -1445,9 +1494,9 @@ private fun LlmConfigurationStep(
                 Spacer(modifier = Modifier.height(16.dp))
             }
 
-            // API Key input (optional for LocalAI and OpenAI Compatible)
-            if (state.llmProvider != "LocalAI") {
-                val apiKeyLabel = if (state.llmProvider == "OpenAI Compatible") {
+            // API Key input (optional for local providers)
+            if (state.llmProvider !in listOf("local", "local_inference")) {
+                val apiKeyLabel = if (isLocalProvider) {
                     "API Key (optional)"
                 } else {
                     localizedString("mobile.setup_api_key_label")
@@ -1623,13 +1672,13 @@ private fun LlmConfigurationStep(
                     placeholder = {
                         Text(
                             text = when (state.llmProvider) {
-                                "OpenAI" -> "gpt-4o"
-                                "Anthropic" -> "claude-sonnet-4-5-20250514"
-                                "Google AI" -> "gemini-2.0-flash"
-                                "OpenRouter" -> "anthropic/claude-sonnet-4"
-                                "Groq" -> "llama-3.3-70b-versatile"
-                                "Together AI" -> "meta-llama/Llama-3.3-70B-Instruct-Turbo"
-                                "LocalAI" -> "llama3"
+                                "openai" -> "gpt-4o"
+                                "anthropic" -> "claude-sonnet-4-5-20250514"
+                                "google" -> "gemini-2.0-flash"
+                                "openrouter" -> "anthropic/claude-sonnet-4"
+                                "groq" -> "llama-3.3-70b-versatile"
+                                "together" -> "meta-llama/Llama-3.3-70B-Instruct-Turbo"
+                                "local", "local_inference" -> "llama3.2"
                                 else -> "model-name"
                             },
                             color = SetupColors.TextSecondary
@@ -1656,17 +1705,8 @@ private fun LlmConfigurationStep(
                         testResult = null
                         coroutineScope.launch(Dispatchers.IO) {
                             try {
-                                val providerId = when (state.llmProvider) {
-                                    "OpenAI" -> "openai"
-                                    "Anthropic" -> "anthropic"
-                                    "Google AI" -> "google"
-                                    "OpenRouter" -> "openrouter"
-                                    "Groq" -> "groq"
-                                    "Together AI" -> "together"
-                                    "LocalAI" -> "local"
-                                    "OpenAI Compatible" -> "openai_compatible"
-                                    else -> "other"
-                                }
+                                // Provider is now stored as key directly (e.g., "openai", "local")
+                                val providerId = state.llmProvider
                                 val result = apiClient.validateLlmConfiguration(
                                     provider = providerId,
                                     apiKey = state.llmApiKey,
@@ -1712,7 +1752,7 @@ private fun LlmConfigurationStep(
                     }
                 },
                 modifier = Modifier.fillMaxWidth().testable("btn_test_connection"),
-                enabled = !isTesting && (state.llmProvider == "LocalAI" || state.llmProvider == "OpenAI Compatible" || state.llmApiKey.isNotEmpty()),
+                enabled = !isTesting && (isLocalProvider || state.llmApiKey.isNotEmpty()),
                 colors = ButtonDefaults.outlinedButtonColors(
                     contentColor = SetupColors.Primary
                 )

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/screens/SetupScreen.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/screens/SetupScreen.kt
@@ -1385,8 +1385,12 @@ private fun LlmConfigurationStep(
             }
         }
 
-        // BYOK configuration (shown when in BYOK mode or for non-Google users)
-        if (state.setupMode == SetupMode.BYOK || !state.isGoogleAuth) {
+        // BYOK configuration (shown when in BYOK mode or for non-Google
+        // users). Hidden when the user picked on-device inference —
+        // that mode owns its entire card above and needs no API key,
+        // base URL, or model text input.
+        if (state.setupMode != SetupMode.LOCAL_ON_DEVICE &&
+            (state.setupMode == SetupMode.BYOK || !state.isGoogleAuth)) {
             // Provider selection
             Text(
                 text = localizedString("mobile.setup_provider"),

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/screens/SetupScreen.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/screens/SetupScreen.kt
@@ -5,9 +5,12 @@ import ai.ciris.mobile.shared.localization.localizedString
 import ai.ciris.mobile.shared.models.Platform
 import ai.ciris.mobile.shared.models.SetupMode
 import ai.ciris.mobile.shared.models.filterAdaptersForPlatform
+import ai.ciris.mobile.shared.platform.LocalInferenceCapability
+import ai.ciris.mobile.shared.platform.LocalInferenceTier
 import ai.ciris.mobile.shared.platform.PlatformLogger
 import ai.ciris.mobile.shared.platform.getOAuthProviderName
 import ai.ciris.mobile.shared.platform.getPlatform
+import ai.ciris.mobile.shared.platform.probeLocalInferenceCapability
 import ai.ciris.mobile.shared.platform.testable
 import ai.ciris.mobile.shared.platform.testableClickable
 import ai.ciris.mobile.shared.platform.TestAutomation
@@ -1251,8 +1254,12 @@ private fun LlmConfigurationStep(
     var availableModels by remember { mutableStateOf<List<ModelInfo>>(emptyList()) }
     val coroutineScope = rememberCoroutineScope()
 
-    // State for local LLM server discovery
+    // State for local LLM server discovery (finds running servers on network)
     val discoveryState = rememberLocalLlmDiscoveryState()
+
+    // Probe on-device inference capability (checks if system CAN run local inference)
+    // Cheap: ActivityManager/NSProcessInfo call + disk check
+    val localInference: LocalInferenceCapability = remember { probeLocalInferenceCapability() }
 
     Column(
         modifier = modifier
@@ -1274,6 +1281,19 @@ private fun LlmConfigurationStep(
             fontSize = 14.sp,
             modifier = Modifier.padding(bottom = 24.dp)
         )
+
+        // On-device Gemma 4 option. Shown only when the device capability
+        // probe reports a capable mobile phone, or when the platform is iOS
+        // with capable hardware but no model bundle installed yet (stub).
+        // Hidden entirely on desktop and low-spec devices so the wizard is
+        // not cluttered with options that cannot run.
+        if (!localInference.isHidden) {
+            LocalInferenceOptionCard(
+                capability = localInference,
+                isSelected = state.setupMode == SetupMode.LOCAL_ON_DEVICE,
+                onSelect = { viewModel.setSetupMode(SetupMode.LOCAL_ON_DEVICE) },
+            )
+        }
 
         // CIRIS Proxy card (for Google users in CIRIS_PROXY mode)
         if (state.isGoogleAuth && state.setupMode == SetupMode.CIRIS_PROXY) {
@@ -1806,6 +1826,99 @@ private fun LlmConfigurationStep(
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+/**
+ * Card for selecting on-device Gemma 4 inference during setup.
+ *
+ * Three visible states, driven by [LocalInferenceCapability]:
+ *
+ * 1. Capable (E2B or E4B) — card is selectable and, when selected,
+ *    highlighted. Shows the tier so the user knows which model will run.
+ * 2. iOS stub — card is shown but disabled, labelled "Coming soon".
+ *    Lets the user know the path exists without offering a broken click.
+ * 3. Incapable — card is not rendered (handled by the caller via
+ *    [LocalInferenceCapability.isHidden]).
+ */
+@Composable
+private fun LocalInferenceOptionCard(
+    capability: LocalInferenceCapability,
+    isSelected: Boolean,
+    onSelect: () -> Unit,
+) {
+    val isStub = capability.isComingSoon
+    val backgroundColor = when {
+        isSelected -> SetupColors.SuccessLight
+        isStub -> SetupColors.InfoLight
+        else -> SetupColors.InfoLight
+    }
+    val titleColor = if (isStub) SetupColors.InfoDark else SetupColors.SuccessDark
+    val bodyColor = if (isStub) SetupColors.InfoText else SetupColors.SuccessText
+
+    val tierLabel = when (capability.tier) {
+        LocalInferenceTier.CAPABLE_E4B -> "Gemma 4 E4B"
+        LocalInferenceTier.CAPABLE_E2B -> "Gemma 4 E2B"
+        LocalInferenceTier.IOS_STUB -> "Coming soon"
+        LocalInferenceTier.INCAPABLE -> "Unavailable"
+    }
+
+    val titleText = if (isStub) {
+        "On-Device (Coming Soon)"
+    } else {
+        "On-Device Local — $tierLabel"
+    }
+
+    val cardModifier = Modifier
+        .fillMaxWidth()
+        .padding(bottom = 16.dp)
+        .then(
+            if (!isStub) {
+                Modifier.testableClickable("btn_select_local_on_device") { onSelect() }
+            } else {
+                Modifier.testable("card_local_on_device_stub")
+            }
+        )
+
+    Surface(
+        shape = RoundedCornerShape(12.dp),
+        color = backgroundColor,
+        modifier = cardModifier,
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(bottom = 8.dp),
+            ) {
+                Text(
+                    text = if (isSelected) "✓" else if (isStub) "⏳" else "📱",
+                    color = titleColor,
+                    fontSize = 20.sp,
+                    modifier = Modifier.padding(end = 8.dp),
+                )
+                Text(
+                    text = titleText,
+                    color = titleColor,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+            Text(
+                text = capability.reason,
+                color = bodyColor,
+                fontSize = 13.sp,
+                lineHeight = 18.sp,
+                modifier = Modifier.padding(bottom = 4.dp),
+            )
+            if (capability.totalRamGb > 0.0) {
+                val rounded = (capability.totalRamGb * 10).toLong() / 10.0
+                Text(
+                    text = "Detected device RAM: $rounded GB",
+                    color = bodyColor,
+                    fontSize = 12.sp,
+                )
             }
         }
     }

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SettingsViewModel.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SettingsViewModel.kt
@@ -139,21 +139,37 @@ class SettingsViewModel(
         "deepseek" to "DeepSeek",
         "xai" to "xAI (Grok)",
         "azure" to "Azure OpenAI",
+        "local_inference" to "Local Inference Server",
         "local" to "Local (Ollama)",
         "openai_compatible" to "OpenAI Compatible",
         "other" to "Other"
     )
 
-    // Available models per provider
+    // Available models per provider (static fallbacks for cloud providers only)
+    // Local providers should ALWAYS query - no hardcoded defaults
     private val modelsByProvider = mapOf(
         "openai" to listOf("gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "gpt-4", "gpt-3.5-turbo"),
         "anthropic" to listOf("claude-sonnet-4-20250514", "claude-3-5-sonnet-20241022", "claude-3-5-haiku-20241022"),
-        "other" to listOf("default"),
-        "local" to listOf("llama3.2", "llama3.1", "mistral", "codellama", "qwen2.5")
+        "other" to listOf("default")
+        // NOTE: "local" and "openai_compatible" intentionally omitted - always query the endpoint
     )
 
     private val _availableModels = MutableStateFlow<List<String>>(emptyList())
     val availableModels: StateFlow<List<String>> = _availableModels.asStateFlow()
+
+    // ========== Local Inference Server Discovery ==========
+
+    // Discovered servers from network scan
+    private val _discoveredServers = MutableStateFlow<List<DiscoveredLlmServer>>(emptyList())
+    val discoveredServers: StateFlow<List<DiscoveredLlmServer>> = _discoveredServers.asStateFlow()
+
+    // Currently selected server (for local_inference provider)
+    private val _selectedServer = MutableStateFlow<DiscoveredLlmServer?>(null)
+    val selectedServer: StateFlow<DiscoveredLlmServer?> = _selectedServer.asStateFlow()
+
+    // Discovery in progress flag
+    private val _isDiscovering = MutableStateFlow(false)
+    val isDiscovering: StateFlow<Boolean> = _isDiscovering.asStateFlow()
 
     // Track if we've loaded config
     private var hasLoadedConfig = false
@@ -349,9 +365,15 @@ class SettingsViewModel(
 
     // ========== BYOK Mode: Form Updates ==========
 
+    // Default base URLs for providers that need them
+    private val defaultBaseUrlsByProvider = mapOf(
+        "local" to "http://127.0.0.1:11434/v1",  // Ollama default with OpenAI-compatible endpoint
+        "openai_compatible" to "http://127.0.0.1:8080/v1"  // Generic local server
+    )
+
     /**
      * Update LLM provider (BYOK mode only).
-     * Fetches available models from the API for the selected provider.
+     * Resets base URL and API key to provider defaults, then fetches available models.
      */
     fun onProviderChanged(provider: String) {
         if (_isCirisProxy.value) {
@@ -363,16 +385,110 @@ class SettingsViewModel(
         logInfo(method, "Provider changed to: $provider")
 
         _llmProvider.value = provider
+
+        // Reset base URL to provider's default (clear for cloud providers, set localhost for local)
+        val defaultBaseUrl = defaultBaseUrlsByProvider[provider] ?: ""
+        _llmBaseUrl.value = defaultBaseUrl
+        logInfo(method, "Reset base URL to: ${defaultBaseUrl.ifEmpty { "(empty - use provider default)" }}")
+
+        // Clear API key for local providers (they don't need one)
+        // For cloud providers, load from storage
+        if (provider == "local" || provider == "openai_compatible" || provider == "local_inference") {
+            _apiKey.value = ""
+            _apiKeyMasked.value = ""
+            logInfo(method, "Cleared API key for local provider")
+        }
+
+        // For local_inference, trigger discovery instead of using static list
+        if (provider == "local_inference") {
+            _availableModels.value = emptyList()
+            _llmModel.value = ""
+            _selectedServer.value = null
+            _discoveredServers.value = emptyList()
+            discoverLocalServers()
+            return
+        }
+
         // Use static fallback first while fetching
         _availableModels.value = modelsByProvider[provider] ?: emptyList()
 
         // Reset model to first available
         _llmModel.value = modelsByProvider[provider]?.firstOrNull() ?: ""
 
-        // Load API key for new provider and fetch live models
+        // Load API key for cloud providers and fetch live models
         viewModelScope.launch {
-            loadApiKeyFromStorage(provider)
+            if (provider != "local" && provider != "openai_compatible") {
+                loadApiKeyFromStorage(provider)
+            }
             fetchModelsForProvider(provider)
+        }
+    }
+
+    // ========== Local Inference Server Discovery ==========
+
+    /**
+     * Discover local LLM inference servers on the network.
+     * Probes hostnames like jetson.local, ollama.local, etc.
+     * Also scans localhost ports for common LLM servers.
+     */
+    fun discoverLocalServers() {
+        val method = "discoverLocalServers"
+        logInfo(method, "Starting local LLM server discovery...")
+
+        viewModelScope.launch {
+            _isDiscovering.value = true
+            _discoveredServers.value = emptyList()
+
+            try {
+                val servers = apiClient.discoverLocalLlmServers(
+                    timeoutSeconds = 5.0f,
+                    includeLocalhost = true
+                )
+
+                _discoveredServers.value = servers
+                logInfo(method, "Discovered ${servers.size} local LLM servers")
+
+                // Auto-select first server if only one found
+                if (servers.size == 1) {
+                    selectServer(servers.first())
+                }
+            } catch (e: Exception) {
+                logError(method, "Discovery failed: ${e.message}")
+                _discoveredServers.value = emptyList()
+            } finally {
+                _isDiscovering.value = false
+            }
+        }
+    }
+
+    /**
+     * Select a discovered server as the LLM endpoint.
+     * Sets the base URL and fetches available models from the server.
+     */
+    fun selectServer(server: DiscoveredLlmServer) {
+        val method = "selectServer"
+        logInfo(method, "Selected server: ${server.label} (${server.url})")
+
+        _selectedServer.value = server
+
+        // Set base URL to server's URL with /v1 suffix for OpenAI-compatible endpoint
+        val baseUrl = when (server.serverType) {
+            "ollama" -> "${server.url}/v1"  // Ollama needs /v1 for OpenAI-compat
+            else -> "${server.url}/v1"      // Most servers use /v1
+        }
+        _llmBaseUrl.value = baseUrl
+        logInfo(method, "Set base URL to: $baseUrl")
+
+        // If server reported models, use them directly
+        if (server.models.isNotEmpty()) {
+            _availableModels.value = server.models
+            _llmModel.value = server.models.first()
+            logInfo(method, "Using ${server.models.size} models from discovery: ${server.models}")
+        } else {
+            // Otherwise fetch from the server's API
+            viewModelScope.launch {
+                fetchModelsForProvider("local")
+            }
         }
     }
 

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SettingsViewModel.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SettingsViewModel.kt
@@ -126,8 +126,15 @@ class SettingsViewModel(
 
     private var locationSearchJob: Job? = null
 
-    // Available LLM providers for BYOK mode
+    // Available LLM providers for BYOK mode.
+    //
+    // The "mobile_local" entry is the on-device Gemma 4 provider backed by
+    // the `mobile_local_llm` Python adapter. The first-start wizard only
+    // surfaces it when `probeLocalInferenceCapability()` returns a capable
+    // or stub tier — this list exposes it for settings too so a user who
+    // sideloads a model on iOS can flip to on-device inference later.
     val availableProviders = listOf(
+        "mobile_local" to "On-Device (Local Gemma 4)",
         "openai" to "OpenAI",
         "anthropic" to "Anthropic",
         "google" to "Google AI",

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SettingsViewModel.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SettingsViewModel.kt
@@ -36,6 +36,14 @@ class SettingsViewModel(
 
     companion object {
         private const val TAG = "SettingsViewModel"
+
+        /**
+         * Canonical backend provider id for on-device Gemma 4 inference.
+         * Kept in sync with [SetupViewModel.LOCAL_ON_DEVICE_PROVIDER_ID]
+         * so that a selection made in either flow maps to the same
+         * `.env` value on the agent.
+         */
+        const val LOCAL_ON_DEVICE_PROVIDER_ID = "mobile_local"
     }
 
     private fun log(level: String, method: String, message: String) {
@@ -520,9 +528,12 @@ class SettingsViewModel(
                 else -> provider.lowercase()
             }
 
-            // Only fetch if we have an API key
+            // Only fetch if we have an API key. The on-device
+            // `mobile_local` provider is keyless by design — it talks to
+            // a loopback server spawned by the Python adapter — so treat
+            // it the same way as the `local` (Ollama) provider here.
             val apiKey = _apiKey.value
-            if (apiKey.isEmpty() && provider != "local") {
+            if (apiKey.isEmpty() && provider != "local" && provider != LOCAL_ON_DEVICE_PROVIDER_ID) {
                 logWarn(method, "No API key available, using static model list")
                 return
             }
@@ -607,14 +618,20 @@ class SettingsViewModel(
             _errorMessage.value = null
 
             try {
-                // Validate
-                if (_apiKey.value.isEmpty() && _llmProvider.value != "local") {
+                // Validate — the on-device `mobile_local` provider has no
+                // external key. Everything else still requires one unless
+                // the user is using the Ollama-style "local" provider.
+                val providerLower = _llmProvider.value.lowercase()
+                val isKeylessProvider = providerLower == "local" ||
+                    providerLower == LOCAL_ON_DEVICE_PROVIDER_ID ||
+                    providerLower == "on-device (local gemma 4)"
+                if (_apiKey.value.isEmpty() && !isKeylessProvider) {
                     logWarn(method, "Validation failed: API key is required")
                     throw Exception("API key is required")
                 }
 
                 // Map provider display name to ID for API
-                val providerId = when (_llmProvider.value.lowercase()) {
+                val providerId = when (providerLower) {
                     "openai" -> "openai"
                     "openrouter" -> "openrouter"
                     "anthropic" -> "anthropic"
@@ -622,6 +639,7 @@ class SettingsViewModel(
                     "groq" -> "groq"
                     "together ai", "together" -> "together"
                     "local", "localai" -> "local"
+                    LOCAL_ON_DEVICE_PROVIDER_ID, "on-device (local gemma 4)" -> LOCAL_ON_DEVICE_PROVIDER_ID
                     else -> _llmProvider.value.lowercase()
                 }
 

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupState.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupState.kt
@@ -397,17 +397,21 @@ data class SetupFormState(
                     // CIRIS proxy mode - need Google auth token
                     googleIdToken != null
                 } else if (setupMode == SetupMode.BYOK) {
-                    // BYOK mode - need provider and API key (unless local provider)
-                    if (llmProvider in listOf("local", "local_inference", "LocalAI")) {
-                        true
-                    } else {
-                        llmApiKey.isNotEmpty()
-                    }
+                    // BYOK mode - need provider and API key unless the provider is keyless.
+                    // Keyless providers: local inference servers (Ollama, llama.cpp),
+                    // discovered local servers, or on-device mobile_local adapter.
+                    val providerLower = llmProvider.lowercase()
+                    val isKeyless = providerLower == "localai" ||
+                        providerLower == "local" ||
+                        providerLower == "local_inference" ||
+                        providerLower == "mobile_local" ||
+                        providerLower.startsWith("mobile local") ||
+                        providerLower.startsWith("local inference")
+                    isKeyless || llmApiKey.isNotEmpty()
                 } else if (setupMode == SetupMode.LOCAL_ON_DEVICE) {
-                    // On-device inference — the capability probe already
-                    // gated the UI option itself, and the Python adapter
-                    // runs a second probe at runtime, so no API key or
-                    // further input is required to progress.
+                    // On-device inference — the capability probe already gated
+                    // the UI option, and the Python adapter probes at runtime.
+                    // No API key required.
                     true
                 } else {
                     false // No mode selected
@@ -462,11 +466,19 @@ data class SetupFormState(
             }
 
             SetupStep.LLM_CONFIGURATION -> {
+                // Keyless providers skip the API-key requirement: LocalAI
+                // (Ollama) and on-device Gemma 4 via the Mobile Local LLM
+                // adapter (`mobile_local`).
+                val providerLower = llmProvider.lowercase()
+                val isKeylessProvider = providerLower == "localai" ||
+                    providerLower == "local" ||
+                    providerLower == "mobile_local" ||
+                    providerLower.startsWith("mobile local")
                 when {
                     setupMode == null -> LocalizationHelper.getString("setup_validation_select_mode")
                     setupMode == SetupMode.CIRIS_PROXY && googleIdToken == null ->
                         LocalizationHelper.getString("setup_validation_google_required")
-                    setupMode == SetupMode.BYOK && llmProvider != "LocalAI" && llmApiKey.isEmpty() ->
+                    setupMode == SetupMode.BYOK && !isKeylessProvider && llmApiKey.isEmpty() ->
                         LocalizationHelper.getString("setup_validation_api_key_required")
                     else -> null
                 }

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupState.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupState.kt
@@ -403,6 +403,12 @@ data class SetupFormState(
                     } else {
                         llmApiKey.isNotEmpty()
                     }
+                } else if (setupMode == SetupMode.LOCAL_ON_DEVICE) {
+                    // On-device inference — the capability probe already
+                    // gated the UI option itself, and the Python adapter
+                    // runs a second probe at runtime, so no API key or
+                    // further input is required to progress.
+                    true
                 } else {
                     false // No mode selected
                 }

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupState.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupState.kt
@@ -556,6 +556,31 @@ data class DiscoveredLlmServer(
 )
 
 /**
+ * Result of starting a local LLM server.
+ * Source: POST /v1/setup/start-local-server
+ */
+@Serializable
+data class StartLocalServerResult(
+    /** Whether the server was started successfully */
+    val success: Boolean,
+    /** Human-readable message explaining the result */
+    val message: String,
+    /** Server URL if started (http://127.0.0.1:port) */
+    @SerialName("server_url")
+    val serverUrl: String? = null,
+    /** Server type that was started: llama_cpp, ollama */
+    @SerialName("server_type")
+    val serverType: String? = null,
+    /** Model being loaded */
+    val model: String? = null,
+    /** Process ID of the server */
+    val pid: Int? = null,
+    /** Estimated seconds until server is ready to accept requests */
+    @SerialName("estimated_ready_seconds")
+    val estimatedReadySeconds: Int = 60
+)
+
+/**
  * Result of setup completion.
  * Source: POST /v1/setup/complete
  */

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupState.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupState.kt
@@ -397,8 +397,8 @@ data class SetupFormState(
                     // CIRIS proxy mode - need Google auth token
                     googleIdToken != null
                 } else if (setupMode == SetupMode.BYOK) {
-                    // BYOK mode - need provider and API key (unless LocalAI)
-                    if (llmProvider == "LocalAI") {
+                    // BYOK mode - need provider and API key (unless local provider)
+                    if (llmProvider in listOf("local", "local_inference", "LocalAI")) {
                         true
                     } else {
                         llmApiKey.isNotEmpty()
@@ -513,6 +513,28 @@ data class ModelInfo(
     val cirisCompatible: Boolean = false,
     val cirisRecommended: Boolean = false,
     val contextWindow: Int? = null
+)
+
+/**
+ * Discovered local LLM server from network discovery.
+ * Source: POST /v1/setup/discover-local-llm
+ */
+@Serializable
+data class DiscoveredLlmServer(
+    /** Unique server ID (ip_port format) */
+    val id: String,
+    /** Display label (e.g., "jetson.local:8080 (Gemma 4)") */
+    val label: String,
+    /** Server URL (http://ip:port) */
+    val url: String,
+    /** Server type: ollama, llama_cpp, vllm, lmstudio, localai, openai_compatible */
+    @SerialName("server_type")
+    val serverType: String,
+    /** Number of models available */
+    @SerialName("model_count")
+    val modelCount: Int = 0,
+    /** Model names available on server */
+    val models: List<String> = emptyList()
 )
 
 /**

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupViewModel.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupViewModel.kt
@@ -107,10 +107,21 @@ class SetupViewModel : ViewModel() {
     // Source: SetupViewModel.kt:82-85
 
     /**
-     * Set the LLM setup mode (CIRIS_PROXY or BYOK).
+     * Set the LLM setup mode (CIRIS_PROXY, BYOK, or LOCAL_ON_DEVICE).
+     *
+     * When the user picks [SetupMode.LOCAL_ON_DEVICE] we also pre-populate
+     * the provider name so the downstream BYOK-style flow knows which
+     * entry in `availableProviders` to use — the Python runtime still
+     * reads the actual configuration from the `CIRIS_MOBILE_LOCAL_LLM_*`
+     * env vars that are set up at runtime_complete().
      */
     fun setSetupMode(mode: SetupMode) {
-        _state.value = _state.value.copy(setupMode = mode)
+        val next = _state.value.copy(setupMode = mode)
+        _state.value = if (mode == SetupMode.LOCAL_ON_DEVICE) {
+            next.copy(llmProvider = "On-Device (Local Gemma 4)")
+        } else {
+            next
+        }
     }
 
     // ========== LLM Configuration (BYOK mode) ==========

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupViewModel.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupViewModel.kt
@@ -107,37 +107,41 @@ class SetupViewModel : ViewModel() {
     // Source: SetupViewModel.kt:82-85
 
     /**
-     * Set the LLM setup mode (CIRIS_PROXY, BYOK, or LOCAL_ON_DEVICE).
-     *
-     * When the user picks [SetupMode.LOCAL_ON_DEVICE] we store the
-     * canonical backend provider id [LOCAL_ON_DEVICE_PROVIDER_ID]
-     * ("mobile_local") in `llmProvider`, not a display label. The id
-     * is what both the BYOK completion path and the settings save path
-     * use to decide whether an API key is required, and it is also the
-     * value written to the backend `/v1/config/setup/complete` payload.
-     * The human-readable label lives in [SettingsViewModel.availableProviders].
+     * Set the LLM setup mode (CIRIS_PROXY or BYOK).
      */
     fun setSetupMode(mode: SetupMode) {
-        val next = _state.value.copy(setupMode = mode)
-        _state.value = if (mode == SetupMode.LOCAL_ON_DEVICE) {
-            next.copy(
-                llmProvider = LOCAL_ON_DEVICE_PROVIDER_ID,
-                // On-device inference has no API key and defaults to the
-                // Mobile Local LLM loopback server on port 8091. Set both
-                // fields so the wizard summary and the completion payload
-                // stay internally consistent.
-                llmApiKey = "",
-                llmBaseUrl = LOCAL_ON_DEVICE_BASE_URL,
-                llmModel = LOCAL_ON_DEVICE_DEFAULT_MODEL,
-            )
-        } else {
-            next
-        }
+        _state.value = _state.value.copy(setupMode = mode)
+    }
+
+    /**
+     * Select the on-device Gemma 4 provider inside BYOK mode.
+     *
+     * This is a convenience wrapper the wizard UI calls when the user
+     * taps the "Mobile Local (On-Device)" option in the provider
+     * dropdown. It sets the canonical backend provider id
+     * [LOCAL_ON_DEVICE_PROVIDER_ID] in `llmProvider`, clears any
+     * previously entered API key, and pre-populates the loopback base
+     * URL the Python adapter serves on. Users can still come back and
+     * choose a different provider (e.g. OpenAI as a backup) if they
+     * want cloud fallback — the on-device adapter runs in parallel at
+     * [Priority.HIGH] so the LLM bus routes local-first.
+     */
+    fun selectLocalOnDeviceProvider() {
+        _state.value = _state.value.copy(
+            setupMode = SetupMode.BYOK,
+            llmProvider = LOCAL_ON_DEVICE_PROVIDER_ID,
+            llmApiKey = "",
+            llmBaseUrl = LOCAL_ON_DEVICE_BASE_URL,
+            llmModel = LOCAL_ON_DEVICE_DEFAULT_MODEL,
+        )
     }
 
     companion object {
         /** Canonical backend provider id for on-device Gemma 4 inference. */
         const val LOCAL_ON_DEVICE_PROVIDER_ID = "mobile_local"
+
+        /** Display label shown in the BYOK provider dropdown. */
+        const val LOCAL_ON_DEVICE_DISPLAY_NAME = "Mobile Local (On-Device)"
 
         /** Default model id used when the user picks on-device mode. */
         const val LOCAL_ON_DEVICE_DEFAULT_MODEL = "gemma-4-e2b"
@@ -1237,11 +1241,14 @@ class SetupViewModel : ViewModel() {
 
         val currentState = _state.value
 
-        // On-device inference does not hit any external endpoint, so there
-        // is nothing to validate here — the device capability probe is the
-        // validation step for this mode. Return success immediately so the
-        // wizard's "Test connection" action does not appear broken.
-        if (currentState.setupMode == SetupMode.LOCAL_ON_DEVICE) {
+        // On-device inference does not hit any external endpoint, so
+        // there is nothing to validate here — the device capability
+        // probe is the validation step for this provider. Return
+        // success immediately so the wizard's "Test connection" action
+        // does not appear broken.
+        val providerLower = currentState.llmProvider.lowercase()
+        if (providerLower == LOCAL_ON_DEVICE_PROVIDER_ID ||
+            providerLower.startsWith("mobile local")) {
             val ok = LlmValidationResult(
                 valid = true,
                 message = "On-device inference — no remote endpoint to validate",
@@ -1262,6 +1269,8 @@ class SetupViewModel : ViewModel() {
                 "LocalAI" -> "local"
                 "OpenAI Compatible" -> "openai_compatible"
                 "Azure OpenAI" -> "other"
+                LOCAL_ON_DEVICE_PROVIDER_ID, LOCAL_ON_DEVICE_DISPLAY_NAME ->
+                    LOCAL_ON_DEVICE_PROVIDER_ID
                 else -> "openai"
             },
             api_key = currentState.llmApiKey,
@@ -1404,9 +1413,9 @@ class SetupViewModel : ViewModel() {
                 signing_key_id = nodeFlowData?.keyId
             )
         } else {
-            // BYOK mode and LOCAL_ON_DEVICE mode share the same completion
-            // payload shape — the only differences are the provider id and
-            // the API-key handling, which are both no-op for on-device.
+            // BYOK mode — user-provided API key, or keyless providers
+            // (LocalAI / Ollama, or on-device Gemma 4 via the
+            // mobile_local adapter).
             val providerId = when (currentState.llmProvider) {
                 "OpenAI" -> "openai"
                 "OpenRouter" -> "openrouter"
@@ -1417,10 +1426,12 @@ class SetupViewModel : ViewModel() {
                 "Azure OpenAI" -> "other"
                 "LocalAI", "Local LLM" -> "local"
                 "OpenAI Compatible" -> "openai_compatible"
-                // setSetupMode(LOCAL_ON_DEVICE) stores the canonical id
-                // directly, so this branch is taken when the user picked
-                // the on-device option in the wizard.
-                LOCAL_ON_DEVICE_PROVIDER_ID -> LOCAL_ON_DEVICE_PROVIDER_ID
+                // Both the canonical id and the display label funnel to
+                // the same backend provider id. Using the canonical id
+                // end-to-end means the agent writes it straight into
+                // `.env` so the Python adapter picks it up verbatim.
+                LOCAL_ON_DEVICE_PROVIDER_ID, LOCAL_ON_DEVICE_DISPLAY_NAME ->
+                    LOCAL_ON_DEVICE_PROVIDER_ID
                 else -> "openai"
             }
 

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupViewModel.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupViewModel.kt
@@ -109,19 +109,45 @@ class SetupViewModel : ViewModel() {
     /**
      * Set the LLM setup mode (CIRIS_PROXY, BYOK, or LOCAL_ON_DEVICE).
      *
-     * When the user picks [SetupMode.LOCAL_ON_DEVICE] we also pre-populate
-     * the provider name so the downstream BYOK-style flow knows which
-     * entry in `availableProviders` to use — the Python runtime still
-     * reads the actual configuration from the `CIRIS_MOBILE_LOCAL_LLM_*`
-     * env vars that are set up at runtime_complete().
+     * When the user picks [SetupMode.LOCAL_ON_DEVICE] we store the
+     * canonical backend provider id [LOCAL_ON_DEVICE_PROVIDER_ID]
+     * ("mobile_local") in `llmProvider`, not a display label. The id
+     * is what both the BYOK completion path and the settings save path
+     * use to decide whether an API key is required, and it is also the
+     * value written to the backend `/v1/config/setup/complete` payload.
+     * The human-readable label lives in [SettingsViewModel.availableProviders].
      */
     fun setSetupMode(mode: SetupMode) {
         val next = _state.value.copy(setupMode = mode)
         _state.value = if (mode == SetupMode.LOCAL_ON_DEVICE) {
-            next.copy(llmProvider = "On-Device (Local Gemma 4)")
+            next.copy(
+                llmProvider = LOCAL_ON_DEVICE_PROVIDER_ID,
+                // On-device inference has no API key and defaults to the
+                // Mobile Local LLM loopback server on port 8091. Set both
+                // fields so the wizard summary and the completion payload
+                // stay internally consistent.
+                llmApiKey = "",
+                llmBaseUrl = LOCAL_ON_DEVICE_BASE_URL,
+                llmModel = LOCAL_ON_DEVICE_DEFAULT_MODEL,
+            )
         } else {
             next
         }
+    }
+
+    companion object {
+        /** Canonical backend provider id for on-device Gemma 4 inference. */
+        const val LOCAL_ON_DEVICE_PROVIDER_ID = "mobile_local"
+
+        /** Default model id used when the user picks on-device mode. */
+        const val LOCAL_ON_DEVICE_DEFAULT_MODEL = "gemma-4-e2b"
+
+        /**
+         * Loopback base URL of the on-device OpenAI-compatible server
+         * spawned by the Mobile Local LLM Python adapter. Kept in sync
+         * with `MobileLocalLLMConfig.base_url()` in the Python side.
+         */
+        const val LOCAL_ON_DEVICE_BASE_URL = "http://127.0.0.1:8091/v1"
     }
 
     // ========== LLM Configuration (BYOK mode) ==========
@@ -1210,6 +1236,21 @@ class SetupViewModel : ViewModel() {
         _state.value = _state.value.copy(isValidating = true, validationError = null)
 
         val currentState = _state.value
+
+        // On-device inference does not hit any external endpoint, so there
+        // is nothing to validate here — the device capability probe is the
+        // validation step for this mode. Return success immediately so the
+        // wizard's "Test connection" action does not appear broken.
+        if (currentState.setupMode == SetupMode.LOCAL_ON_DEVICE) {
+            val ok = LlmValidationResult(
+                valid = true,
+                message = "On-device inference — no remote endpoint to validate",
+                error = null,
+            )
+            _state.value = _state.value.copy(isValidating = false, validationError = null)
+            return ok
+        }
+
         val request = ValidateLlmRequest(
             provider = when (currentState.llmProvider) {
                 "OpenAI" -> "openai"
@@ -1363,7 +1404,9 @@ class SetupViewModel : ViewModel() {
                 signing_key_id = nodeFlowData?.keyId
             )
         } else {
-            // BYOK mode - use user-provided API key
+            // BYOK mode and LOCAL_ON_DEVICE mode share the same completion
+            // payload shape — the only differences are the provider id and
+            // the API-key handling, which are both no-op for on-device.
             val providerId = when (currentState.llmProvider) {
                 "OpenAI" -> "openai"
                 "OpenRouter" -> "openrouter"
@@ -1374,12 +1417,21 @@ class SetupViewModel : ViewModel() {
                 "Azure OpenAI" -> "other"
                 "LocalAI", "Local LLM" -> "local"
                 "OpenAI Compatible" -> "openai_compatible"
+                // setSetupMode(LOCAL_ON_DEVICE) stores the canonical id
+                // directly, so this branch is taken when the user picked
+                // the on-device option in the wizard.
+                LOCAL_ON_DEVICE_PROVIDER_ID -> LOCAL_ON_DEVICE_PROVIDER_ID
                 else -> "openai"
             }
 
             var apiKey = currentState.llmApiKey
             if (apiKey.isEmpty() && providerId == "local") {
                 apiKey = "local"
+            }
+            if (providerId == LOCAL_ON_DEVICE_PROVIDER_ID) {
+                // No external credential is required: the Python adapter
+                // runs its own OpenAI-compatible server on loopback.
+                apiKey = ""
             }
 
             // For BYOK mode, we still need OAuth fields if user authenticated via OAuth

--- a/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupViewModel.kt
+++ b/mobile/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupViewModel.kt
@@ -52,6 +52,25 @@ class SetupViewModel : ViewModel() {
         CIRISApiClient()
     }
 
+    // Available LLM providers for BYOK mode
+    val availableProviders = listOf(
+        "openai" to "OpenAI",
+        "anthropic" to "Anthropic",
+        "google" to "Google AI",
+        "openrouter" to "OpenRouter",
+        "groq" to "Groq",
+        "together" to "Together AI",
+        "mistral" to "Mistral",
+        "cohere" to "Cohere",
+        "deepseek" to "DeepSeek",
+        "xai" to "xAI (Grok)",
+        "azure" to "Azure OpenAI",
+        "local_inference" to "Local Inference Server",
+        "local" to "Local (Ollama)",
+        "openai_compatible" to "OpenAI Compatible",
+        "other" to "Other"
+    )
+
     // ========== Google OAuth State ==========
     // Source: SetupViewModel.kt:68-80, SetupWizardActivity.kt:110-174
 

--- a/mobile/shared/src/desktopMain/kotlin/ai/ciris/mobile/shared/platform/LocalInferenceCapability.desktop.kt
+++ b/mobile/shared/src/desktopMain/kotlin/ai/ciris/mobile/shared/platform/LocalInferenceCapability.desktop.kt
@@ -1,18 +1,74 @@
 package ai.ciris.mobile.shared.platform
 
+import java.io.File
+
 /**
  * Desktop implementation of the local-inference capability probe.
  *
- * The first-start wizard does not offer the on-device option on desktop.
- * Desktop developers who want to exercise the adapter can opt in via the
- * Python config flag `CIRIS_MOBILE_LOCAL_LLM_ALLOW_DESKTOP=1`, which the
- * adapter honours at runtime. From the UI's perspective the option is
- * simply hidden.
+ * Checks system RAM and disk space to determine if the desktop can run
+ * llama.cpp with Gemma4. Unlike mobile, desktop doesn't auto-start the
+ * server - the wizard offers the user the option to start one.
  */
 actual fun probeLocalInferenceCapability(): LocalInferenceCapability {
-    return LocalInferenceCapability(
-        tier = LocalInferenceTier.INCAPABLE,
-        totalRamGb = 0.0,
-        reason = "on-device Gemma 4 is a mobile-only option; use a cloud provider on desktop",
-    )
+    val runtime = Runtime.getRuntime()
+
+    // Get total RAM in GB (maxMemory is JVM limit, we need system RAM)
+    // Use OS-specific methods to get actual system RAM
+    val totalRamGb = getSystemRamGb()
+
+    // Get free disk space on the app data directory
+    val homeDir = File(System.getProperty("user.home") ?: "/")
+    val freeDiskGb = homeDir.freeSpace.toDouble() / (1024.0 * 1024.0 * 1024.0)
+
+    // Minimum requirements for Gemma4 E2B: 6GB RAM, 3GB disk
+    val minRamGb = 6.0
+    val minDiskGb = 3.0
+
+    return when {
+        totalRamGb < minRamGb -> LocalInferenceCapability(
+            tier = LocalInferenceTier.INCAPABLE,
+            totalRamGb = totalRamGb,
+            reason = "System has ${String.format("%.1f", totalRamGb)}GB RAM; need ${minRamGb}GB+ for local inference",
+        )
+        freeDiskGb < minDiskGb -> LocalInferenceCapability(
+            tier = LocalInferenceTier.INCAPABLE,
+            totalRamGb = totalRamGb,
+            reason = "Only ${String.format("%.1f", freeDiskGb)}GB free disk; need ${minDiskGb}GB+ for model",
+        )
+        else -> LocalInferenceCapability(
+            tier = LocalInferenceTier.DESKTOP_CAPABLE,
+            totalRamGb = totalRamGb,
+            reason = "System can run local llama.cpp inference (${String.format("%.1f", totalRamGb)}GB RAM)",
+        )
+    }
+}
+
+/**
+ * Get system RAM in GB using OS-specific methods.
+ */
+private fun getSystemRamGb(): Double {
+    // Try to read from /proc/meminfo on Linux
+    try {
+        val meminfo = File("/proc/meminfo")
+        if (meminfo.exists()) {
+            meminfo.readLines().forEach { line ->
+                if (line.startsWith("MemTotal:")) {
+                    val kb = line.split(Regex("\\s+"))[1].toLongOrNull() ?: 0L
+                    return kb.toDouble() / (1024.0 * 1024.0)
+                }
+            }
+        }
+    } catch (_: Exception) { }
+
+    // Try using com.sun.management for macOS/Windows
+    try {
+        val osBean = java.lang.management.ManagementFactory.getOperatingSystemMXBean()
+        val method = osBean.javaClass.getMethod("getTotalPhysicalMemorySize")
+        method.isAccessible = true
+        val bytes = method.invoke(osBean) as Long
+        return bytes.toDouble() / (1024.0 * 1024.0 * 1024.0)
+    } catch (_: Exception) { }
+
+    // Fallback: use JVM max memory as a rough estimate (will underreport)
+    return Runtime.getRuntime().maxMemory().toDouble() / (1024.0 * 1024.0 * 1024.0)
 }

--- a/mobile/shared/src/desktopMain/kotlin/ai/ciris/mobile/shared/platform/LocalInferenceCapability.desktop.kt
+++ b/mobile/shared/src/desktopMain/kotlin/ai/ciris/mobile/shared/platform/LocalInferenceCapability.desktop.kt
@@ -1,0 +1,18 @@
+package ai.ciris.mobile.shared.platform
+
+/**
+ * Desktop implementation of the local-inference capability probe.
+ *
+ * The first-start wizard does not offer the on-device option on desktop.
+ * Desktop developers who want to exercise the adapter can opt in via the
+ * Python config flag `CIRIS_MOBILE_LOCAL_LLM_ALLOW_DESKTOP=1`, which the
+ * adapter honours at runtime. From the UI's perspective the option is
+ * simply hidden.
+ */
+actual fun probeLocalInferenceCapability(): LocalInferenceCapability {
+    return LocalInferenceCapability(
+        tier = LocalInferenceTier.INCAPABLE,
+        totalRamGb = 0.0,
+        reason = "on-device Gemma 4 is a mobile-only option; use a cloud provider on desktop",
+    )
+}

--- a/mobile/shared/src/desktopMain/kotlin/ai/ciris/mobile/shared/platform/PythonRuntime.desktop.kt
+++ b/mobile/shared/src/desktopMain/kotlin/ai/ciris/mobile/shared/platform/PythonRuntime.desktop.kt
@@ -319,12 +319,13 @@ actual class PythonRuntime actual constructor() : PythonRuntimeProtocol {
     }
 
     actual override suspend fun getServicesStatus(): Result<Pair<Int, Int>> = runCatching {
-        val response = httpClient.get("$_serverUrl/v1/telemetry/unified")
+        // Use unauthenticated startup-status endpoint for service counts
+        val response = httpClient.get("$_serverUrl/v1/system/startup-status")
         if (response.status != HttpStatusCode.OK) {
             return@runCatching Pair(0, 0)
         }
         val body = response.bodyAsText()
-        // Simple JSON parsing for services_online and services_total
+        // Parse services_online and services_total from startup-status response
         val onlineMatch = Regex(""""services_online"\s*:\s*(\d+)""").find(body)
         val totalMatch = Regex(""""services_total"\s*:\s*(\d+)""").find(body)
         val online = onlineMatch?.groupValues?.get(1)?.toIntOrNull() ?: 0

--- a/mobile/shared/src/iosMain/kotlin/ai/ciris/mobile/shared/platform/LocalInferenceCapability.ios.kt
+++ b/mobile/shared/src/iosMain/kotlin/ai/ciris/mobile/shared/platform/LocalInferenceCapability.ios.kt
@@ -1,0 +1,106 @@
+package ai.ciris.mobile.shared.platform
+
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSProcessInfo
+import platform.Foundation.NSSearchPathForDirectoriesInDomains
+import platform.Foundation.NSUserDomainMask
+
+/**
+ * iOS implementation of the local-inference capability probe.
+ *
+ * Per the Google AI Edge guidance for Gemma 4 on iPhone:
+ *
+ * - AI Edge Gallery now ships on iOS, but LiteRT-LM iOS model bundles
+ *   are not yet distributed with the CIRIS app.
+ * - Capable iOS hardware (arm64, ≥ 6 GB RAM) is therefore reported as
+ *   [LocalInferenceTier.IOS_STUB] — the wizard shows the on-device
+ *   option labelled "coming soon" and keeps it disabled until a model
+ *   bundle is installed at the expected path.
+ * - Anyone who side-loads a model into
+ *   `Documents/ciris/models/gemma-4-litert.bundle` will see the tier
+ *   flip to CAPABLE_E2B / CAPABLE_E4B automatically on next app launch.
+ */
+
+private const val IOS_E2B_MIN_RAM_GB = 6.0
+private const val IOS_E4B_MIN_RAM_GB = 8.0
+private const val BYTES_PER_GB = 1024.0 * 1024.0 * 1024.0
+
+/** Documents-relative path at which a LiteRT-LM iOS model bundle is expected. */
+private const val IOS_MODEL_BUNDLE_NAME = "ciris/models/gemma-4-litert.bundle"
+
+actual fun probeLocalInferenceCapability(): LocalInferenceCapability {
+    val processInfo = NSProcessInfo.processInfo
+    val totalRamBytes = processInfo.physicalMemory.toDouble()
+    val totalRamGb = totalRamBytes / BYTES_PER_GB
+    val ramGbText = formatOneDecimal(totalRamGb)
+
+    // iOS is arm64 everywhere it matters since iPhone 5S (2013). We keep
+    // the check for parity with Android and for the simulator case.
+    val isArm64 = processInfo.operatingSystemVersionString.contains("arm64") ||
+        processInfo.environment["SIMULATOR_DEVICE_NAME"] == null
+    if (!isArm64) {
+        return LocalInferenceCapability(
+            tier = LocalInferenceTier.INCAPABLE,
+            totalRamGb = totalRamGb,
+            reason = "iOS device does not appear to be arm64; on-device Gemma 4 requires arm64",
+        )
+    }
+
+    if (totalRamGb < IOS_E2B_MIN_RAM_GB) {
+        return LocalInferenceCapability(
+            tier = LocalInferenceTier.INCAPABLE,
+            totalRamGb = totalRamGb,
+            reason = "iOS device has $ramGbText GB RAM; on-device Gemma 4 requires at least " +
+                "${formatOneDecimal(IOS_E2B_MIN_RAM_GB)} GB",
+        )
+    }
+
+    // Hardware is capable. Check whether the user already has a model
+    // bundle installed; if not, return the IOS_STUB tier per the user
+    // requirement ("on apple, leave it as a stub if an adequate model
+    // does not exist").
+    val hasModelBundle = iosModelBundleExists()
+    if (!hasModelBundle) {
+        return LocalInferenceCapability(
+            tier = LocalInferenceTier.IOS_STUB,
+            totalRamGb = totalRamGb,
+            reason = "iOS device is capable ($ramGbText GB RAM), but no on-device Gemma 4 model " +
+                "bundle is installed yet. Install one at Documents/$IOS_MODEL_BUNDLE_NAME or wait " +
+                "for a future release.",
+        )
+    }
+
+    return if (totalRamGb >= IOS_E4B_MIN_RAM_GB) {
+        LocalInferenceCapability(
+            tier = LocalInferenceTier.CAPABLE_E4B,
+            totalRamGb = totalRamGb,
+            reason = "iOS device with $ramGbText GB RAM and installed model bundle — " +
+                "can run Gemma 4 E4B on-device",
+        )
+    } else {
+        LocalInferenceCapability(
+            tier = LocalInferenceTier.CAPABLE_E2B,
+            totalRamGb = totalRamGb,
+            reason = "iOS device with $ramGbText GB RAM and installed model bundle — " +
+                "can run Gemma 4 E2B on-device",
+        )
+    }
+}
+
+/** Returns true if the expected LiteRT-LM model bundle is present in Documents/. */
+private fun iosModelBundleExists(): Boolean {
+    val documentsPath = NSSearchPathForDirectoriesInDomains(
+        NSDocumentDirectory,
+        NSUserDomainMask,
+        true,
+    ).firstOrNull() as? String ?: return false
+    val fullPath = "$documentsPath/$IOS_MODEL_BUNDLE_NAME"
+    return NSFileManager.defaultManager.fileExistsAtPath(fullPath)
+}
+
+/** Format a Double with one decimal place without depending on String.format (Kotlin/Native). */
+private fun formatOneDecimal(value: Double): String {
+    val rounded = (value * 10.0).toLong() / 10.0
+    return rounded.toString()
+}

--- a/qa_reports/qa_status.json
+++ b/qa_reports/qa_status.json
@@ -1,78 +1,78 @@
 {
-  "last_updated": "2026-04-13T00:23:41.194301+00:00",
+  "last_updated": "2026-04-14T03:06:39.902532+00:00",
   "version": "2.0.0-beta",
   "modules": {
     "_comment_core": "=== CORE API MODULES ===",
     "auth": {
-      "last_run": "2026-04-13T00:23:41.193386+00:00",
-      "passed": 3,
-      "failed": 0,
-      "total": 3,
-      "status": "passing",
-      "duration_seconds": 12.26,
+      "last_run": "2026-04-14T03:06:39.890768+00:00",
+      "passed": 4,
+      "failed": 1,
+      "total": 5,
+      "status": "failing",
+      "duration_seconds": 9.27,
       "context": "Tests authentication system including login with username/password, JWT token generation/validation, token refresh, and logout. Validates OAuth integration readiness and API key authentication."
     },
     "telemetry": {
-      "last_run": "2026-04-13T00:23:41.194271+00:00",
-      "passed": 4,
+      "last_run": "2026-04-14T03:06:39.898647+00:00",
+      "passed": 9,
       "failed": 0,
-      "total": 4,
+      "total": 9,
       "status": "passing",
-      "duration_seconds": 12.26,
+      "duration_seconds": 9.27,
       "context": "Tests telemetry collection and aggregation including unified metrics endpoint, service health status for all 22 core services, TSDB storage, and metrics export formats (OTLP, Prometheus)."
     },
     "agent": {
-      "last_run": "2026-04-11T01:55:12.187057+00:00",
+      "last_run": "2026-04-14T03:06:39.899039+00:00",
       "passed": 12,
       "failed": 0,
       "total": 12,
       "status": "passing",
-      "duration_seconds": 6.63,
+      "duration_seconds": 9.27,
       "context": "Tests agent interaction endpoints including message submission, response retrieval, conversation history, queue status, thought processing, and the H3ERE reasoning pipeline integration."
     },
     "system": {
-      "last_run": "2026-04-11T01:55:12.187371+00:00",
+      "last_run": "2026-04-14T03:06:39.899389+00:00",
       "passed": 23,
       "failed": 0,
       "total": 23,
       "status": "passing",
-      "duration_seconds": 6.63,
+      "duration_seconds": 9.27,
       "context": "Tests system management endpoints including health checks, runtime control (pause/resume), configuration management, emergency shutdown, and service status monitoring."
     },
     "memory": {
-      "last_run": "2026-04-11T01:55:12.187663+00:00",
+      "last_run": "2026-04-14T03:06:39.899978+00:00",
       "passed": 6,
       "failed": 0,
       "total": 6,
       "status": "passing",
-      "duration_seconds": 6.63,
+      "duration_seconds": 9.27,
       "context": "Tests graph memory system including memorize/recall/forget operations, node and relationship management, user-scoped memory isolation, and query API with filtering."
     },
     "audit": {
-      "last_run": "2026-04-11T01:55:12.187946+00:00",
+      "last_run": "2026-04-14T03:06:39.900335+00:00",
       "passed": 5,
       "failed": 0,
       "total": 5,
       "status": "passing",
-      "duration_seconds": 6.63,
+      "duration_seconds": 9.27,
       "context": "Tests cryptographic audit trail including Ed25519 signed entries, hash chain integrity, event querying with filters, and immutable decision ledger compliance."
     },
     "tools": {
-      "last_run": "2026-04-11T01:55:12.188237+00:00",
+      "last_run": "2026-04-14T03:06:39.900905+00:00",
       "passed": 2,
       "failed": 0,
       "total": 2,
       "status": "passing",
-      "duration_seconds": 6.63,
+      "duration_seconds": 9.27,
       "context": "Tests tool registration and discovery via ToolBus including listing available tools, tool metadata retrieval, and tool service integration from adapters."
     },
     "guidance": {
-      "last_run": "2026-04-11T01:55:12.188536+00:00",
+      "last_run": "2026-04-14T03:06:39.901480+00:00",
       "passed": 2,
       "failed": 0,
       "total": 2,
       "status": "passing",
-      "duration_seconds": 6.63,
+      "duration_seconds": 9.27,
       "context": "Tests WiseAuthority guidance system including deferral request handling, guidance history retrieval, human oversight escalation, and WA certificate validation."
     },
     "consent": {
@@ -139,12 +139,12 @@
       "context": "Tests complete billing workflow with OAuth user including initial 3-credit check, credit deduction after messages (with cache expiry waits), credit exhaustion flow, purchase_required flag validation, and Stripe payment initiation with status checks."
     },
     "multi_occurrence": {
-      "last_run": "2026-04-11T01:55:12.188819+00:00",
+      "last_run": "2026-04-14T03:06:39.902060+00:00",
       "passed": 4,
       "failed": 0,
       "total": 4,
       "status": "passing",
-      "duration_seconds": 6.63,
+      "duration_seconds": 9.27,
       "context": "Tests horizontal scaling with multiple agent occurrences including shared task coordination, atomic claiming with deterministic IDs, wakeup/shutdown synchronization, and PostgreSQL backend compatibility."
     },
     "message_id_debug": {
@@ -382,12 +382,12 @@
       "context": "Tests adaptive filtering system including WiseBus capability restrictions, prohibited domain blocking (medical, financial, legal, weapons), severity level enforcement, and ethical conscience validation gates."
     },
     "sdk": {
-      "last_run": "2026-04-11T01:55:12.189106+00:00",
-      "passed": 8,
-      "failed": 0,
+      "last_run": "2026-04-14T03:06:39.902520+00:00",
+      "passed": 7,
+      "failed": 1,
       "total": 8,
-      "status": "passing",
-      "duration_seconds": 6.63,
+      "status": "failing",
+      "duration_seconds": 9.27,
       "context": "Tests CIRIS Python SDK client library including API client initialization, authentication, agent interaction, memory operations, telemetry queries, and all SDK-wrapped endpoints."
     },
     "extended_api": {
@@ -427,12 +427,12 @@
       "context": "Tests the H3ERE ethical reasoning pipeline's single-step debugging functionality by pausing, stepping through processing, creating tasks, and verifying queue states with cleanup guarantees."
     },
     "streaming": {
-      "last_run": "2026-04-11T02:06:05.867886+00:00",
+      "last_run": "2026-04-14T03:06:39.889500+00:00",
       "passed": 3,
       "failed": 0,
       "total": 3,
       "status": "passing",
-      "duration_seconds": 31.79,
+      "duration_seconds": 9.27,
       "context": "Validates SSE streaming of the 7 core H3ERE reasoning events (thought_start through action_result) with comprehensive schema validation, duplicate detection, audit trail verification, and resource tracking."
     },
     "api_full": {
@@ -474,8 +474,8 @@
   },
   "summary": {
     "total_modules": 52,
-    "passing": 47,
-    "failing": 3,
+    "passing": 45,
+    "failing": 5,
     "not_run": 2
   }
 }

--- a/tests/adapters/api/conftest.py
+++ b/tests/adapters/api/conftest.py
@@ -7,6 +7,8 @@ High-quality centralized fixtures for comprehensive API testing including:
 - WebSocket client simulation
 - Time service mocking for consistent timestamps
 - Service correlation fixtures for testing message fetching
+
+Note: CIRIS_TESTING_MODE is set globally in tests/conftest.py
 """
 
 import asyncio
@@ -185,7 +187,10 @@ def mock_persistence():
 
 @pytest.fixture
 def app():
-    """Create FastAPI app with minimal required state."""
+    """Create FastAPI app with minimal required state.
+
+    Note: CIRIS_TESTING_MODE is set by the autouse enable_testing_mode fixture.
+    """
     app = create_app()
 
     # Initialize auth service (required for auth endpoints)

--- a/tests/adapters/api/test_connectors.py
+++ b/tests/adapters/api/test_connectors.py
@@ -14,32 +14,19 @@ from tests.fixtures.auth import make_login_request
 
 @pytest.fixture
 def client_with_auth(test_db):
-    """Create test client with admin authentication."""
+    """Create test client with admin authentication.
+
+    Note: CIRIS_TESTING_MODE is set globally in tests/conftest.py
+    """
+    from ciris_engine.logic.adapters.api.services.auth_service import APIAuthService
+
     app = create_app()
-
-    # Mock authentication
-    from ciris_engine.logic.adapters.api.services.auth_service import APIAuthService, User
-
-    auth_service = APIAuthService()
-    admin_user = User(
-        wa_id="test_admin",
-        name="Test Admin",
-        auth_type="password",
-        api_role="ADMIN",
-        created_at=datetime.now(timezone.utc),
-        is_active=True,
-    )
-    auth_service._users[admin_user.wa_id] = admin_user
-    app.state.auth_service = auth_service
+    app.state.auth_service = APIAuthService()
 
     client = TestClient(app)
-
-    # Login and get token using centralized auth helper
     client.auth_headers = make_login_request(client)
-
     client.app = app
 
-    # Clear connector registry before each test
     connectors._connector_registry.clear()
 
     yield client

--- a/tests/adapters/api/test_dsar_multi_source.py
+++ b/tests/adapters/api/test_dsar_multi_source.py
@@ -135,25 +135,15 @@ def mock_orchestrator():
 
 @pytest.fixture
 def client_with_auth(test_db, mock_orchestrator):
-    """Create test client with mocked orchestrator."""
+    """Create test client with mocked orchestrator.
+
+    Note: CIRIS_TESTING_MODE is set globally in tests/conftest.py
+    """
+    from ciris_engine.logic.adapters.api.services.auth_service import APIAuthService
+
     app = create_app()
+    app.state.auth_service = APIAuthService()
 
-    # Mock authentication
-    from ciris_engine.logic.adapters.api.services.auth_service import APIAuthService, User
-
-    auth_service = APIAuthService()
-    user = User(
-        wa_id="test_admin",
-        name="Test Admin",
-        auth_type="password",
-        api_role="ADMIN",
-        created_at=datetime.now(timezone.utc),
-        is_active=True,
-    )
-    auth_service._users[user.wa_id] = user
-    app.state.auth_service = auth_service
-
-    # Mock services needed for orchestrator
     with patch("ciris_engine.logic.adapters.api.routes.dsar_multi_source._initialize_orchestrator") as mock_init:
         mock_init.return_value = mock_orchestrator
         client = TestClient(app)

--- a/tests/adapters/api/test_scheduler_routes.py
+++ b/tests/adapters/api/test_scheduler_routes.py
@@ -33,7 +33,10 @@ from ciris_engine.schemas.runtime.extended import ScheduledTask, ScheduledTaskIn
 
 @pytest.fixture
 def app():
-    """Create FastAPI app with minimal required state."""
+    """Create FastAPI app with minimal required state.
+
+    Note: CIRIS_TESTING_MODE is set globally in tests/conftest.py
+    """
     app = create_app()
     app.state.auth_service = APIAuthService()
     app.state.auth_service._dev_mode = True

--- a/tests/api/test_single_step_endpoint.py
+++ b/tests/api/test_single_step_endpoint.py
@@ -39,13 +39,13 @@ class TestSingleStepEndpoint:
 
     @pytest.fixture
     def app(self):
-        """Create FastAPI app with required services."""
-        app = create_app()
+        """Create FastAPI app with required services.
 
-        # Initialize auth service (required for auth endpoints)
+        Note: CIRIS_TESTING_MODE is set globally in tests/conftest.py
+        """
+        app = create_app()
         app.state.auth_service = APIAuthService()
         app.state.auth_service._dev_mode = True
-
         return app
 
     @pytest.fixture

--- a/tests/ciris_adapters/mobile_local_llm/test_adapter.py
+++ b/tests/ciris_adapters/mobile_local_llm/test_adapter.py
@@ -1,0 +1,249 @@
+"""Tests for the MobileLocalLLMAdapter wrapper and lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest import mock
+
+import pytest
+
+from ciris_adapters.mobile_local_llm.adapter import MobileLocalLLMAdapter
+from ciris_adapters.mobile_local_llm.capability import DeviceCapabilityReport
+from ciris_adapters.mobile_local_llm.config import (
+    DeviceTier,
+    MobileLocalLLMConfig,
+    ModelVariant,
+    Platform,
+)
+from ciris_engine.logic.registries.base import Priority
+from ciris_engine.schemas.runtime.enums import ServiceType
+
+
+def _capable_report() -> DeviceCapabilityReport:
+    return DeviceCapabilityReport(
+        tier=DeviceTier.CAPABLE_E2B,
+        platform=Platform.ANDROID,
+        architecture="arm64-v8a",
+        total_ram_gb=6.5,
+        available_ram_gb=3.5,
+        free_disk_gb=10.0,
+        reasons=["capable"],
+    )
+
+
+def _ios_stub_report() -> DeviceCapabilityReport:
+    return DeviceCapabilityReport(
+        tier=DeviceTier.IOS_STUB,
+        platform=Platform.IOS,
+        architecture="arm64-v8a",
+        total_ram_gb=8.0,
+        available_ram_gb=4.0,
+        free_disk_gb=20.0,
+        reasons=["iOS hardware capable but no Gemma 4 model bundle found"],
+    )
+
+
+def _incapable_report() -> DeviceCapabilityReport:
+    return DeviceCapabilityReport(
+        tier=DeviceTier.INCAPABLE,
+        platform=Platform.ANDROID,
+        architecture="arm64-v8a",
+        total_ram_gb=3.0,
+        available_ram_gb=1.0,
+        free_disk_gb=5.0,
+        reasons=["total RAM 3.0GB below threshold"],
+    )
+
+
+@pytest.fixture
+def patched_probe():
+    """Patch the capability probe used by both adapter and service."""
+    with mock.patch(
+        "ciris_adapters.mobile_local_llm.adapter.probe_device_capability"
+    ) as adapter_probe, mock.patch(
+        "ciris_adapters.mobile_local_llm.service.probe_device_capability"
+    ) as service_probe:
+        yield adapter_probe, service_probe
+
+
+@pytest.mark.asyncio
+class TestAdapterRegistration:
+    async def test_registers_single_llm_service_at_high_priority(self):
+        cfg = MobileLocalLLMConfig()
+        adapter = MobileLocalLLMAdapter(runtime=None, adapter_config=cfg)
+        services = adapter.get_services_to_register()
+        assert len(services) == 1
+        reg = services[0]
+        assert reg.service_type == ServiceType.LLM
+        assert reg.priority == Priority.HIGH
+        assert reg.provider is adapter.llm_service
+        assert "provider:mobile_local" in reg.capabilities
+        assert "call_llm_structured" in reg.capabilities
+        assert f"model:{cfg.model_variant.value}" in reg.capabilities
+
+    async def test_accepts_config_as_pydantic(self):
+        cfg = MobileLocalLLMConfig(model_variant=ModelVariant.GEMMA_4_E4B)
+        adapter = MobileLocalLLMAdapter(runtime=None, adapter_config=cfg)
+        assert adapter.config.model_variant == ModelVariant.GEMMA_4_E4B
+
+    async def test_accepts_config_as_dict_overlay(self):
+        adapter = MobileLocalLLMAdapter(
+            runtime=None, adapter_config={"port": 9100, "host": "127.0.0.1"}
+        )
+        assert adapter.config.port == 9100
+
+
+@pytest.mark.asyncio
+class TestAdapterLifecycle:
+    async def test_start_on_capable_device_spawns_health_loop(self, patched_probe):
+        adapter_probe, service_probe = patched_probe
+        adapter_probe.return_value = _capable_report()
+        service_probe.return_value = _capable_report()
+
+        cfg = MobileLocalLLMConfig(health_interval_seconds=0.05)
+        adapter = MobileLocalLLMAdapter(runtime=None, adapter_config=cfg)
+        # Replace the underlying server manager so we don't spawn anything.
+        mgr = mock.MagicMock()
+        mgr.start = mock.AsyncMock(return_value=None)
+        mgr.stop = mock.AsyncMock(return_value=None)
+        mgr.health_check = mock.AsyncMock(return_value=True)
+        adapter.llm_service._server = mgr  # type: ignore[attr-defined]
+
+        await adapter.start()
+        try:
+            assert adapter._running is True  # type: ignore[attr-defined]
+            assert adapter.llm_service.available is True
+            assert adapter._health_task is not None  # type: ignore[attr-defined]
+        finally:
+            await adapter.stop()
+        assert adapter._running is False  # type: ignore[attr-defined]
+        mgr.stop.assert_awaited()
+
+    async def test_start_on_incapable_device_skips_health_loop(self, patched_probe):
+        adapter_probe, service_probe = patched_probe
+        adapter_probe.return_value = _incapable_report()
+        service_probe.return_value = _incapable_report()
+
+        cfg = MobileLocalLLMConfig()
+        adapter = MobileLocalLLMAdapter(runtime=None, adapter_config=cfg)
+        mgr = mock.MagicMock()
+        mgr.start = mock.AsyncMock(return_value=None)
+        mgr.stop = mock.AsyncMock(return_value=None)
+        mgr.health_check = mock.AsyncMock(return_value=False)
+        adapter.llm_service._server = mgr  # type: ignore[attr-defined]
+
+        await adapter.start()
+        try:
+            assert adapter.llm_service.available is False
+            assert adapter._health_task is None  # type: ignore[attr-defined]
+            mgr.start.assert_not_awaited()
+        finally:
+            await adapter.stop()
+
+    async def test_stop_cancels_health_loop_cleanly(self, patched_probe):
+        adapter_probe, service_probe = patched_probe
+        adapter_probe.return_value = _capable_report()
+        service_probe.return_value = _capable_report()
+
+        cfg = MobileLocalLLMConfig(health_interval_seconds=0.05)
+        adapter = MobileLocalLLMAdapter(runtime=None, adapter_config=cfg)
+        mgr = mock.MagicMock()
+        mgr.start = mock.AsyncMock(return_value=None)
+        mgr.stop = mock.AsyncMock(return_value=None)
+        mgr.health_check = mock.AsyncMock(return_value=True)
+        adapter.llm_service._server = mgr  # type: ignore[attr-defined]
+
+        await adapter.start()
+        await asyncio.sleep(0.12)  # let the health loop run at least once
+        await adapter.stop()
+        assert adapter._health_task is None or adapter._health_task.done()  # type: ignore[attr-defined]
+
+    async def test_run_lifecycle_returns_when_agent_task_finishes(self, patched_probe):
+        adapter_probe, service_probe = patched_probe
+        adapter_probe.return_value = _incapable_report()
+        service_probe.return_value = _incapable_report()
+
+        cfg = MobileLocalLLMConfig()
+        adapter = MobileLocalLLMAdapter(runtime=None, adapter_config=cfg)
+        mgr = mock.MagicMock()
+        mgr.start = mock.AsyncMock(return_value=None)
+        mgr.stop = mock.AsyncMock(return_value=None)
+        mgr.health_check = mock.AsyncMock(return_value=True)
+        adapter.llm_service._server = mgr  # type: ignore[attr-defined]
+
+        await adapter.start()
+
+        async def agent():
+            await asyncio.sleep(0.01)
+
+        await adapter.run_lifecycle(asyncio.create_task(agent()))
+        assert adapter._running is False  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+class TestStatusReporting:
+    async def test_get_status_reports_device_not_capable(self, patched_probe):
+        adapter_probe, service_probe = patched_probe
+        adapter_probe.return_value = _incapable_report()
+        service_probe.return_value = _incapable_report()
+
+        cfg = MobileLocalLLMConfig()
+        adapter = MobileLocalLLMAdapter(runtime=None, adapter_config=cfg)
+        mgr = mock.MagicMock()
+        mgr.start = mock.AsyncMock()
+        mgr.stop = mock.AsyncMock()
+        mgr.health_check = mock.AsyncMock(return_value=False)
+        adapter.llm_service._server = mgr  # type: ignore[attr-defined]
+        await adapter.start()
+        status = adapter.get_status()
+        assert status.adapter_type == "mobile_local_llm"
+        assert status.is_running is True
+        assert "device_not_capable" in (status.error or "")
+        await adapter.stop()
+
+    async def test_get_config_surfaces_tier_and_variant(self, patched_probe):
+        adapter_probe, service_probe = patched_probe
+        adapter_probe.return_value = _capable_report()
+        service_probe.return_value = _capable_report()
+
+        cfg = MobileLocalLLMConfig(port=9090)
+        adapter = MobileLocalLLMAdapter(runtime=None, adapter_config=cfg)
+        mgr = mock.MagicMock()
+        mgr.start = mock.AsyncMock()
+        mgr.stop = mock.AsyncMock()
+        mgr.health_check = mock.AsyncMock(return_value=True)
+        adapter.llm_service._server = mgr  # type: ignore[attr-defined]
+        await adapter.start()
+        config_snapshot = adapter.get_config()
+        assert config_snapshot.adapter_type == "mobile_local_llm"
+        assert config_snapshot.settings["variant"] == "gemma-4-e2b"
+        assert config_snapshot.settings["port"] == 9090
+        assert config_snapshot.settings["device_tier"] == "capable_e2b"
+        await adapter.stop()
+
+    async def test_get_status_reports_ios_stub_distinctly(self, patched_probe):
+        """iOS stub is reported as a distinct state — not as a plain failure."""
+        adapter_probe, service_probe = patched_probe
+        adapter_probe.return_value = _ios_stub_report()
+        service_probe.return_value = _ios_stub_report()
+
+        cfg = MobileLocalLLMConfig()
+        adapter = MobileLocalLLMAdapter(runtime=None, adapter_config=cfg)
+        mgr = mock.MagicMock()
+        mgr.start = mock.AsyncMock()
+        mgr.stop = mock.AsyncMock()
+        mgr.health_check = mock.AsyncMock(return_value=False)
+        adapter.llm_service._server = mgr  # type: ignore[attr-defined]
+        await adapter.start()
+        status = adapter.get_status()
+        config_snapshot = adapter.get_config()
+        assert status.error is not None
+        assert status.error.startswith("ios_stub")
+        assert config_snapshot.settings["device_tier"] == "ios_stub"
+        mgr.start.assert_not_awaited()  # stub tier must not spawn the server
+        await adapter.stop()
+
+    async def test_adapter_export_alias(self):
+        from ciris_adapters.mobile_local_llm import Adapter
+
+        assert Adapter is MobileLocalLLMAdapter

--- a/tests/ciris_adapters/mobile_local_llm/test_capability.py
+++ b/tests/ciris_adapters/mobile_local_llm/test_capability.py
@@ -1,0 +1,245 @@
+"""Tests for device capability detection across Android, iOS, and desktop."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ciris_adapters.mobile_local_llm.capability import (
+    DeviceCapabilityReport,
+    detect_architecture,
+    probe_device_capability,
+)
+from ciris_adapters.mobile_local_llm.config import (
+    DeviceTier,
+    MobileLocalLLMConfig,
+    ModelVariant,
+    Platform,
+)
+
+
+def _config(**overrides):
+    return MobileLocalLLMConfig(**overrides)
+
+
+def _probe(
+    config,
+    *,
+    platform=Platform.ANDROID,
+    arch="arm64-v8a",
+    total_ram=8.0,
+    available_ram=4.0,
+    free_disk=5.0,
+):
+    return probe_device_capability(
+        config,
+        platform_fn=lambda: platform,
+        arch_fn=lambda: arch,
+        total_ram_fn=lambda: total_ram,
+        available_ram_fn=lambda: available_ram,
+        free_disk_fn=lambda: free_disk,
+    )
+
+
+class TestDeviceCapabilityReport:
+    def test_capable_and_can_run(self):
+        report = DeviceCapabilityReport(
+            tier=DeviceTier.CAPABLE_E4B,
+            platform=Platform.ANDROID,
+            architecture="arm64-v8a",
+            total_ram_gb=12.0,
+            available_ram_gb=6.0,
+            free_disk_gb=10.0,
+            reasons=["test"],
+        )
+        assert report.capable is True
+        assert report.is_stub is False
+        assert report.is_android is True
+        assert report.is_ios is False
+        assert report.can_run(ModelVariant.GEMMA_4_E2B) is True
+        assert report.can_run(ModelVariant.GEMMA_4_E4B) is True
+
+    def test_e2b_tier_cannot_run_e4b(self):
+        report = DeviceCapabilityReport(
+            tier=DeviceTier.CAPABLE_E2B,
+            platform=Platform.ANDROID,
+            architecture="arm64-v8a",
+            total_ram_gb=6.0,
+            available_ram_gb=3.0,
+            free_disk_gb=5.0,
+            reasons=[],
+        )
+        assert report.capable is True
+        assert report.can_run(ModelVariant.GEMMA_4_E2B) is True
+        assert report.can_run(ModelVariant.GEMMA_4_E4B) is False
+
+    def test_ios_stub_is_not_capable_but_distinct(self):
+        report = DeviceCapabilityReport(
+            tier=DeviceTier.IOS_STUB,
+            platform=Platform.IOS,
+            architecture="arm64-v8a",
+            total_ram_gb=8.0,
+            available_ram_gb=4.0,
+            free_disk_gb=10.0,
+            reasons=["model missing"],
+        )
+        assert report.capable is False
+        assert report.is_stub is True
+        assert report.is_ios is True
+        assert report.can_run(ModelVariant.GEMMA_4_E2B) is False
+
+    def test_incapable_cannot_run_anything(self):
+        report = DeviceCapabilityReport(
+            tier=DeviceTier.INCAPABLE,
+            platform=Platform.DESKTOP,
+            architecture="x86_64",
+            total_ram_gb=2.0,
+            available_ram_gb=1.0,
+            free_disk_gb=1.0,
+            reasons=["x"],
+        )
+        assert report.capable is False
+        assert report.is_stub is False
+        assert report.can_run(ModelVariant.GEMMA_4_E2B) is False
+        assert report.summary().startswith("tier=incapable")
+
+
+class TestProbeAndroid:
+    def test_high_end_phone_gets_e4b(self):
+        report = _probe(_config(), total_ram=12.0)
+        assert report.tier == DeviceTier.CAPABLE_E4B
+        assert report.capable
+        assert report.platform == Platform.ANDROID
+
+    def test_mid_range_phone_gets_e2b(self):
+        report = _probe(_config(), total_ram=6.5)
+        assert report.tier == DeviceTier.CAPABLE_E2B
+
+    def test_low_ram_phone_is_incapable(self):
+        report = _probe(_config(), total_ram=3.5)
+        assert report.tier == DeviceTier.INCAPABLE
+        assert any("below E2B threshold" in r for r in report.reasons)
+
+    def test_32bit_phone_is_incapable_even_with_enough_ram(self):
+        report = _probe(_config(), arch="armeabi-v7a", total_ram=16.0)
+        assert report.tier == DeviceTier.INCAPABLE
+        assert any("arm64" in r for r in report.reasons)
+
+    def test_low_disk_is_incapable(self):
+        report = _probe(_config(min_free_disk_gb=5.0), free_disk=1.0)
+        assert report.tier == DeviceTier.INCAPABLE
+        assert any("free disk" in r for r in report.reasons)
+
+    def test_unknown_ram_fails_safely(self):
+        """If /proc/meminfo is unavailable we must NOT try local inference."""
+        report = _probe(_config(), total_ram=0.0)
+        assert report.tier == DeviceTier.INCAPABLE
+        assert any("could not determine total RAM" in r for r in report.reasons)
+
+
+class TestProbeiOS:
+    def test_capable_ios_without_model_reports_stub(self):
+        """Per user guidance: iOS gets a stub tier when no adequate model exists."""
+        report = _probe(
+            _config(ios_model_path=None, model_path=None),
+            platform=Platform.IOS,
+            arch="arm64-v8a",
+            total_ram=8.0,
+            free_disk=10.0,
+        )
+        assert report.tier == DeviceTier.IOS_STUB
+        assert report.is_stub
+        assert any("coming soon" in r.lower() for r in report.reasons)
+
+    def test_capable_ios_with_model_reports_capable(self, tmp_path):
+        model = tmp_path / "gemma.litert"
+        model.write_bytes(b"x")  # just needs to exist
+        report = _probe(
+            _config(ios_model_path=model),
+            platform=Platform.IOS,
+            total_ram=12.0,
+            free_disk=10.0,
+        )
+        assert report.tier == DeviceTier.CAPABLE_E4B
+        assert report.is_ios
+
+    def test_ios_low_ram_is_incapable_not_stub(self):
+        """Low-RAM iOS devices are not 'coming soon' — they simply cannot run it."""
+        report = _probe(
+            _config(),
+            platform=Platform.IOS,
+            total_ram=3.0,
+            free_disk=10.0,
+        )
+        assert report.tier == DeviceTier.INCAPABLE
+
+    def test_ios_32bit_is_incapable_not_stub(self):
+        """Pre-A7 hypothetical 32-bit iOS is incapable."""
+        report = _probe(
+            _config(),
+            platform=Platform.IOS,
+            arch="armeabi-v7a",
+            total_ram=8.0,
+        )
+        assert report.tier == DeviceTier.INCAPABLE
+
+
+class TestProbeDesktop:
+    def test_desktop_without_opt_in_is_incapable(self):
+        report = _probe(_config(), platform=Platform.DESKTOP, arch="x86_64", total_ram=32.0)
+        assert report.tier == DeviceTier.INCAPABLE
+        assert any("allow_desktop" in r for r in report.reasons)
+
+    def test_desktop_with_opt_in_is_capable(self):
+        report = _probe(
+            _config(allow_desktop=True),
+            platform=Platform.DESKTOP,
+            arch="x86_64",
+            total_ram=32.0,
+        )
+        assert report.tier == DeviceTier.CAPABLE_E4B
+
+    def test_unknown_platform_is_incapable(self):
+        report = _probe(_config(allow_desktop=True), platform=Platform.UNKNOWN, total_ram=16.0)
+        assert report.tier == DeviceTier.INCAPABLE
+
+
+class TestForceCapability:
+    def test_force_capability_bypasses_everything(self):
+        report = _probe(
+            _config(force_capability=DeviceTier.CAPABLE_E2B),
+            platform=Platform.DESKTOP,
+            total_ram=1.0,
+            arch="armeabi-v7a",
+        )
+        assert report.tier == DeviceTier.CAPABLE_E2B
+        # Observed values are still populated for diagnostics.
+        assert report.total_ram_gb == 1.0
+        assert report.architecture == "armeabi-v7a"
+
+    def test_force_ios_stub_respected(self):
+        report = _probe(
+            _config(force_capability=DeviceTier.IOS_STUB),
+            platform=Platform.ANDROID,
+            total_ram=8.0,
+        )
+        assert report.tier == DeviceTier.IOS_STUB
+
+
+class TestDetectArchitecture:
+    @pytest.mark.parametrize(
+        "machine,expected",
+        [
+            ("aarch64", "arm64-v8a"),
+            ("arm64", "arm64-v8a"),
+            ("armv7l", "armeabi-v7a"),
+            ("armv7", "armeabi-v7a"),
+            ("x86_64", "x86_64"),
+            ("AMD64", "x86_64"),
+            ("i686", "x86"),
+        ],
+    )
+    def test_normalises_common_machines(self, monkeypatch, machine, expected):
+        monkeypatch.setattr("platform.machine", lambda: machine)
+        assert detect_architecture() == expected

--- a/tests/ciris_adapters/mobile_local_llm/test_capability.py
+++ b/tests/ciris_adapters/mobile_local_llm/test_capability.py
@@ -89,6 +89,23 @@ class TestDeviceCapabilityReport:
         assert report.is_ios is True
         assert report.can_run(ModelVariant.GEMMA_4_E2B) is False
 
+    def test_desktop_capable_can_run_e2b(self):
+        report = DeviceCapabilityReport(
+            tier=DeviceTier.DESKTOP_CAPABLE,
+            platform=Platform.DESKTOP,
+            architecture="x86_64",
+            total_ram_gb=16.0,
+            available_ram_gb=8.0,
+            free_disk_gb=10.0,
+            reasons=["desktop system"],
+        )
+        assert report.capable is True
+        assert report.is_stub is False
+        # Desktop runs llama.cpp with E2B model
+        assert report.can_run(ModelVariant.GEMMA_4_E2B) is True
+        # E4B requires mobile tiers
+        assert report.can_run(ModelVariant.GEMMA_4_E4B) is False
+
     def test_incapable_cannot_run_anything(self):
         report = DeviceCapabilityReport(
             tier=DeviceTier.INCAPABLE,
@@ -186,22 +203,22 @@ class TestProbeiOS:
 
 
 class TestProbeDesktop:
-    def test_desktop_without_opt_in_is_incapable(self):
+    def test_desktop_with_sufficient_ram_is_capable(self):
+        # Desktop systems with enough RAM are now DESKTOP_CAPABLE
+        # User opts in via the wizard, not via config flag
         report = _probe(_config(), platform=Platform.DESKTOP, arch="x86_64", total_ram=32.0)
-        assert report.tier == DeviceTier.INCAPABLE
-        assert any("allow_desktop" in r for r in report.reasons)
+        assert report.tier == DeviceTier.DESKTOP_CAPABLE
+        assert report.capable is True
+        assert any("desktop system" in r for r in report.reasons)
 
-    def test_desktop_with_opt_in_is_capable(self):
-        report = _probe(
-            _config(allow_desktop=True),
-            platform=Platform.DESKTOP,
-            arch="x86_64",
-            total_ram=32.0,
-        )
-        assert report.tier == DeviceTier.CAPABLE_E4B
+    def test_desktop_with_low_ram_is_incapable(self):
+        # Desktop with insufficient RAM returns INCAPABLE
+        report = _probe(_config(), platform=Platform.DESKTOP, arch="x86_64", total_ram=4.0)
+        assert report.tier == DeviceTier.INCAPABLE
+        assert report.capable is False
 
     def test_unknown_platform_is_incapable(self):
-        report = _probe(_config(allow_desktop=True), platform=Platform.UNKNOWN, total_ram=16.0)
+        report = _probe(_config(), platform=Platform.UNKNOWN, total_ram=16.0)
         assert report.tier == DeviceTier.INCAPABLE
 
 

--- a/tests/ciris_adapters/mobile_local_llm/test_config.py
+++ b/tests/ciris_adapters/mobile_local_llm/test_config.py
@@ -1,0 +1,150 @@
+"""Tests for Mobile Local LLM adapter configuration."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from ciris_adapters.mobile_local_llm.config import (
+    DeviceTier,
+    ENV_ALLOW_DESKTOP,
+    ENV_ENABLED,
+    ENV_FORCE_CAPABILITY,
+    ENV_HEALTH_INTERVAL,
+    ENV_IOS_STUB_MODEL_PATH,
+    ENV_MIN_FREE_DISK_GB,
+    ENV_MIN_RAM_GB,
+    ENV_MODEL_PATH,
+    ENV_MODEL_VARIANT,
+    ENV_READY_TIMEOUT,
+    ENV_REQUEST_TIMEOUT,
+    ENV_SERVER_BINARY,
+    ENV_SERVER_HOST,
+    ENV_SERVER_PORT,
+    MobileLocalLLMConfig,
+    ModelVariant,
+    load_config_from_env,
+)
+
+
+class TestMobileLocalLLMConfig:
+    """Tests for the config model itself."""
+
+    def test_defaults_are_sensible(self):
+        cfg = MobileLocalLLMConfig()
+        assert cfg.enabled is True
+        assert cfg.model_variant == ModelVariant.GEMMA_4_E2B
+        assert cfg.host == "127.0.0.1"
+        assert 1024 <= cfg.port <= 65535
+        assert cfg.min_total_ram_gb_e2b == 6.0
+        assert cfg.min_total_ram_gb_e4b == 8.0
+        assert cfg.min_free_disk_gb == 3.0
+        assert cfg.allow_desktop is False
+        assert cfg.ios_model_path is None
+
+    def test_base_url_and_health_url_match_host_port(self):
+        cfg = MobileLocalLLMConfig(host="127.0.0.1", port=9001)
+        assert cfg.base_url() == "http://127.0.0.1:9001/v1"
+        assert cfg.health_url() == "http://127.0.0.1:9001/health"
+
+    def test_required_ram_depends_on_variant(self):
+        e2b = MobileLocalLLMConfig(model_variant=ModelVariant.GEMMA_4_E2B)
+        e4b = MobileLocalLLMConfig(model_variant=ModelVariant.GEMMA_4_E4B)
+        assert e2b.required_ram_gb() == 6.0
+        assert e4b.required_ram_gb() == 8.0
+
+    def test_port_validation(self):
+        with pytest.raises(ValueError):
+            MobileLocalLLMConfig(port=80)  # privileged, blocked
+        with pytest.raises(ValueError):
+            MobileLocalLLMConfig(port=70000)
+
+    def test_extra_fields_forbidden(self):
+        with pytest.raises(ValueError):
+            MobileLocalLLMConfig(random_field="x")  # type: ignore[call-arg]
+
+    def test_device_tier_includes_ios_stub(self):
+        """IOS_STUB is how we surface 'capable hardware, model not yet shipped'."""
+        assert DeviceTier.IOS_STUB.value == "ios_stub"
+        assert DeviceTier.CAPABLE_E2B in set(DeviceTier)
+
+
+class TestLoadConfigFromEnv:
+    """Tests for env-var hydration."""
+
+    @mock.patch.dict(os.environ, {}, clear=True)
+    def test_empty_env_returns_defaults(self):
+        cfg = load_config_from_env()
+        assert cfg == MobileLocalLLMConfig()
+
+    def test_env_overrides_applied(self, tmp_path):
+        model_path = tmp_path / "gemma.bin"
+        ios_model_path = tmp_path / "gemma.litert"
+        server_binary = tmp_path / "litertlm"
+        env = {
+            ENV_ENABLED: "false",
+            ENV_MODEL_VARIANT: "gemma-4-e4b",
+            ENV_MODEL_PATH: str(model_path),
+            ENV_IOS_STUB_MODEL_PATH: str(ios_model_path),
+            ENV_SERVER_BINARY: str(server_binary),
+            ENV_SERVER_HOST: "127.0.0.1",
+            ENV_SERVER_PORT: "9999",
+            ENV_READY_TIMEOUT: "12.5",
+            ENV_REQUEST_TIMEOUT: "45",
+            ENV_HEALTH_INTERVAL: "7",
+            ENV_MIN_RAM_GB: "7.5",
+            ENV_MIN_FREE_DISK_GB: "2.5",
+            ENV_FORCE_CAPABILITY: "capable_e4b",
+            ENV_ALLOW_DESKTOP: "1",
+        }
+        with mock.patch.dict(os.environ, env, clear=True):
+            cfg = load_config_from_env()
+        assert cfg.enabled is False
+        assert cfg.model_variant == ModelVariant.GEMMA_4_E4B
+        assert cfg.model_path == model_path
+        assert cfg.ios_model_path == ios_model_path
+        assert cfg.server_binary == server_binary
+        assert cfg.port == 9999
+        assert cfg.ready_timeout_seconds == 12.5
+        assert cfg.request_timeout_seconds == 45.0
+        assert cfg.health_interval_seconds == 7.0
+        assert cfg.min_total_ram_gb_e2b == 7.5
+        assert cfg.min_free_disk_gb == 2.5
+        assert cfg.force_capability == DeviceTier.CAPABLE_E4B
+        assert cfg.allow_desktop is True
+
+    @mock.patch.dict(
+        os.environ,
+        {
+            ENV_MODEL_VARIANT: "not-a-variant",
+            ENV_FORCE_CAPABILITY: "definitely-invalid",
+            ENV_SERVER_PORT: "not-a-number",
+            ENV_READY_TIMEOUT: "banana",
+        },
+        clear=True,
+    )
+    def test_invalid_env_values_fall_back_to_defaults(self):
+        cfg = load_config_from_env()
+        defaults = MobileLocalLLMConfig()
+        assert cfg.model_variant == defaults.model_variant
+        assert cfg.force_capability is None
+        assert cfg.port == defaults.port
+        assert cfg.ready_timeout_seconds == defaults.ready_timeout_seconds
+
+    @mock.patch.dict(os.environ, {ENV_ENABLED: "0"}, clear=True)
+    def test_enabled_false_parsed_correctly(self):
+        cfg = load_config_from_env()
+        assert cfg.enabled is False
+
+    @mock.patch.dict(os.environ, {ENV_ENABLED: "Yes"}, clear=True)
+    def test_enabled_truthy_parsed_correctly(self):
+        cfg = load_config_from_env()
+        assert cfg.enabled is True
+
+    @mock.patch.dict(os.environ, {ENV_FORCE_CAPABILITY: "ios_stub"}, clear=True)
+    def test_force_capability_accepts_ios_stub(self):
+        cfg = load_config_from_env()
+        assert cfg.force_capability == DeviceTier.IOS_STUB

--- a/tests/ciris_adapters/mobile_local_llm/test_inference_server.py
+++ b/tests/ciris_adapters/mobile_local_llm/test_inference_server.py
@@ -1,0 +1,166 @@
+"""Tests for the inference server lifecycle manager."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from ciris_adapters.mobile_local_llm.config import MobileLocalLLMConfig
+from ciris_adapters.mobile_local_llm.inference_server import (
+    InferenceServerError,
+    InferenceServerManager,
+)
+
+
+def _config(**overrides) -> MobileLocalLLMConfig:
+    return MobileLocalLLMConfig(**overrides)
+
+
+@pytest.mark.asyncio
+class TestAttachMode:
+    """When server_binary is None we attach to a pre-running server."""
+
+    async def test_attach_becomes_ready_when_probe_succeeds(self):
+        cfg = _config(server_binary=None, ready_timeout_seconds=1.0)
+        mgr = InferenceServerManager(cfg)
+        with mock.patch.object(mgr, "_probe_health", mock.AsyncMock(return_value=True)):
+            await mgr.start()
+        assert mgr.owns_process is False
+        assert mgr.is_running is True
+        assert mgr.process_id is None
+
+    async def test_attach_raises_when_probe_never_succeeds(self):
+        cfg = _config(server_binary=None, ready_timeout_seconds=0.2)
+        mgr = InferenceServerManager(cfg)
+        with mock.patch.object(mgr, "_probe_health", mock.AsyncMock(return_value=False)):
+            with pytest.raises(InferenceServerError):
+                await mgr.start()
+
+    async def test_health_check_after_start(self):
+        cfg = _config(server_binary=None, ready_timeout_seconds=1.0)
+        mgr = InferenceServerManager(cfg)
+        with mock.patch.object(mgr, "_probe_health", mock.AsyncMock(return_value=True)):
+            await mgr.start()
+            assert await mgr.health_check() is True
+            mgr._probe_health.return_value = False  # type: ignore[attr-defined]
+            assert await mgr.health_check() is False
+
+    async def test_stop_is_safe_when_nothing_was_spawned(self):
+        cfg = _config(server_binary=None)
+        mgr = InferenceServerManager(cfg)
+        await mgr.stop()  # should not raise
+
+
+@pytest.mark.asyncio
+class TestSpawnMode:
+    """When server_binary is set we spawn and supervise a subprocess."""
+
+    async def test_missing_binary_raises(self, tmp_path):
+        missing = tmp_path / "does_not_exist"
+        cfg = _config(server_binary=missing, ready_timeout_seconds=0.1)
+        mgr = InferenceServerManager(cfg)
+        with pytest.raises(InferenceServerError):
+            await mgr.start()
+
+    async def test_spawn_failure_is_wrapped(self, tmp_path):
+        binary = tmp_path / "fake_server"
+        binary.write_text("#!/bin/sh\nexit 0\n")
+        binary.chmod(0o755)
+
+        cfg = _config(server_binary=binary, ready_timeout_seconds=0.1)
+        mgr = InferenceServerManager(cfg)
+
+        async def boom(*_args, **_kwargs):
+            raise OSError("exec fail")
+
+        with mock.patch("asyncio.create_subprocess_exec", side_effect=boom):
+            with pytest.raises(InferenceServerError):
+                await mgr.start()
+
+    async def test_build_argv_passes_host_port_and_model(self, tmp_path):
+        binary = tmp_path / "srv"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        model_path = tmp_path / "model.bin"
+        cfg = _config(
+            server_binary=binary,
+            model_path=model_path,
+            host="127.0.0.1",
+            port=12345,
+            server_extra_args=["--threads", "4"],
+        )
+        mgr = InferenceServerManager(cfg)
+        argv = mgr._build_argv(binary)
+        assert argv[0] == str(binary)
+        assert "--host" in argv and "127.0.0.1" in argv
+        assert "--port" in argv and "12345" in argv
+        assert "--model" in argv and str(model_path) in argv
+        assert argv[-2:] == ["--threads", "4"]
+
+    async def test_process_death_during_startup_raises(self, tmp_path):
+        binary = tmp_path / "srv"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+
+        fake_process = mock.MagicMock()
+        fake_process.returncode = 42
+        fake_process.pid = 1234
+
+        async def fake_exec(*_args, **_kwargs):
+            return fake_process
+
+        cfg = _config(server_binary=binary, ready_timeout_seconds=0.5)
+        mgr = InferenceServerManager(cfg)
+        with mock.patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+            with mock.patch.object(mgr, "_probe_health", mock.AsyncMock(return_value=False)):
+                with pytest.raises(InferenceServerError):
+                    await mgr.start()
+        assert mgr.last_exit_code == 42
+
+    async def test_stop_sends_sigterm_and_reaps(self, tmp_path):
+        binary = tmp_path / "srv"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+
+        fake_process = mock.MagicMock()
+        fake_process.returncode = None
+        fake_process.pid = 5678
+        # First call during health loop: still running; after SIGTERM: exited.
+        fake_process.wait = mock.AsyncMock(return_value=0)
+        fake_process.send_signal = mock.MagicMock()
+
+        async def fake_exec(*_args, **_kwargs):
+            return fake_process
+
+        cfg = _config(server_binary=binary, ready_timeout_seconds=0.5)
+        mgr = InferenceServerManager(cfg)
+        with mock.patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+            with mock.patch.object(mgr, "_probe_health", mock.AsyncMock(return_value=True)):
+                await mgr.start()
+        # Simulate graceful exit after SIGTERM.
+        fake_process.returncode = 0
+        await mgr.stop()
+        fake_process.send_signal.assert_called_once()
+        fake_process.wait.assert_awaited()
+
+
+@pytest.mark.asyncio
+class TestHealthCheck:
+    async def test_health_check_false_when_owned_process_exited(self, tmp_path):
+        binary = tmp_path / "srv"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+
+        fake_process = mock.MagicMock()
+        fake_process.returncode = 1
+
+        cfg = _config(server_binary=binary)
+        mgr = InferenceServerManager(cfg)
+        mgr._process = fake_process  # type: ignore[assignment]
+        mgr._owned_process = True
+
+        assert await mgr.health_check() is False
+        assert mgr.last_exit_code == 1

--- a/tests/ciris_adapters/mobile_local_llm/test_service.py
+++ b/tests/ciris_adapters/mobile_local_llm/test_service.py
@@ -1,0 +1,229 @@
+"""Tests for the MobileLocalLLMService LLM provider."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest import mock
+
+import pytest
+from pydantic import BaseModel
+
+from ciris_adapters.mobile_local_llm.capability import DeviceCapabilityReport
+from ciris_adapters.mobile_local_llm.config import (
+    DeviceTier,
+    MobileLocalLLMConfig,
+    ModelVariant,
+    Platform,
+)
+from ciris_adapters.mobile_local_llm.service import (
+    MobileLocalLLMService,
+    _estimate_input_tokens,
+)
+
+
+class _SampleResponse(BaseModel):
+    answer: str
+
+
+def _capable_report(tier: DeviceTier = DeviceTier.CAPABLE_E2B) -> DeviceCapabilityReport:
+    return DeviceCapabilityReport(
+        tier=tier,
+        platform=Platform.ANDROID,
+        architecture="arm64-v8a",
+        total_ram_gb=8.0,
+        available_ram_gb=4.0,
+        free_disk_gb=10.0,
+        reasons=["test"],
+    )
+
+
+def _ios_stub_report() -> DeviceCapabilityReport:
+    return DeviceCapabilityReport(
+        tier=DeviceTier.IOS_STUB,
+        platform=Platform.IOS,
+        architecture="arm64-v8a",
+        total_ram_gb=8.0,
+        available_ram_gb=4.0,
+        free_disk_gb=10.0,
+        reasons=["iOS capable but no model bundle"],
+    )
+
+
+def _incapable_report() -> DeviceCapabilityReport:
+    return DeviceCapabilityReport(
+        tier=DeviceTier.INCAPABLE,
+        platform=Platform.DESKTOP,
+        architecture="x86_64",
+        total_ram_gb=4.0,
+        available_ram_gb=2.0,
+        free_disk_gb=1.0,
+        reasons=["running on desktop"],
+    )
+
+
+def _fake_server_manager(*, available=True, health=True):
+    mgr = mock.MagicMock()
+    mgr.start = mock.AsyncMock(return_value=None) if available else mock.AsyncMock(
+        side_effect=__import__(
+            "ciris_adapters.mobile_local_llm.inference_server", fromlist=["InferenceServerError"]
+        ).InferenceServerError("boom")
+    )
+    mgr.stop = mock.AsyncMock(return_value=None)
+    mgr.health_check = mock.AsyncMock(return_value=health)
+    return mgr
+
+
+@pytest.mark.asyncio
+class TestLifecycle:
+    async def test_capable_device_becomes_available(self):
+        cfg = MobileLocalLLMConfig()
+        mgr = _fake_server_manager(available=True, health=True)
+        svc = MobileLocalLLMService(cfg, server_manager=mgr, capability_report=_capable_report())
+        await svc.start()
+        try:
+            assert svc.available is True
+            assert await svc.is_healthy() is True
+        finally:
+            await svc.stop()
+        mgr.start.assert_awaited_once()
+        mgr.stop.assert_awaited_once()
+
+    async def test_incapable_device_stays_unavailable(self):
+        cfg = MobileLocalLLMConfig()
+        mgr = _fake_server_manager()
+        svc = MobileLocalLLMService(cfg, server_manager=mgr, capability_report=_incapable_report())
+        await svc.start()
+        assert svc.available is False
+        assert await svc.is_healthy() is False
+        mgr.start.assert_not_awaited()
+        await svc.stop()
+
+    async def test_disabled_config_skips_start(self):
+        cfg = MobileLocalLLMConfig(enabled=False)
+        mgr = _fake_server_manager()
+        svc = MobileLocalLLMService(cfg, server_manager=mgr, capability_report=_capable_report())
+        await svc.start()
+        assert svc.available is False
+        mgr.start.assert_not_awaited()
+        await svc.stop()
+
+    async def test_ios_stub_stays_unavailable(self):
+        """iOS stub devices must not try to spawn the inference server."""
+        cfg = MobileLocalLLMConfig()
+        mgr = _fake_server_manager()
+        svc = MobileLocalLLMService(cfg, server_manager=mgr, capability_report=_ios_stub_report())
+        await svc.start()
+        assert svc.available is False
+        assert await svc.is_healthy() is False
+        mgr.start.assert_not_awaited()
+        await svc.stop()
+
+    async def test_server_start_error_keeps_service_unavailable(self):
+        cfg = MobileLocalLLMConfig()
+        mgr = _fake_server_manager(available=False)
+        svc = MobileLocalLLMService(cfg, server_manager=mgr, capability_report=_capable_report())
+        await svc.start()
+        assert svc.available is False
+        assert await svc.is_healthy() is False
+        await svc.stop()
+
+    async def test_e2b_device_rejects_e4b_variant(self):
+        """Mid-range phone config: E2B tier should refuse to load E4B."""
+        cfg = MobileLocalLLMConfig(model_variant=ModelVariant.GEMMA_4_E4B)
+        mgr = _fake_server_manager()
+        svc = MobileLocalLLMService(
+            cfg,
+            server_manager=mgr,
+            capability_report=_capable_report(DeviceTier.CAPABLE_E2B),
+        )
+        await svc.start()
+        assert svc.available is False
+        mgr.start.assert_not_awaited()
+        await svc.stop()
+
+    async def test_is_healthy_drops_availability_on_probe_failure(self):
+        cfg = MobileLocalLLMConfig()
+        mgr = _fake_server_manager(available=True, health=False)
+        svc = MobileLocalLLMService(cfg, server_manager=mgr, capability_report=_capable_report())
+        await svc.start()
+        # After start we are available (no probe run yet).
+        assert svc.available is True
+        # is_healthy() must flip us unavailable when the probe reports false.
+        assert await svc.is_healthy() is False
+        assert svc.available is False
+        await svc.stop()
+
+
+@pytest.mark.asyncio
+class TestCallLLMStructured:
+    async def test_raises_when_unavailable(self):
+        cfg = MobileLocalLLMConfig()
+        mgr = _fake_server_manager()
+        svc = MobileLocalLLMService(cfg, server_manager=mgr, capability_report=_incapable_report())
+        await svc.start()
+        with pytest.raises(RuntimeError):
+            await svc.call_llm_structured(
+                messages=[{"role": "user", "content": "hi"}],
+                response_model=_SampleResponse,
+            )
+        await svc.stop()
+
+    async def test_success_path_returns_parsed_response_and_usage(self):
+        cfg = MobileLocalLLMConfig()
+        mgr = _fake_server_manager(available=True, health=True)
+        svc = MobileLocalLLMService(cfg, server_manager=mgr, capability_report=_capable_report())
+        await svc.start()
+
+        parsed = _SampleResponse(answer="ok")
+
+        async def fake_dispatch(**_kwargs):
+            return parsed
+
+        with mock.patch.object(svc, "_dispatch_structured", side_effect=fake_dispatch):
+            result, usage = await svc.call_llm_structured(
+                messages=[{"role": "user", "content": "hello world"}],
+                response_model=_SampleResponse,
+                max_tokens=128,
+            )
+
+        assert result is parsed
+        assert usage.tokens_input > 0
+        assert usage.tokens_output > 0
+        assert usage.cost_cents == 0.0
+        assert "mobile-local" in (usage.model_used or "")
+        await svc.stop()
+
+    async def test_inference_error_marks_unavailable_and_reraises(self):
+        cfg = MobileLocalLLMConfig()
+        mgr = _fake_server_manager(available=True, health=True)
+        svc = MobileLocalLLMService(cfg, server_manager=mgr, capability_report=_capable_report())
+        await svc.start()
+
+        async def boom(**_kwargs):
+            raise RuntimeError("inference failure")
+
+        with mock.patch.object(svc, "_dispatch_structured", side_effect=boom):
+            with pytest.raises(RuntimeError, match="inference failure"):
+                await svc.call_llm_structured(
+                    messages=[{"role": "user", "content": "hi"}],
+                    response_model=_SampleResponse,
+                )
+        assert svc.available is False
+        await svc.stop()
+
+
+class TestTokenEstimator:
+    def test_counts_word_tokens_with_1_3_multiplier(self):
+        count = _estimate_input_tokens([{"role": "user", "content": "hello world foo bar"}])
+        assert count >= 4
+
+    def test_handles_multimodal_content(self):
+        msg = [{"role": "user", "content": [{"type": "text", "text": "hi there friend"}]}]
+        # ``MessageDict`` uses ``content: str``, but the implementation is
+        # defensive about list content used by multimodal callers. We cast via
+        # ``Any`` here.
+        count = _estimate_input_tokens(msg)  # type: ignore[arg-type]
+        assert count >= 3
+
+    def test_returns_at_least_one(self):
+        assert _estimate_input_tokens([]) == 1

--- a/tests/ciris_engine/logic/adapters/api/routes/system/test_context_enrichment.py
+++ b/tests/ciris_engine/logic/adapters/api/routes/system/test_context_enrichment.py
@@ -81,12 +81,13 @@ class TestGetContextEnrichmentCache:
         # Import directly since we can't use TestClient easily with async
         result = await get_context_enrichment_cache(request, auth, refresh=False)
 
-        assert result.data["entries"] == mock_enrichment_cache.get_all_entries()
-        assert result.data["stats"]["entry_count"] == 1
-        assert result.data["stats"]["hits"] == 10
-        assert result.data["stats"]["misses"] == 5
-        assert result.data["stats"]["hit_rate_pct"] == 66.7
-        assert result.data["stats"]["startup_populated"] is True
+        # data is now EnrichmentCacheResponse, use attribute access
+        assert result.data.entries == mock_enrichment_cache.get_all_entries()
+        assert result.data.stats.entry_count == 1
+        assert result.data.stats.hits == 10
+        assert result.data.stats.misses == 5
+        assert result.data.stats.hit_rate_pct == 66.7
+        assert result.data.stats.startup_populated is True
 
     @pytest.mark.asyncio
     async def test_returns_empty_when_no_entries(self):
@@ -110,8 +111,9 @@ class TestGetContextEnrichmentCache:
 
             result = await get_context_enrichment_cache(request, Mock(), refresh=False)
 
-            assert result.data["entries"] == {}
-            assert result.data["stats"]["entry_count"] == 0
+            # data is now EnrichmentCacheResponse, use attribute access
+            assert result.data.entries == {}
+            assert result.data.stats.entry_count == 0
 
     @pytest.mark.asyncio
     async def test_refresh_triggers_cache_refresh(self):
@@ -134,7 +136,8 @@ class TestGetContextEnrichmentCache:
             result = await get_context_enrichment_cache(request, Mock(), refresh=True)
 
             mock_refresh.assert_called_once_with(runtime)
-            assert result.data["entries"]["test:tool"]["data"] == "refreshed"
+            # data is now EnrichmentCacheResponse, use attribute access
+            assert result.data.entries["test:tool"]["data"] == "refreshed"
 
     @pytest.mark.asyncio
     async def test_refresh_skipped_when_no_runtime(self):
@@ -224,9 +227,10 @@ class TestGetContextEnrichmentCache:
 
         result = await get_context_enrichment_cache(request, Mock(), refresh=False)
 
-        stats = result.data["stats"]
-        assert "entry_count" in stats
-        assert "hits" in stats
-        assert "misses" in stats
-        assert "hit_rate_pct" in stats
-        assert "startup_populated" in stats
+        # data is now EnrichmentCacheResponse with stats as EnrichmentCacheStats
+        stats = result.data.stats
+        assert hasattr(stats, "entry_count")
+        assert hasattr(stats, "hits")
+        assert hasattr(stats, "misses")
+        assert hasattr(stats, "hit_rate_pct")
+        assert hasattr(stats, "startup_populated")

--- a/tests/ciris_engine/logic/context/test_system_snapshot_helpers.py
+++ b/tests/ciris_engine/logic/context/test_system_snapshot_helpers.py
@@ -20,6 +20,8 @@ from ciris_engine.logic.context.system_snapshot_helpers import (
     _collect_available_tools,
     _collect_resource_alerts,
     _collect_service_health,
+    _create_preferences_memory_query,
+    _enrich_single_user_profile,
     _enrich_user_profiles,
     _extract_agent_identity,
     _extract_thought_summary,
@@ -30,6 +32,8 @@ from ciris_engine.logic.context.system_snapshot_helpers import (
     _get_telemetry_summary,
     _get_top_tasks,
     _json_serial_for_users,
+    _merge_preferences_into_profile,
+    _query_user_preferences,
     _resolve_channel_context,
     _safe_extract_channel_info,
 )
@@ -1054,17 +1058,40 @@ class TestUserManagement:
 
     @pytest.mark.asyncio
     async def test_enrich_user_profiles_with_existing_user(self, caplog):
-        """Test enriching user profiles skips existing users."""
+        """Test enriching user profiles merges memory data into existing users."""
         memory_service = Mock()
+
+        # Mock user node with preferences
+        user_node = Mock()
+        user_node.attributes = {
+            "username": "existing_user",
+            "display_name": "Existing User",
+            "language": "fr",  # Non-default language should be merged
+            "timezone": "Europe/Paris",  # Non-default timezone should be merged
+        }
+        memory_service.recall = AsyncMock(return_value=[user_node])
+
         user_ids = {"existing_user"}
         channel_id = "test_channel"
-        existing_profiles = [Mock()]
-        existing_profiles[0].user_id = "existing_user"
+        existing_profile = Mock()
+        existing_profile.user_id = "existing_user"
+        existing_profile.preferred_language = "en"  # Will be overwritten with "fr"
+        existing_profile.timezone = "UTC"  # Will be overwritten with "Europe/Paris"
+        existing_profile.communication_style = "formal"
+        existing_profile.user_preferred_name = None
+        existing_profile.location = None
+        existing_profile.interaction_preferences = None
+        existing_profile.oauth_name = None
+        existing_profile.memorized_attributes = None
+        existing_profiles = [existing_profile]
 
         result = await _enrich_user_profiles(memory_service, user_ids, channel_id, existing_profiles)
 
         assert len(result) == 1
-        assert "User existing_user already exists, skipping" in caplog.text
+        # Verify memory graph data was merged into existing profile
+        assert "Merging memory graph data into existing profile" in caplog.text
+        assert existing_profile.preferred_language == "fr"
+        assert existing_profile.timezone == "Europe/Paris"
 
     @pytest.mark.asyncio
     async def test_enrich_user_profiles_with_new_user_valid_node(self, caplog):
@@ -1975,3 +2002,225 @@ class TestRefreshEnrichmentCache:
         assert "test:test_get_status" in result
         assert result["test:test_list_items"]["items"] == [1, 2, 3]
         assert result["test:test_get_status"]["status"] == "healthy"
+
+
+# =============================================================================
+# LOCALIZATION / USER PREFERENCES TESTS
+# =============================================================================
+
+
+class TestUserPreferencesQuery:
+    """Test user preferences query and merge functions for localization.
+
+    These tests verify that user preferences (especially preferred_language)
+    are correctly queried from the preferences/{user_id} node and merged
+    into user profiles. This is critical for localization.
+    """
+
+    def test_create_preferences_memory_query(self):
+        """Test that preferences query is correctly constructed."""
+        query = _create_preferences_memory_query("user123")
+
+        assert query.node_id == "preferences/user123"
+        assert query.scope == GraphScope.LOCAL
+        assert query.type == NodeType.CONCEPT
+        assert query.include_edges is False
+        assert query.depth == 1
+
+    def test_merge_preferences_into_profile_with_language(self):
+        """Test merging preferences with non-English language."""
+        profile = UserProfile(
+            user_id="test_user",
+            display_name="Test User",
+            created_at=datetime.now(timezone.utc),
+            preferred_language="en",  # Default
+            timezone="UTC",
+        )
+
+        prefs_attrs = {
+            "preferred_language": "am",  # Amharic
+            "timezone": "Africa/Addis_Ababa",
+            "location": "Addis Ababa, Ethiopia",
+        }
+
+        result = _merge_preferences_into_profile(profile, prefs_attrs)
+
+        assert result.preferred_language == "am"
+        assert result.timezone == "Africa/Addis_Ababa"
+        assert result.location == "Addis Ababa, Ethiopia"
+
+    def test_merge_preferences_skips_english_default(self):
+        """Test that English language is not overwritten with English."""
+        profile = UserProfile(
+            user_id="test_user",
+            display_name="Test User",
+            created_at=datetime.now(timezone.utc),
+            preferred_language="es",  # Spanish already set
+            timezone="Europe/Madrid",
+        )
+
+        prefs_attrs = {
+            "preferred_language": "en",  # Default - should not overwrite
+        }
+
+        result = _merge_preferences_into_profile(profile, prefs_attrs)
+
+        # Should keep Spanish since prefs has English (default)
+        assert result.preferred_language == "es"
+
+    def test_merge_preferences_builds_location_from_parts(self):
+        """Test that location is built from city/region/country parts."""
+        profile = UserProfile(
+            user_id="test_user",
+            display_name="Test User",
+            created_at=datetime.now(timezone.utc),
+        )
+
+        prefs_attrs = {
+            "location_city": "Austin",
+            "location_region": "Texas",
+            "location_country": "USA",
+        }
+
+        result = _merge_preferences_into_profile(profile, prefs_attrs)
+
+        assert result.location == "Austin, Texas, USA"
+
+    def test_merge_preferences_with_empty_attrs(self):
+        """Test merging empty preferences doesn't modify profile."""
+        profile = UserProfile(
+            user_id="test_user",
+            display_name="Test User",
+            created_at=datetime.now(timezone.utc),
+            preferred_language="de",
+            timezone="Europe/Berlin",
+        )
+
+        result = _merge_preferences_into_profile(profile, {})
+
+        assert result.preferred_language == "de"
+        assert result.timezone == "Europe/Berlin"
+
+    @pytest.mark.asyncio
+    async def test_query_user_preferences_with_results(self):
+        """Test querying preferences when node exists."""
+        mock_memory_service = AsyncMock()
+
+        # Create a mock node with preferences
+        mock_node = MagicMock()
+        mock_node.attributes = {
+            "preferred_language": "ja",
+            "timezone": "Asia/Tokyo",
+        }
+
+        mock_memory_service.recall = AsyncMock(return_value=[mock_node])
+
+        result = await _query_user_preferences("user123", mock_memory_service)
+
+        assert result.get("preferred_language") == "ja"
+        assert result.get("timezone") == "Asia/Tokyo"
+
+    @pytest.mark.asyncio
+    async def test_query_user_preferences_no_node(self):
+        """Test querying preferences when no node exists."""
+        mock_memory_service = AsyncMock()
+        mock_memory_service.recall = AsyncMock(return_value=[])
+
+        result = await _query_user_preferences("user123", mock_memory_service)
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_query_user_preferences_handles_exception(self):
+        """Test that query handles exceptions gracefully."""
+        mock_memory_service = AsyncMock()
+        mock_memory_service.recall = AsyncMock(side_effect=Exception("Database error"))
+
+        result = await _query_user_preferences("user123", mock_memory_service)
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_enrich_single_user_profile_merges_preferences(self):
+        """Test that single user enrichment queries and merges preferences."""
+        mock_memory_service = AsyncMock()
+
+        # Create mock user node
+        mock_user_node = MagicMock()
+        mock_user_node.id = "user/test_user"
+        mock_user_node.attributes = {
+            "username": "TestUser",
+            "trust_level": 0.8,
+        }
+        mock_user_node.edges = []
+
+        # Create mock preferences node
+        mock_prefs_node = MagicMock()
+        mock_prefs_node.attributes = {
+            "preferred_language": "ko",  # Korean
+            "timezone": "Asia/Seoul",
+        }
+
+        def recall_side_effect(query):
+            if "preferences/" in query.node_id:
+                return [mock_prefs_node]
+            elif "user/" in query.node_id:
+                return [mock_user_node]
+            return []
+
+        mock_memory_service.recall = AsyncMock(side_effect=recall_side_effect)
+
+        result = await _enrich_single_user_profile("test_user", mock_memory_service, "channel1")
+
+        assert result is not None
+        assert result.preferred_language == "ko"
+        assert result.timezone == "Asia/Seoul"
+
+    @pytest.mark.asyncio
+    async def test_enrich_user_profiles_merges_into_existing(self):
+        """Test that profile enrichment merges preferences into GraphQL profiles."""
+        mock_memory_service = AsyncMock()
+
+        # Create existing profile from GraphQL (with default English)
+        existing_profile = UserProfile(
+            user_id="oauth_user",
+            display_name="OAuth User",
+            created_at=datetime.now(timezone.utc),
+            preferred_language="en",  # Default from GraphQL
+        )
+
+        # Create mock user node
+        mock_user_node = MagicMock()
+        mock_user_node.id = "user/oauth_user"
+        mock_user_node.attributes = {
+            "username": "OAuth User",
+        }
+        mock_user_node.edges = []
+
+        # Create mock preferences node with non-English language
+        mock_prefs_node = MagicMock()
+        mock_prefs_node.attributes = {
+            "preferred_language": "ar",  # Arabic
+            "timezone": "Asia/Dubai",
+        }
+
+        def recall_side_effect(query):
+            if "preferences/" in query.node_id:
+                return [mock_prefs_node]
+            elif "user/" in query.node_id:
+                return [mock_user_node]
+            return []
+
+        mock_memory_service.recall = AsyncMock(side_effect=recall_side_effect)
+
+        result = await _enrich_user_profiles(
+            mock_memory_service,
+            {"oauth_user"},
+            "channel1",
+            [existing_profile],
+        )
+
+        # The existing profile should have been updated with Arabic
+        assert len(result) == 1
+        assert result[0].preferred_language == "ar"
+        assert result[0].timezone == "Asia/Dubai"

--- a/tests/ciris_engine/logic/services/runtime/llm_service/test_llm_service_coverage.py
+++ b/tests/ciris_engine/logic/services/runtime/llm_service/test_llm_service_coverage.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
-from ciris_engine.schemas.services.llm import JSONExtractionResult
+from ciris_engine.schemas.services.llm import JSONExtractionResult, RetryState
 
 
 class TestExtractJSON:
@@ -303,7 +303,7 @@ class TestReasoningModeDisabling:
             task_id="test-task-123",
             thought_id="test-thought-456",
             resp_model_name="EthicalDMAResult",
-            retry_state={},
+            retry_state=RetryState(),
         )
 
         # Verify reasoning is disabled
@@ -331,7 +331,7 @@ class TestReasoningModeDisabling:
             task_id="test-task-123",
             thought_id="test-thought-456",
             resp_model_name="ActionSelectionDMAResult",
-            retry_state={},
+            retry_state=RetryState(),
         )
 
         # Verify thinking is disabled
@@ -359,7 +359,7 @@ class TestReasoningModeDisabling:
             task_id="test-task-123",
             thought_id="test-thought-456",
             resp_model_name="ActionSelectionDMAResult",
-            retry_state={},
+            retry_state=RetryState(),
         )
 
         # Standard OpenAI should have no extra_body with reasoning/thinking
@@ -386,7 +386,7 @@ class TestReasoningModeDisabling:
             task_id="test-task-123",
             thought_id="test-thought-456",
             resp_model_name="ActionSelectionDMAResult",
-            retry_state={},
+            retry_state=RetryState(),
         )
 
         # Verify reasoning is disabled

--- a/tests/ciris_engine/logic/services/runtime/llm_service/test_service_helpers.py
+++ b/tests/ciris_engine/logic/services/runtime/llm_service/test_service_helpers.py
@@ -43,6 +43,7 @@ from ciris_engine.logic.services.runtime.llm_service.service import (
     _log_instructor_error,
     _log_multimodal_content,
 )
+from ciris_engine.schemas.services.llm import LLMErrorContext, RetryState
 
 
 class TestBuildCirisProxyMetadata:
@@ -50,7 +51,7 @@ class TestBuildCirisProxyMetadata:
 
     def test_builds_metadata_with_task_id(self):
         """Builds metadata with interaction_id from task_id."""
-        retry_state: Dict[str, Any] = {"count": 0, "previous_error": None, "original_request_id": None}
+        retry_state = RetryState()
 
         with patch("ciris_engine.logic.services.runtime.llm_service.service.logger"):
             metadata = _build_ciris_proxy_metadata(
@@ -60,14 +61,14 @@ class TestBuildCirisProxyMetadata:
                 resp_model_name="TestModel",
             )
 
-        assert "interaction_id" in metadata
-        assert len(metadata["interaction_id"]) == 32  # sha256[:32]
-        assert "request_id" in metadata
-        assert retry_state["original_request_id"] is not None
+        assert metadata.interaction_id is not None
+        assert len(metadata.interaction_id) == 32  # sha256[:32]
+        assert metadata.original_request_id is not None
+        assert retry_state.original_request_id is not None
 
     def test_raises_without_task_id(self):
         """Raises RuntimeError when task_id is None."""
-        retry_state: Dict[str, Any] = {"count": 0, "previous_error": None, "original_request_id": None}
+        retry_state = RetryState()
 
         with pytest.raises(RuntimeError) as exc_info:
             _build_ciris_proxy_metadata(
@@ -82,11 +83,11 @@ class TestBuildCirisProxyMetadata:
 
     def test_includes_retry_info_on_retry(self):
         """Includes retry count and previous error on retry attempts."""
-        retry_state: Dict[str, Any] = {
-            "count": 2,
-            "previous_error": "TIMEOUT",
-            "original_request_id": "abc123",
-        }
+        retry_state = RetryState(
+            count=2,
+            previous_error="TIMEOUT",
+            original_request_id="abc123",
+        )
 
         with patch("ciris_engine.logic.services.runtime.llm_service.service.logger"):
             metadata = _build_ciris_proxy_metadata(
@@ -96,14 +97,14 @@ class TestBuildCirisProxyMetadata:
                 resp_model_name="TestModel",
             )
 
-        assert metadata["retry_count"] == 2
-        assert metadata["previous_error"] == "TIMEOUT"
-        assert metadata["original_request_id"] == "abc123"
+        assert metadata.retry_count == 2
+        assert metadata.previous_error == "TIMEOUT"
+        assert metadata.original_request_id == "abc123"
 
     def test_same_task_id_produces_same_interaction_id(self):
         """Same task_id always produces same interaction_id (for billing)."""
-        retry_state1: Dict[str, Any] = {"count": 0, "previous_error": None, "original_request_id": None}
-        retry_state2: Dict[str, Any] = {"count": 0, "previous_error": None, "original_request_id": None}
+        retry_state1 = RetryState()
+        retry_state2 = RetryState()
 
         with patch("ciris_engine.logic.services.runtime.llm_service.service.logger"):
             metadata1 = _build_ciris_proxy_metadata(
@@ -119,19 +120,20 @@ class TestBuildCirisProxyMetadata:
                 resp_model_name="TestModel",
             )
 
-        assert metadata1["interaction_id"] == metadata2["interaction_id"]
+        assert metadata1.interaction_id == metadata2.interaction_id
 
 
 class TestBuildOpenrouterProviderConfig:
     """Tests for _build_openrouter_provider_config function."""
 
     def test_returns_empty_when_no_env_vars(self):
-        """Returns empty dict when no env vars set."""
+        """Returns empty config when no env vars set."""
         with patch.dict(os.environ, {}, clear=True):
             with patch("ciris_engine.logic.services.runtime.llm_service.service.logger"):
                 config = _build_openrouter_provider_config()
 
-        assert config == {}
+        assert config.order == []
+        assert config.ignore == []
 
     def test_parses_provider_order(self):
         """Parses OPENROUTER_PROVIDER_ORDER env var."""
@@ -139,7 +141,7 @@ class TestBuildOpenrouterProviderConfig:
             with patch("ciris_engine.logic.services.runtime.llm_service.service.logger"):
                 config = _build_openrouter_provider_config()
 
-        assert config["order"] == ["together", "groq", "sambanova"]
+        assert config.order == ["together", "groq", "sambanova"]
 
     def test_parses_ignore_providers(self):
         """Parses OPENROUTER_IGNORE_PROVIDERS env var."""
@@ -147,7 +149,7 @@ class TestBuildOpenrouterProviderConfig:
             with patch("ciris_engine.logic.services.runtime.llm_service.service.logger"):
                 config = _build_openrouter_provider_config()
 
-        assert config["ignore"] == ["friendli", "google-vertex"]
+        assert config.ignore == ["friendli", "google-vertex"]
 
     def test_parses_both_env_vars(self):
         """Parses both env vars together."""
@@ -161,8 +163,8 @@ class TestBuildOpenrouterProviderConfig:
             with patch("ciris_engine.logic.services.runtime.llm_service.service.logger"):
                 config = _build_openrouter_provider_config()
 
-        assert config["order"] == ["together", "groq"]
-        assert config["ignore"] == ["friendli"]
+        assert config.order == ["together", "groq"]
+        assert config.ignore == ["friendli"]
 
     def test_handles_whitespace_in_values(self):
         """Strips whitespace from comma-separated values."""
@@ -170,7 +172,7 @@ class TestBuildOpenrouterProviderConfig:
             with patch("ciris_engine.logic.services.runtime.llm_service.service.logger"):
                 config = _build_openrouter_provider_config()
 
-        assert config["order"] == ["together", "groq", "sambanova"]
+        assert config.order == ["together", "groq", "sambanova"]
 
     def test_ignores_empty_values(self):
         """Ignores empty values from comma splitting."""
@@ -178,7 +180,7 @@ class TestBuildOpenrouterProviderConfig:
             with patch("ciris_engine.logic.services.runtime.llm_service.service.logger"):
                 config = _build_openrouter_provider_config()
 
-        assert config["order"] == ["together", "groq"]
+        assert config.order == ["together", "groq"]
 
 
 class TestLogMultimodalContent:
@@ -281,13 +283,13 @@ class TestLogInstructorError:
 
     def test_logs_error_with_context(self):
         """Logs error with full context."""
-        error_context = {
-            "model": "gpt-4",
-            "provider": "openai",
-            "response_model": "TestModel",
-            "circuit_breaker_state": "closed",
-            "consecutive_failures": 2,
-        }
+        error_context = LLMErrorContext(
+            model="gpt-4",
+            provider="openai",
+            response_model="TestModel",
+            circuit_breaker_state="closed",
+            consecutive_failures=2,
+        )
 
         with patch("ciris_engine.logic.services.runtime.llm_service.service.logger") as mock_logger:
             _log_instructor_error("TIMEOUT", error_context, "Connection timed out")
@@ -300,13 +302,13 @@ class TestLogInstructorError:
 
     def test_logs_extra_info_when_provided(self):
         """Includes extra info when provided."""
-        error_context = {
-            "model": "gpt-4",
-            "provider": "openai",
-            "response_model": "TestModel",
-            "circuit_breaker_state": "closed",
-            "consecutive_failures": 0,
-        }
+        error_context = LLMErrorContext(
+            model="gpt-4",
+            provider="openai",
+            response_model="TestModel",
+            circuit_breaker_state="closed",
+            consecutive_failures=0,
+        )
 
         with patch("ciris_engine.logic.services.runtime.llm_service.service.logger") as mock_logger:
             _log_instructor_error("VALIDATION", error_context, "Schema mismatch", extra="Expected: TestModel")
@@ -330,13 +332,13 @@ class TestHandleInstructorRetryException:
     @pytest.fixture
     def error_context(self):
         """Create error context for tests."""
-        return {
-            "model": "gpt-4",
-            "provider": "openai",
-            "response_model": "TestModel",
-            "circuit_breaker_state": "closed",
-            "consecutive_failures": 0,
-        }
+        return LLMErrorContext(
+            model="gpt-4",
+            provider="openai",
+            response_model="TestModel",
+            circuit_breaker_state="closed",
+            consecutive_failures=0,
+        )
 
     def test_handles_validation_error(self, mock_circuit_breaker, error_context):
         """Handles validation errors correctly."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import tempfile
 
 os.environ["CIRIS_IMPORT_MODE"] = "true"
 os.environ["CIRIS_MOCK_LLM"] = "true"
+os.environ["CIRIS_TESTING_MODE"] = "true"  # Enable fallback admin credentials for tests
 
 # CRITICAL: Override log directory for tests to prevent container interference
 # Tests should NEVER write to the main logs directory that containers use

--- a/tools/qa_runner/__main__.py
+++ b/tools/qa_runner/__main__.py
@@ -354,6 +354,8 @@ def main():
         # Fail-fast configuration
         fail_fast=not args.proceed_anyway,
         test_timeout=args.test_timeout,
+        # Data management
+        wipe_data=args.wipe_data,
     )
 
     # Create and run runner

--- a/tools/qa_runner/config.py
+++ b/tools/qa_runner/config.py
@@ -148,6 +148,7 @@ class QAConfig:
     )
     mock_llm: bool = True
     adapter: str = "api"
+    wipe_data: bool = False  # Wipe data directory before starting server
 
     # Database backend configuration (for parallel testing)
     database_backends: List[str] = None  # None = ["sqlite"], or ["sqlite", "postgres"] for parallel
@@ -302,7 +303,7 @@ class QAConfig:
 
         # SDK test modules
         elif module == QAModule.SDK:
-            return SDKTestModule.get_sdk_tests()
+            return SDKTestModule.get_sdk_tests(admin_password=effective_password)
 
         # Extended API tests
         elif module == QAModule.EXTENDED_API:

--- a/tools/qa_runner/modules/sdk_tests.py
+++ b/tools/qa_runner/modules/sdk_tests.py
@@ -11,8 +11,14 @@ class SDKTestModule:
     """Test module for SDK operations."""
 
     @staticmethod
-    def get_sdk_tests() -> List[QATestCase]:
-        """Get SDK test cases."""
+    def get_sdk_tests(admin_password: str = "__DYNAMIC__") -> List[QATestCase]:
+        """Get SDK test cases.
+
+        Args:
+            admin_password: The admin password to use for login tests.
+                            Defaults to "__DYNAMIC__" which should be replaced
+                            by the QA runner with the actual password.
+        """
         return [
             # Authentication flow
             QATestCase(
@@ -20,7 +26,7 @@ class SDKTestModule:
                 module=QAModule.SDK,
                 endpoint="/v1/auth/login",
                 method="POST",
-                payload={"username": "admin", "password": "ciris_admin_password"},
+                payload={"username": "admin", "password": admin_password},
                 expected_status=200,
                 requires_auth=False,
                 description="Test SDK authentication flow",

--- a/tools/qa_runner/runner.py
+++ b/tools/qa_runner/runner.py
@@ -112,6 +112,8 @@ class QARunner:
                 live_base_url=self.config.live_base_url,
                 # Live Lens configuration
                 live_lens=self.config.live_lens,
+                # Data management
+                wipe_data=self.config.wipe_data,
             )
             self.server_managers[backend] = APIServerManager(
                 backend_config, database_backend=backend, modules=self.modules

--- a/tools/qa_runner/server.py
+++ b/tools/qa_runner/server.py
@@ -330,6 +330,104 @@ def _stop_postgres_container(console: Console):
             console.print(f"[yellow]⚠️  Failed to stop PostgreSQL: {e}[/yellow]")
 
 
+def _wipe_postgres_databases(console: Console) -> bool:
+    """Wipe all tables in PostgreSQL databases for clean QA testing.
+
+    This drops and recreates all three databases:
+    - ciris_test_db (main)
+    - ciris_test_db_secrets
+    - ciris_test_db_auth
+
+    Returns:
+        True if wipe succeeded, False otherwise
+    """
+    if not _is_postgres_container_running():
+        console.print("[yellow]⚠️  PostgreSQL container not running, nothing to wipe[/yellow]")
+        return True
+
+    console.print("[cyan]🧹 Wiping PostgreSQL databases for clean QA state...[/cyan]")
+
+    databases = ["ciris_test_db", "ciris_test_db_secrets", "ciris_test_db_auth"]
+
+    for db_name in databases:
+        try:
+            # Drop and recreate the database
+            # First, terminate all connections to the database
+            result = subprocess.run(
+                [
+                    "docker",
+                    "exec",
+                    POSTGRES_CONTAINER_NAME,
+                    "psql",
+                    "-U",
+                    "ciris_test",
+                    "-d",
+                    "postgres",
+                    "-c",
+                    f"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '{db_name}' AND pid <> pg_backend_pid();",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            # Drop the database
+            result = subprocess.run(
+                [
+                    "docker",
+                    "exec",
+                    POSTGRES_CONTAINER_NAME,
+                    "psql",
+                    "-U",
+                    "ciris_test",
+                    "-d",
+                    "postgres",
+                    "-c",
+                    f"DROP DATABASE IF EXISTS {db_name};",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            if result.returncode != 0 and "does not exist" not in result.stderr:
+                console.print(f"[yellow]⚠️  Could not drop {db_name}: {result.stderr}[/yellow]")
+
+            # Recreate the database
+            result = subprocess.run(
+                [
+                    "docker",
+                    "exec",
+                    POSTGRES_CONTAINER_NAME,
+                    "psql",
+                    "-U",
+                    "ciris_test",
+                    "-d",
+                    "postgres",
+                    "-c",
+                    f"CREATE DATABASE {db_name} OWNER ciris_test;",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            if result.returncode == 0:
+                console.print(f"[green]✅ Wiped and recreated {db_name}[/green]")
+            elif "already exists" in result.stderr:
+                console.print(f"[dim]{db_name} already exists (drop may have failed)[/dim]")
+            else:
+                console.print(f"[yellow]⚠️  Could not create {db_name}: {result.stderr}[/yellow]")
+
+        except subprocess.TimeoutExpired:
+            console.print(f"[yellow]⚠️  Timeout wiping {db_name}[/yellow]")
+        except Exception as e:
+            console.print(f"[yellow]⚠️  Error wiping {db_name}: {e}[/yellow]")
+
+    console.print("[green]✅ PostgreSQL databases wiped[/green]")
+    return True
+
+
 def _ensure_env_file(console: Console, mock_llm: bool = True) -> bool:
     """Ensure a minimal .env file exists for QA testing.
 
@@ -494,6 +592,10 @@ class APIServerManager:
             if not _start_postgres_container(self.console):
                 self.console.print("[red]❌ Failed to start PostgreSQL - cannot proceed[/red]")
                 return False
+            # Wipe PostgreSQL databases if --wipe-data is set
+            if self.config.wipe_data:
+                if not _wipe_postgres_databases(self.console):
+                    self.console.print("[yellow]⚠️  PostgreSQL wipe failed, continuing anyway[/yellow]")
 
         # Start mock logshipper to receive accord traces (unless using live lens)
         if self.config.live_lens:
@@ -522,6 +624,7 @@ class APIServerManager:
         # Set environment variables
         env = os.environ.copy()
         env["PYTHONUNBUFFERED"] = "1"
+        env["CIRIS_TESTING_MODE"] = "true"  # Enable testing mode for admin user creation
 
         # Set CIRIS_HOME for verifier_singleton (required for audit hash chain)
         if "CIRIS_HOME" not in env:
@@ -551,12 +654,16 @@ class APIServerManager:
         if self.mock_logshipper:
             env["CIRIS_ACCORD_METRICS_ENDPOINT"] = self.mock_logshipper.endpoint_url
 
-        # Force first-run mode for SETUP module tests
+        # Force first-run mode for SETUP module tests or when data was wiped
         from .config import QAModule
 
         if any(m == QAModule.SETUP for m in self.modules):
             env["CIRIS_FORCE_FIRST_RUN"] = "1"
             self.console.print("[dim]Setting CIRIS_FORCE_FIRST_RUN=1 for SETUP module tests[/dim]")
+        elif self.config.wipe_data:
+            # When data is wiped, we need first-run to allow setup completion
+            env["CIRIS_FORCE_FIRST_RUN"] = "1"
+            self.console.print("[dim]Setting CIRIS_FORCE_FIRST_RUN=1 for wiped data[/dim]")
 
         # Set backend-specific log directory to avoid symlink collisions
         # But preserve existing CIRIS_LOG_DIR if set (for multi-occurrence)
@@ -836,6 +943,45 @@ class APIServerManager:
             "Try using --wipe-data to reset to first-run state."
         )
 
+    def _complete_qa_setup(self) -> bool:
+        """Complete setup wizard to create test user when data was wiped.
+
+        This is called when --wipe-data is used to create a known test user
+        before attempting authentication.
+        """
+        self.console.print("[cyan]🔧 Completing setup to create test user...[/cyan]")
+
+        # Use the config's admin credentials
+        setup_payload = {
+            "llm_provider": "openai",
+            "llm_api_key": "test-key-for-qa",
+            "llm_model": "gpt-4",
+            "template_id": "default",
+            "enabled_adapters": ["api"],
+            "adapter_config": {},
+            "admin_username": self.config.admin_username,
+            "admin_password": self.config.admin_password if self.config.admin_password != "__auto_detect__" else "qa_test_password_12345",
+            "agent_port": self.config.api_port,
+        }
+
+        try:
+            response = requests.post(
+                f"{self.config.base_url}/v1/setup/complete",
+                json=setup_payload,
+                timeout=30,
+            )
+            if response.status_code == 200:
+                self.console.print("[green]✅ Setup completed, test user created[/green]")
+                # Store the password we used
+                self._extracted_password = setup_payload["admin_password"]
+                return True
+            else:
+                self.console.print(f"[red]❌ Setup failed: {response.status_code} - {response.text[:200]}[/red]")
+                return False
+        except Exception as e:
+            self.console.print(f"[red]❌ Setup error: {e}[/red]")
+            return False
+
     def _wait_for_server(self) -> bool:
         """Wait for server to be ready and reach WORK state."""
         from .config import QAModule
@@ -904,6 +1050,11 @@ class APIServerManager:
         if QAModule.SETUP in self.modules:
             self.console.print("[green]✅ Server ready for SETUP tests (first-run mode)[/green]")
             return True
+
+        # If data was wiped, complete setup to create test user before authenticating
+        if self.config.wipe_data:
+            if not self._complete_qa_setup():
+                return False
 
         # Now wait for agent to reach WORK state
         self.console.print("[cyan]⏳ Waiting for agent to reach WORK state...[/cyan]")


### PR DESCRIPTION
Introduces a new CIRIS adapter that runs a local OpenAI-compatible Gemma 4
inference server as part of the runtime on mobile devices that are capable
enough per the Google AI Edge / LiteRT-LM guidance, and wires it into the
first-start wizard on both Android and iOS.

Python adapter (ciris_adapters/mobile_local_llm/):
- Pydantic-typed config (MobileLocalLLMConfig) with env-var bindings.
- Device capability probe that classifies a phone into a concrete tier
  (CAPABLE_E4B / CAPABLE_E2B / IOS_STUB / INCAPABLE) based on platform,
  arm64 ABI, total RAM, and free disk — thresholds match the Google AI
  Edge guidance (E2B ~6 GB, E4B ~8 GB).
- InferenceServerManager owns the subprocess lifecycle of the on-device
  server (LiteRT-LM / llama.cpp / similar), waits on /health, and SIGTERM
  -> SIGKILL on shutdown.
- MobileLocalLLMService implements LLMServiceProtocol and stays
  healthy=False on weak devices so the LLM bus transparently falls back
  to the hosted provider.
- Adapter registers with Priority.HIGH, runs a background health loop,
  and reports a distinct "ios_stub" error when iOS hardware is capable
  but no Gemma 4 model bundle is shipped yet.

iOS behaviour:
- Detected via path + environment markers. Capable iOS hardware returns
  IOS_STUB when no model bundle exists at the configured path — per user
  requirement "on apple, leave it as a stub if an adequate model does
  not exist".
- Sideloading a bundle at Documents/ciris/models/gemma-4-litert.bundle
  flips the tier to CAPABLE_E2B / CAPABLE_E4B automatically.

Kotlin Multiplatform wizard integration:
- New expect fun probeLocalInferenceCapability() in commonMain with
  Android (ActivityManager), iOS (NSProcessInfo + NSFileManager), and
  Desktop (always INCAPABLE) actual implementations.
- SetupScreen's LLM_CONFIGURATION step renders a new
  LocalInferenceOptionCard that is shown only for capable mobile phones;
  iOS-stub devices see "Coming Soon" (disabled); incapable devices see
  nothing.
- New SetupMode.LOCAL_ON_DEVICE enum value wires the wizard selection
  through to the existing SettingsViewModel BYOK provider list.

Tests:
- tests/ciris_adapters/mobile_local_llm/ covers config hydration, the
  capability probe across Android / iOS / Desktop, server lifecycle,
  LLM service lifecycle, and adapter registration + health loop.
- Capability probe accepts callable overrides for every system call so
  tests can simulate the full device matrix without touching the real
  runtime.

https://claude.ai/code/session_01Bb4395jCsSGNyM5e2nx7jj