### PR TITLE
Fix CIRIS proxy token refresh for secondary LLM service

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 **A type-safe, auditable AI agent framework with built-in ethical reasoning**
 
-**BETA RELEASE 2.5.0-stable** | [Release Notes](CHANGELOG.md) | [Documentation Hub](docs/README.md)
+**BETA RELEASE 2.5.1-stable** | [Release Notes](CHANGELOG.md) | [Documentation Hub](docs/README.md)
 
 CIRIS lets you run AI agents that explain their decisions, defer to humans when uncertain, and maintain complete audit trails. Currently powering Discord community moderation, designed to scale to healthcare and education.
 

--- a/android/app/src/main/python/version.py
+++ b/android/app/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.5.0"
+__version__ = "android-2.5.1"
 
 
 def get_version() -> str:

--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -3,11 +3,11 @@
 from pathlib import Path
 
 # Version information
-CIRIS_VERSION = "2.5.0-stable"
+CIRIS_VERSION = "2.5.1-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
 CIRIS_VERSION_MINOR = 5
-CIRIS_VERSION_PATCH = 0
+CIRIS_VERSION_PATCH = 1
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/ciris_engine/logic/runtime/service_initializer.py
+++ b/ciris_engine/logic/runtime/service_initializer.py
@@ -1106,6 +1106,11 @@ This directory contains critical cryptographic keys for the CIRIS system.
                 metadata={"provider": "openai_secondary", "model": model_name, "base_url": base_url},
             )
 
+        # Register token refresh handler for secondary LLM (CIRIS proxy uses JWT auth)
+        if self.resource_monitor_service and hasattr(self.resource_monitor_service, "signal_bus"):
+            self.resource_monitor_service.signal_bus.register("token_refreshed", service.handle_token_refreshed)
+            logger.info("Registered secondary LLM service token refresh handler")
+
         logger.info(f"Secondary LLM service initialized: {model_name}")
 
     async def _initialize_ciris_proxy_fallback(self, config: Any, id_token: str) -> None:

--- a/ciris_engine/logic/services/runtime/llm_service/service.py
+++ b/ciris_engine/logic/services/runtime/llm_service/service.py
@@ -921,11 +921,24 @@ class OpenAICompatibleClient(BaseService, LLMServiceProtocol):
         """
         logger.info("[LLM_TOKEN] Received token_refreshed signal: %s for %s", signal, resource)
 
-        # Read fresh API key from environment
-        new_api_key = os.environ.get("OPENAI_API_KEY", "")
+        # Check if this service uses CIRIS proxy (JWT auth via Google/Apple ID token)
+        base_url = getattr(self.openai_config, "base_url", "") or ""
+        is_ciris_proxy = any(domain in base_url for domain in ("ciris.ai", "ciris-services"))
+
+        # Read fresh API key from appropriate environment variable
+        if is_ciris_proxy:
+            # CIRIS proxy uses JWT auth (Google/Apple ID token)
+            new_api_key = os.environ.get("CIRIS_BILLING_GOOGLE_ID_TOKEN", "") or os.environ.get(
+                "CIRIS_BILLING_APPLE_ID_TOKEN", ""
+            )
+            logger.info("[LLM_TOKEN] CIRIS proxy service - reading from CIRIS_BILLING_*_ID_TOKEN")
+        else:
+            # Standard OpenAI-compatible service uses OPENAI_API_KEY
+            new_api_key = os.environ.get("OPENAI_API_KEY", "")
 
         if not new_api_key:
-            logger.warning("[LLM_TOKEN] No OPENAI_API_KEY found in environment after refresh")
+            env_var = "CIRIS_BILLING_*_ID_TOKEN" if is_ciris_proxy else "OPENAI_API_KEY"
+            logger.warning("[LLM_TOKEN] No %s found in environment after refresh", env_var)
             return
 
         # Check if key actually changed

--- a/ios/CirisiOS/src/ciris_ios/version.py
+++ b/ios/CirisiOS/src/ciris_ios/version.py
@@ -6,7 +6,7 @@ The version hash is computed at build time from the main repository.
 """
 
 # Static version - updated at build time by the iOS build process
-__version__ = "ios-2.5.0"
+__version__ = "ios-2.5.1"
 
 
 def get_version() -> str:

--- a/mobile/androidApp/build.gradle
+++ b/mobile/androidApp/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 35
-        versionCode 89
-        versionName "2.5.0"
+        versionCode 90
+        versionName "2.5.1"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/mobile/androidApp/src/main/python/version.py
+++ b/mobile/androidApp/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.5.0"
+__version__ = "android-2.5.1"
 
 
 def get_version() -> str:

--- a/mobile/iosApp/iosApp/Info.plist
+++ b/mobile/iosApp/iosApp/Info.plist
@@ -19,9 +19,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.5.0</string>
+	<string>2.5.1</string>
 	<key>CFBundleVersion</key>
-	<string>228</string>
+	<string>229</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
## Summary
- Fix `ciris_secondary` LLM service not receiving token refresh updates
- `handle_token_refreshed()` now detects CIRIS proxy services (by checking base URL for `ciris.ai` or `ciris-services`) and reads from `CIRIS_BILLING_*_ID_TOKEN` instead of `OPENAI_API_KEY`
- Register token refresh handler for `ciris_secondary` service (was missing)

## Root Cause
The secondary LLM service was initialized with the Google ID token at startup, but when the token was refreshed:
1. The refresh handler read from `OPENAI_API_KEY` (wrong env var for CIRIS proxy)
2. The `ciris_secondary` service had no token refresh handler registered

## Test plan
- [x] Build and deploy to Android device
- [x] Verify app starts without crash
- [ ] Verify token refresh works when Google ID token expires

🤖 Generated with [Claude Code](https://claude.com/claude-code)