### PR TITLE
Release 2.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 **A type-safe, auditable AI agent framework with built-in ethical reasoning**
 
-**BETA RELEASE 2.6.3-stable** | [Release Notes](CHANGELOG.md) | [Documentation Hub](docs/README.md)
+**BETA RELEASE 2.6.4-stable** | [Release Notes](CHANGELOG.md) | [Documentation Hub](docs/README.md)
 
 CIRIS lets you run AI agents that explain their decisions, defer to humans when uncertain, and maintain complete audit trails. Currently powering Discord community moderation, designed to scale to healthcare and education.
 

--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -3,11 +3,11 @@
 from pathlib import Path
 
 # Version information
-CIRIS_VERSION = "2.6.3-stable"
+CIRIS_VERSION = "2.6.4-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
 CIRIS_VERSION_MINOR = 6
-CIRIS_VERSION_PATCH = 3
+CIRIS_VERSION_PATCH = 4
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/client/androidApp/build.gradle
+++ b/client/androidApp/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 35
-        versionCode 95
-        versionName "2.6.3"
+        versionCode 96
+        versionName "2.6.4"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/client/androidApp/src/main/python/version.py
+++ b/client/androidApp/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.6.3"
+__version__ = "android-2.6.4"
 
 
 def get_version() -> str:

--- a/client/gradle.properties
+++ b/client/gradle.properties
@@ -12,6 +12,8 @@ kotlin.incremental.wasm=true
 
 # Android
 android.useAndroidX=true
+# 16KB page alignment for Android 15+ devices (Google Play requirement)
+android.packaging.jniLibs.pageSize=16KB
 
 # Build performance
 org.gradle.jvmargs=-Xmx8g -XX:+UseParallelGC

--- a/client/iosApp/iosApp/Info.plist
+++ b/client/iosApp/iosApp/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.3</string>
+	<string>2.6.4</string>
 	<key>CFBundleVersion</key>
-	<string>247</string>
+	<string>248</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/docs/ERROR_REPORT_CIRISVERIFY_SIGNING.md
+++ b/docs/ERROR_REPORT_CIRISVERIFY_SIGNING.md
@@ -1,0 +1,138 @@
+# CIRISVerify Ed25519 Signing Failure Report
+
+**Date:** 2026-04-21
+**Severity:** Critical
+**Impact:** All audit hash chain signing fails, blocking normal operation
+
+## Summary
+
+The CIRISVerify Ed25519 signing key is failing to sign because it was originally bound to hardware security (TPM/HSM) but the hardware is now unavailable.
+
+## Error Messages
+
+```
+[ciris_keyring::software] Software fallback attempted but hardware marker is set - key is secured by hardware, marker=Some("HARDWARE_SECURED:99044633")
+
+[ciris_verify_ffi] Ed25519 signing failed: Hardware security error: Key is secured by hardware key (marker=HARDWARE_SECURED:99044633) but hardware access failed
+
+VerificationFailedError: Verification failed (-3): Ed25519 signing failed with code -3
+
+RuntimeError: Hash chain data not generated for action task_complete. enable_hash_chain=True. This is a critical audit trail failure.
+```
+
+## Root Cause Analysis
+
+1. **Key Creation**: The Ed25519 signing key was created with hardware security enabled (TPM or HSM binding)
+
+2. **Hardware Marker**: The key was persisted with marker `HARDWARE_SECURED:99044633`, indicating it's bound to hardware security module ID `99044633`
+
+3. **Hardware Unavailable**: When signing is attempted:
+   - The library detects the hardware marker
+   - Attempts to use hardware path but hardware access fails
+   - Software fallback is explicitly blocked because key has hardware marker
+   - Result: Error code -3 (signing failure)
+
+4. **Cascade Effect**: Every action (speak, task_complete, etc.) requires audit hash chain signing → all actions fail
+
+## Key Storage Location
+
+```
+~/.local/share/ciris-verify/
+├── ciris_verify_key.p256.key  (32 bytes, raw key material)
+├── named_keys.master.key      (32 bytes)
+├── test.p256.key              (32 bytes)
+└── keystore.db                (0 bytes - empty)
+```
+
+The hardware marker (`HARDWARE_SECURED:99044633`) is NOT stored in these files - it appears to be encoded in the native library's internal state or key metadata format.
+
+## Timeline
+
+```
+15:26:07.010 - First signing failure detected
+15:26:07.010 - Software fallback blocked due to hardware marker
+15:26:07.010 - Hash chain failure triggers error handling
+15:26:07.xxx - Pattern repeats for every action
+```
+
+## Affected Components
+
+1. `ciris_engine/logic/audit/signature_manager.py` - Cannot sign entries
+2. `ciris_engine/logic/audit/signing_protocol.py:166` - Raises VerificationFailedError
+3. `ciris_engine/logic/services/graph/audit_service/service.py` - Hash chain generation fails
+4. `ciris_engine/logic/infrastructure/handlers/action_dispatcher.py` - All action handlers fail
+5. `ciris_adapters/ciris_verify/ffi_bindings/client.py` - FFI calls return error -3
+
+## Possible Causes
+
+1. **Hardware Changed**: The TPM/HSM that created the key is no longer accessible
+2. **Container/VM**: Running in environment without access to original hardware
+3. **Key Migration**: Key was created on different machine with hardware security
+4. **Driver Issue**: TPM driver not loaded or malfunctioning
+
+## Resolution Options
+
+### Option 1: Re-enable Hardware Access (Preferred if possible)
+- Ensure TPM/HSM driver is loaded
+- Check `/dev/tpm0` or equivalent exists
+- Verify permissions for hardware access
+
+### Option 2: Generate New Software-Only Key
+```bash
+# Delete existing key storage (DESTRUCTIVE - loses existing audit chain)
+rm -rf ~/.local/share/ciris-verify/
+
+# Restart server - new key will be generated without hardware binding
+# Note: Existing audit chain signatures will be invalid
+```
+
+### Option 3: Fix in CIRISVerify Library
+- Add configuration to allow software fallback even with hardware marker
+- Implement key migration from hardware to software mode
+- Add CLI tool to re-key with software-only mode
+
+### Option 4: Disable Hash Chain (Development Only)
+```python
+# In config, set enable_hash_chain=False
+# WARNING: This disables audit integrity guarantees
+```
+
+## Verification Steps
+
+1. Check TPM availability:
+   ```bash
+   ls -la /dev/tpm*
+   dmesg | grep -i tpm
+   ```
+
+2. Check CIRISVerify status:
+   ```bash
+   python3 -c "
+   from ciris_adapters.ciris_verify.ffi_bindings.client import CIRISVerifyClient
+   client = CIRISVerifyClient()
+   print(client.get_status())
+   "
+   ```
+
+3. Verify key can sign:
+   ```bash
+   python3 -c "
+   from ciris_engine.logic.audit.signing_protocol import UnifiedSigningKey
+   key = UnifiedSigningKey()
+   sig = key.sign(b'test')
+   print('Signing works!' if sig else 'Signing failed')
+   "
+   ```
+
+## Impact Assessment
+
+- **Memory Benchmark**: Slowed due to error handling on every action
+- **Normal Operations**: All actions fail with hash chain errors
+- **Audit Trail**: No new entries can be signed
+- **Attestation**: Works (uses separate path) but context building fails
+
+## Recommendations
+
+1. **Immediate**: Regenerate keys without hardware binding for development
+2. **Short-term**: Add configuration option to allow software fallback
+3. **Long-term**: Implement proper key migration tooling


### PR DESCRIPTION
## Summary
- Version bump to 2.6.4-stable
- iOS: CFBundleVersion 248, CFBundleShortVersionString 2.6.4
- Android: versionCode 96, versionName 2.6.4

## Test plan
- [x] CI passes
- [x] Build release AAB
- [ ] Deploy to Play Store

🤖 Generated with [Claude Code](https://claude.com/claude-code)