### PR TITLE
Fix mobile_local_llm lifecycle: always stop on exit

### DIFF
--- a/ciris_adapters/mobile_local_llm/adapter.py
+++ b/ciris_adapters/mobile_local_llm/adapter.py
@@ -175,9 +175,11 @@ class MobileLocalLLMAdapter(Service):
             await agent_task
         except asyncio.CancelledError:
             logger.info("MobileLocalLLMAdapter lifecycle cancelled")
-            await self.stop()
             raise  # Re-raise to propagate cancellation
-        else:
+        except Exception:
+            logger.exception("MobileLocalLLMAdapter lifecycle failed")
+            raise
+        finally:
             await self.stop()
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
run_lifecycle missed cleanup when agent_task raised non-CancelledError exceptions. The else clause only runs on success, so failures left the adapter running with stale state. Use finally to ensure stop() always runs regardless of exit path.