### PR TITLE
v2.6.8: Fix desktop startup race condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 **A type-safe, auditable AI agent framework with built-in ethical reasoning**
 
-**BETA RELEASE 2.6.7-stable** | [Release Notes](CHANGELOG.md) | [Documentation Hub](docs/README.md)
+**BETA RELEASE 2.6.8-stable** | [Release Notes](CHANGELOG.md) | [Documentation Hub](docs/README.md)
 
 CIRIS lets you run AI agents that explain their decisions, defer to humans when uncertain, and maintain complete audit trails. Currently powering Discord community moderation, designed to scale to healthcare and education.
 

--- a/ciris_engine/cli.py
+++ b/ciris_engine/cli.py
@@ -48,6 +48,43 @@ def main() -> None:
         _run_desktop_mode()
 
 
+def _wait_for_server_health(server_url: str, timeout: float = 60.0) -> bool:
+    """Wait for server to be healthy (responding to health checks).
+
+    Args:
+        server_url: Base URL of the server
+        timeout: Maximum seconds to wait
+
+    Returns:
+        True if server became healthy, False if timed out
+    """
+    import time
+    import urllib.request
+    import urllib.error
+
+    health_url = f"{server_url}/v1/system/health"
+    start = time.time()
+    attempt = 0
+
+    while time.time() - start < timeout:
+        attempt += 1
+        try:
+            with urllib.request.urlopen(health_url, timeout=2) as resp:
+                if resp.status == 200:
+                    print(f"Server healthy after {attempt} attempts ({time.time() - start:.1f}s)")
+                    return True
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError):
+            pass
+
+        # Print progress every 5 attempts
+        if attempt % 5 == 0:
+            print(f"Waiting for server... (attempt {attempt})")
+
+        time.sleep(0.5)
+
+    return False
+
+
 def _run_desktop_mode() -> None:
     """Start API server and launch desktop application."""
     import time
@@ -95,6 +132,18 @@ def _run_desktop_mode() -> None:
         print(f"  fuser -k {port}/tcp  (Linux)", file=sys.stderr)
         print(f"{'=' * 60}\n", file=sys.stderr)
         sys.exit(exit_code if exit_code != 0 else 1)
+
+    # Wait for server to be actually healthy before launching desktop
+    # This prevents the desktop app from trying to start its own server
+    print("Waiting for server to be ready...")
+    if not _wait_for_server_health(server_url, timeout=60.0):
+        # Check if process crashed while we were waiting
+        exit_code = server_proc.poll()
+        if exit_code is not None:
+            print(f"ERROR: Server process exited with code {exit_code}", file=sys.stderr)
+            sys.exit(exit_code if exit_code != 0 else 1)
+        print("WARNING: Server not responding to health checks yet, launching desktop anyway...")
+        print("         The desktop app will retry connecting to the server.")
 
     try:
         # Launch bundled desktop app (it has its own server detection logic)

--- a/ciris_engine/cli.py
+++ b/ciris_engine/cli.py
@@ -133,19 +133,19 @@ def _run_desktop_mode() -> None:
         print(f"{'=' * 60}\n", file=sys.stderr)
         sys.exit(exit_code if exit_code != 0 else 1)
 
-    # Wait for server to be actually healthy before launching desktop
-    # This prevents the desktop app from trying to start its own server
-    print("Waiting for server to be ready...")
-    if not _wait_for_server_health(server_url, timeout=60.0):
-        # Check if process crashed while we were waiting
-        exit_code = server_proc.poll()
-        if exit_code is not None:
-            print(f"ERROR: Server process exited with code {exit_code}", file=sys.stderr)
-            sys.exit(exit_code if exit_code != 0 else 1)
-        print("WARNING: Server not responding to health checks yet, launching desktop anyway...")
-        print("         The desktop app will retry connecting to the server.")
-
     try:
+        # Wait for server to be actually healthy before launching desktop
+        # This prevents the desktop app from trying to start its own server
+        print("Waiting for server to be ready...")
+        if not _wait_for_server_health(server_url, timeout=60.0):
+            # Check if process crashed while we were waiting
+            exit_code = server_proc.poll()
+            if exit_code is not None:
+                print(f"ERROR: Server process exited with code {exit_code}", file=sys.stderr)
+                sys.exit(exit_code if exit_code != 0 else 1)
+            print("WARNING: Server not responding to health checks yet, launching desktop anyway...")
+            print("         The desktop app will retry connecting to the server.")
+
         # Launch bundled desktop app (it has its own server detection logic)
         try:
             from ciris_engine.desktop_launcher import launch_desktop_app

--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -3,11 +3,11 @@
 from pathlib import Path
 
 # Version information
-CIRIS_VERSION = "2.6.7-stable"
+CIRIS_VERSION = "2.6.8-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
 CIRIS_VERSION_MINOR = 6
-CIRIS_VERSION_PATCH = 7
+CIRIS_VERSION_PATCH = 8
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/client/androidApp/build.gradle
+++ b/client/androidApp/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 35
-        versionCode 99
-        versionName "2.6.7"
+        versionCode 100
+        versionName "2.6.8"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/client/androidApp/src/main/python/version.py
+++ b/client/androidApp/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.6.7"
+__version__ = "android-2.6.8"
 
 
 def get_version() -> str:

--- a/client/iosApp/iosApp/Info.plist
+++ b/client/iosApp/iosApp/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.7</string>
+	<string>2.6.8</string>
 	<key>CFBundleVersion</key>
-	<string>253</string>
+	<string>254</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
CLI now waits for server to be healthy (responding to /v1/system/health) before launching the desktop app. This prevents the desktop app from detecting no server and trying to start its own backend, which caused port conflicts and health check failures.

The fix adds _wait_for_server_health() which polls the health endpoint for up to 60 seconds with 0.5s intervals, printing progress every 5 attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)