### PR TITLE
v2.6.9: Fix desktop startup race condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 **A type-safe, auditable AI agent framework with built-in ethical reasoning**
 
-**BETA RELEASE 2.6.7-stable** | [Release Notes](CHANGELOG.md) | [Documentation Hub](docs/README.md)
+**BETA RELEASE 2.6.8-stable** | [Release Notes](CHANGELOG.md) | [Documentation Hub](docs/README.md)
 
 CIRIS lets you run AI agents that explain their decisions, defer to humans when uncertain, and maintain complete audit trails. Currently powering Discord community moderation, designed to scale to healthcare and education.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 **A type-safe, auditable AI agent framework with built-in ethical reasoning**
 
-**BETA RELEASE 2.6.8-stable** | [Release Notes](CHANGELOG.md) | [Documentation Hub](docs/README.md)
+**BETA RELEASE 2.6.9-stable** | [Release Notes](CHANGELOG.md) | [Documentation Hub](docs/README.md)
 
 CIRIS lets you run AI agents that explain their decisions, defer to humans when uncertain, and maintain complete audit trails. Currently powering Discord community moderation, designed to scale to healthcare and education.
 

--- a/ciris_engine/cli.py
+++ b/ciris_engine/cli.py
@@ -48,6 +48,43 @@ def main() -> None:
         _run_desktop_mode()
 
 
+def _wait_for_server_health(server_url: str, timeout: float = 60.0) -> bool:
+    """Wait for server to be healthy (responding to health checks).
+
+    Args:
+        server_url: Base URL of the server
+        timeout: Maximum seconds to wait
+
+    Returns:
+        True if server became healthy, False if timed out
+    """
+    import time
+    import urllib.request
+    import urllib.error
+
+    health_url = f"{server_url}/v1/system/health"
+    start = time.time()
+    attempt = 0
+
+    while time.time() - start < timeout:
+        attempt += 1
+        try:
+            with urllib.request.urlopen(health_url, timeout=2) as resp:
+                if resp.status == 200:
+                    print(f"Server healthy after {attempt} attempts ({time.time() - start:.1f}s)")
+                    return True
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError):
+            pass
+
+        # Print progress every 5 attempts
+        if attempt % 5 == 0:
+            print(f"Waiting for server... (attempt {attempt})")
+
+        time.sleep(0.5)
+
+    return False
+
+
 def _run_desktop_mode() -> None:
     """Start API server and launch desktop application."""
     import time
@@ -95,6 +132,18 @@ def _run_desktop_mode() -> None:
         print(f"  fuser -k {port}/tcp  (Linux)", file=sys.stderr)
         print(f"{'=' * 60}\n", file=sys.stderr)
         sys.exit(exit_code if exit_code != 0 else 1)
+
+    # Wait for server to be actually healthy before launching desktop
+    # This prevents the desktop app from trying to start its own server
+    print("Waiting for server to be ready...")
+    if not _wait_for_server_health(server_url, timeout=60.0):
+        # Check if process crashed while we were waiting
+        exit_code = server_proc.poll()
+        if exit_code is not None:
+            print(f"ERROR: Server process exited with code {exit_code}", file=sys.stderr)
+            sys.exit(exit_code if exit_code != 0 else 1)
+        print("WARNING: Server not responding to health checks yet, launching desktop anyway...")
+        print("         The desktop app will retry connecting to the server.")
 
     try:
         # Launch bundled desktop app (it has its own server detection logic)

--- a/ciris_engine/cli.py
+++ b/ciris_engine/cli.py
@@ -49,7 +49,10 @@ def main() -> None:
 
 
 def _wait_for_server_health(server_url: str, timeout: float = 60.0) -> bool:
-    """Wait for server to be healthy (responding to health checks).
+    """Wait for server to be healthy (responding to startup-status).
+
+    Uses /v1/system/startup-status which is available during boot before
+    authentication is ready, and is more lightweight than /health.
 
     Args:
         server_url: Base URL of the server
@@ -58,26 +61,43 @@ def _wait_for_server_health(server_url: str, timeout: float = 60.0) -> bool:
     Returns:
         True if server became healthy, False if timed out
     """
+    import json
     import time
-    import urllib.request
     import urllib.error
+    import urllib.request
 
-    health_url = f"{server_url}/v1/system/health"
+    # Use startup-status endpoint - available during boot, unauthenticated
+    status_url = f"{server_url}/v1/system/startup-status"
     start = time.time()
     attempt = 0
+    last_services = 0
 
     while time.time() - start < timeout:
         attempt += 1
         try:
-            with urllib.request.urlopen(health_url, timeout=2) as resp:
+            with urllib.request.urlopen(status_url, timeout=3) as resp:
                 if resp.status == 200:
-                    print(f"Server healthy after {attempt} attempts ({time.time() - start:.1f}s)")
-                    return True
-        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError):
+                    body = resp.read().decode("utf-8")
+                    data = json.loads(body).get("data", {})
+                    services_online = data.get("services_online", 0)
+                    services_total = data.get("services_total", 22)
+                    phase = data.get("phase", "unknown")
+
+                    # Print progress when services change
+                    if services_online != last_services:
+                        print(f"Server starting: {services_online}/{services_total} services ({phase})")
+                        last_services = services_online
+
+                    # Consider ready when all services are online
+                    if services_online >= services_total:
+                        elapsed = time.time() - start
+                        print(f"Server ready: {services_online}/{services_total} services ({elapsed:.1f}s)")
+                        return True
+        except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError, json.JSONDecodeError):
             pass
 
-        # Print progress every 5 attempts
-        if attempt % 5 == 0:
+        # Print progress every 10 attempts if no service updates
+        if attempt % 10 == 0:
             print(f"Waiting for server... (attempt {attempt})")
 
         time.sleep(0.5)

--- a/ciris_engine/cli.py
+++ b/ciris_engine/cli.py
@@ -48,7 +48,9 @@ def main() -> None:
         _run_desktop_mode()
 
 
-def _wait_for_server_health(server_url: str, timeout: float = 60.0) -> bool:
+def _wait_for_server_health(
+    server_url: str, server_proc: "subprocess.Popen[bytes]", timeout: float = 60.0
+) -> bool:
     """Wait for server to be healthy (responding to startup-status).
 
     Uses /v1/system/startup-status which is available during boot before
@@ -56,10 +58,11 @@ def _wait_for_server_health(server_url: str, timeout: float = 60.0) -> bool:
 
     Args:
         server_url: Base URL of the server
+        server_proc: The server subprocess to monitor for early exit
         timeout: Maximum seconds to wait
 
     Returns:
-        True if server became healthy, False if timed out
+        True if server became healthy, False if timed out or process died
     """
     import json
     import time
@@ -73,6 +76,10 @@ def _wait_for_server_health(server_url: str, timeout: float = 60.0) -> bool:
     last_services = 0
 
     while time.time() - start < timeout:
+        # Check if server process died
+        if server_proc.poll() is not None:
+            return False
+
         attempt += 1
         try:
             with urllib.request.urlopen(status_url, timeout=3) as resp:
@@ -82,14 +89,17 @@ def _wait_for_server_health(server_url: str, timeout: float = 60.0) -> bool:
                     services_online = data.get("services_online", 0)
                     services_total = data.get("services_total", 22)
                     phase = data.get("phase", "unknown")
+                    api_status = data.get("api_status", "")
 
                     # Print progress when services change
                     if services_online != last_services:
                         print(f"Server starting: {services_online}/{services_total} services ({phase})")
                         last_services = services_online
 
-                    # Consider ready when all services are online
-                    if services_online >= services_total:
+                    # Ready when api_status is "server_ready" (works for both
+                    # normal mode with all 22 services and first-run mode with
+                    # only 10 minimal services)
+                    if api_status == "server_ready":
                         elapsed = time.time() - start
                         print(f"Server ready: {services_online}/{services_total} services ({elapsed:.1f}s)")
                         return True
@@ -157,7 +167,7 @@ def _run_desktop_mode() -> None:
         # Wait for server to be actually healthy before launching desktop
         # This prevents the desktop app from trying to start its own server
         print("Waiting for server to be ready...")
-        if not _wait_for_server_health(server_url, timeout=60.0):
+        if not _wait_for_server_health(server_url, server_proc, timeout=60.0):
             # Check if process crashed while we were waiting
             exit_code = server_proc.poll()
             if exit_code is not None:

--- a/ciris_engine/cli.py
+++ b/ciris_engine/cli.py
@@ -133,19 +133,19 @@ def _run_desktop_mode() -> None:
         print(f"{'=' * 60}\n", file=sys.stderr)
         sys.exit(exit_code if exit_code != 0 else 1)
 
-    # Wait for server to be actually healthy before launching desktop
-    # This prevents the desktop app from trying to start its own server
-    print("Waiting for server to be ready...")
-    if not _wait_for_server_health(server_url, timeout=60.0):
-        # Check if process crashed while we were waiting
-        exit_code = server_proc.poll()
-        if exit_code is not None:
-            print(f"ERROR: Server process exited with code {exit_code}", file=sys.stderr)
-            sys.exit(exit_code if exit_code != 0 else 1)
-        print("WARNING: Server not responding to health checks yet, launching desktop anyway...")
-        print("         The desktop app will retry connecting to the server.")
-
     try:
+        # Wait for server to be actually healthy before launching desktop
+        # This prevents the desktop app from trying to start its own server
+        print("Waiting for server to be ready...")
+        if not _wait_for_server_health(server_url, timeout=60.0):
+            # Check if process crashed while we were waiting
+            exit_code = server_proc.poll()
+            if exit_code is not None:
+                print(f"ERROR: Server process exited with code {exit_code}", file=sys.stderr)
+                sys.exit(exit_code if exit_code != 0 else 1)
+            print("WARNING: Server not responding to health checks yet, launching desktop anyway...")
+            print("         The desktop app will retry connecting to the server.")
+
         # Launch bundled desktop app (it has its own server detection logic)
         try:
             from ciris_engine.desktop_launcher import launch_desktop_app

--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -3,11 +3,11 @@
 from pathlib import Path
 
 # Version information
-CIRIS_VERSION = "2.6.8-stable"
+CIRIS_VERSION = "2.6.9-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
 CIRIS_VERSION_MINOR = 6
-CIRIS_VERSION_PATCH = 8
+CIRIS_VERSION_PATCH = 9
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -3,11 +3,11 @@
 from pathlib import Path
 
 # Version information
-CIRIS_VERSION = "2.6.7-stable"
+CIRIS_VERSION = "2.6.8-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
 CIRIS_VERSION_MINOR = 6
-CIRIS_VERSION_PATCH = 7
+CIRIS_VERSION_PATCH = 8
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/client/androidApp/build.gradle
+++ b/client/androidApp/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 35
-        versionCode 99
-        versionName "2.6.7"
+        versionCode 100
+        versionName "2.6.8"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/client/androidApp/build.gradle
+++ b/client/androidApp/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 35
-        versionCode 100
-        versionName "2.6.8"
+        versionCode 101
+        versionName "2.6.9"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/client/androidApp/src/main/python/version.py
+++ b/client/androidApp/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.6.8"
+__version__ = "android-2.6.9"
 
 
 def get_version() -> str:

--- a/client/androidApp/src/main/python/version.py
+++ b/client/androidApp/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.6.7"
+__version__ = "android-2.6.8"
 
 
 def get_version() -> str:

--- a/client/iosApp/iosApp/Info.plist
+++ b/client/iosApp/iosApp/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.8</string>
+	<string>2.6.9</string>
 	<key>CFBundleVersion</key>
-	<string>254</string>
+	<string>255</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/client/iosApp/iosApp/Info.plist
+++ b/client/iosApp/iosApp/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.7</string>
+	<string>2.6.8</string>
 	<key>CFBundleVersion</key>
-	<string>253</string>
+	<string>254</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
## Summary

- Fix CLI to properly wait for server before launching desktop app
- Prevents race condition where desktop app tries to start its own backend
- Ensures server cleanup on Ctrl+C during health polling

## Changes

1. **Move health wait inside try/finally block** (`cli.py`)
   - Ensures server subprocess cleanup on interrupt during health polling
   - Prevents orphaned backend processes on port 8080

2. **Use `/v1/system/startup-status` endpoint instead of `/health`**
   - Designed for boot-time polling, available before auth is ready
   - More lightweight, doesn't require full service health collection
   - Shows progress as services come online

3. **Better progress reporting**
   - Shows `services_online/services_total` count (e.g., "14/22 services")
   - Shows current startup phase
   - Only prints when service count changes

## Test plan

- [ ] Run `ciris-agent` from home directory
- [ ] Verify server starts and desktop launches after all 22 services are ready
- [ ] Test Ctrl+C during health polling - server should be terminated
- [ ] Verify no orphaned processes on port 8080

🤖 Generated with [Claude Code](https://claude.com/claude-code)