### PR TITLE
docs: add round-1 grant baseline measurement workflow

### DIFF
--- a/docs/DOCUMENTATION_VALIDATION_PLAN.md
+++ b/docs/DOCUMENTATION_VALIDATION_PLAN.md
@@ -2,220 +2,115 @@
 
 ## Overview
 
-This plan outlines a systematic bottom-up approach to validate and maintain CIRIS documentation accuracy. Starting from the lowest-level implementation files and working up to high-level architecture documents ensures ground truth accuracy.
+This plan defines a reproducible process for keeping grant-facing and architecture-facing claims synchronized with code reality.
+
+The immediate Round 1 objective is to remove stale hard-coded counts (tests/endpoints) and replace them with script-generated baselines that can be re-run before each release and before external reporting deadlines.
 
 ## Validation Hierarchy
 
 ### Level 1: Implementation Files (Ground Truth)
-These are the source of truth - code never lies.
 
 1. **Service Implementations** (`ciris_engine/logic/services/`)
-   - Count actual services
-   - Verify service categories
-   - Check implemented methods
-
+   - Validate service taxonomy and category mapping.
 2. **Protocol Definitions** (`ciris_engine/protocols/`)
-   - Verify protocol-implementation match
-   - Check inheritance hierarchy
-   - Validate method signatures
-
+   - Validate protocol ↔ implementation alignment.
 3. **Schema Definitions** (`ciris_engine/schemas/`)
-   - Count schema directories
-   - Verify type definitions
-   - Check for Dict[str, Any] usage
+   - Validate schema drift and typed contract coverage.
+4. **Action Handlers** (`ciris_engine/logic/handlers/`)
+   - Validate ten-verb implementation and handler routing.
+5. **API Router Registration** (`ciris_engine/logic/adapters/api/app.py`)
+   - Validate endpoint inventory from runtime registration.
 
-4. **Handler Implementations** (`ciris_engine/logic/handlers/`)
-   - Verify all 10 handlers exist
-   - Check handler categories
-   - Validate action mappings
+### Level 2: Local Documentation
 
-### Level 2: Module Documentation
-Documentation within code directories.
+- Service READMEs, protocol READMEs, schema READMEs, and route docs must inherit counts from Level 1 outputs.
 
-1. **Service READMEs** (`*/services/*/README.md`)
-   - Match implementation details
-   - Update API examples
-   - Remove aspirational features
+### Level 3: Public/External Claims
 
-2. **Protocol READMEs** (`*/protocols/*/README.md`)
-   - Verify file references
-   - Update counts and categories
-   - Fix import paths
+- `README.md`, `CLAUDE.md`, grant text, architecture docs, and site pages must only reference script-derived numbers.
 
-3. **Schema READMEs** (`*/schemas/*/README.md`)
-   - Document actual directories
-   - Update type examples
-   - Remove version references
+### Level 4: Operational Evidence
 
-### Level 3: System Documentation
-High-level architecture and design docs.
+- CI test collection logs, endpoint inventory output, and baseline snapshots must be retained in `docs/grant/`.
 
-1. **CLAUDE.md** (Developer guidance)
-   - Verify service counts
-   - Update architecture claims
-   - Check code examples
+---
 
-2. **README.md** (Project overview)
-   - Validate performance claims
-   - Update feature status
-   - Fix architecture diagrams
+## Round 1 Measurement Methodology (Implemented)
 
-3. **Architecture Docs** (`docs/architecture/`)
-   - Verify component counts
-   - Update service categories
-   - Fix dependency graphs
+### Canonical script
 
-### Level 4: Integration Documentation
-Cross-cutting concerns and workflows.
+Use:
 
-1. **API Documentation** (`docs/api/`)
-   - Verify endpoint counts
-   - Update request/response schemas
-   - Check authentication flows
-
-2. **Deployment Guides** (`deployment/`)
-   - Validate resource requirements
-   - Update configuration examples
-   - Check docker-compose files
-
-3. **Test Documentation** (`tests/README.md`)
-   - Update test counts
-   - Verify coverage claims
-   - Document test categories
-
-## Validation Process
-
-### Step 1: Inventory (Automated)
 ```bash
-# Count services
-find ciris_engine/logic/services -name "*.py" -type f | grep -E "(service|Service)" | wc -l
-
-# Count protocols
-find ciris_engine/protocols/services -name "*.py" -type f | wc -l
-
-# Count schemas
-find ciris_engine/schemas -type d | wc -l
-
-# Find Dict[str, Any] usage
-grep -r "Dict\[str, Any\]" ciris_engine/ --include="*.py" | grep -v test | wc -l
+python tools/analysis/round1_grant_baseline.py \
+  --markdown-out docs/grant/ROUND1_BASELINE_$(date +%F).md
 ```
 
-### Step 2: Cross-Reference
-1. Create a source-of-truth table:
-   - Service name | Category | Protocol file | Implementation file | Documented?
-2. Identify discrepancies
-3. Flag outdated documentation
+This script captures:
+- Service taxonomy counts from `ApiServiceConfiguration`
+- Endpoint counts from the live FastAPI route graph (`create_app()`)
+- Test collection totals/errors via `pytest --collect-only -q tests -o addopts=`
 
-### Step 3: Update Documentation
-1. Start with Level 1 files (never change implementation to match docs)
-2. Update Level 2 based on Level 1
-3. Update Level 3 based on Levels 1-2
-4. Update Level 4 based on all previous levels
+### Why this replaces stale static counts
 
-### Step 4: Validation Rules
+- **Tests** and **endpoint** counts change frequently; hard-coding values in docs creates drift.
+- The baseline script provides a single, repeatable mechanism for “latest known truth.”
 
-#### Rule 1: Count Consistency
-- All service counts must be 22
-- All handler counts must be 10
-- Schema directory count must match LS output
+---
 
-#### Rule 2: Category Consistency
-- Graph Services: 6
-- Infrastructure: 7
-- Governance: 4
-- Runtime: 3
-- Tool: 1
+## Round 1 Baseline Snapshot (2026-04-22 UTC)
 
-#### Rule 3: No Aspirational Content
-- Remove "planned features"
-- Remove "future enhancements"
-- Document only what exists
+Source artifact: `docs/grant/ROUND1_BASELINE_2026-04-22.md`.
 
-#### Rule 4: API Examples Must Work
-- Test all code examples
-- Verify import paths
-- Check method signatures
+- **Core services:** 22
+  - graph 7, infrastructure 4, lifecycle 4, governance 4, runtime 2, tool 1
+- **API method+path routes:** 257
+  - GET 139, POST 83, PUT 17, PATCH 2, DELETE 16
+- **Tests collected:** 10,662
+- **Collection errors:** 37
+- **Missing plugins detected in this environment:** `pytest_asyncio`, `hypothesis`
 
-## Maintenance Schedule
+---
 
-### Daily
-- Check for new services/handlers/schemas
-- Validate recent PRs for doc updates
+## Low-Hanging Hygiene Fixes (Round 1)
 
-### Weekly
-- Run full validation script
-- Update any drift
-- Check for new Dict[str, Any]
+### Ship before June 1, 2026
 
-### Monthly
-- Deep review of architecture docs
-- Update performance metrics
-- Refresh API documentation
+1. Replace stale “78/99 endpoint” claims in grant-facing docs with “script-generated; see latest baseline artifact.”
+2. Replace stale “3,500+ tests” claims with baseline-derived count plus date stamp.
+3. Add a CI job that runs `round1_grant_baseline.py --skip-tests` on every PR.
+4. Add a nightly CI job with full collection (`--skip-tests` off) and publish artifact.
 
-### Quarterly
-- Full bottom-up validation
-- Update all examples
-- Architecture diagram refresh
+### Ship this quarter
 
-## Red Flags
+1. Install and pin missing pytest plugins in dev/test image (`pytest-asyncio`, `hypothesis`) so collection errors reflect code issues rather than environment gaps.
+2. Normalize service strata naming across docs (Graph/Infrastructure/Runtime/Governance/Core Tool vs Lifecycle naming).
+3. Add a generated endpoint CSV (path, method, auth dependency presence) to support the authZ audit pass.
 
-These indicate documentation drift:
-1. Service count != 22 anywhere
-2. "Coming soon" or "planned" features
-3. Import paths that don't exist
-4. Code examples that don't run
-5. Performance claims without data
-6. Dict[str, Any] in examples
-7. Version numbers in paths
-8. Non-existent file references
+### Nice to have
 
-## Validation Tools
+1. Add doc lint to block stale numeric claims unless accompanied by baseline date + artifact reference.
+2. Auto-open a docs PR if baseline count deltas exceed thresholds.
 
-### ciris_doc_validator.py
-```python
-"""
-Automated documentation validator.
-Checks counts, paths, and consistency.
-"""
-# Implementation to be created
-```
+---
 
-### validate_examples.py
-```python
-"""
-Tests all code examples in documentation.
-Ensures they compile and run.
-"""
-# Implementation to be created
-```
+## Ongoing Maintenance Schedule
 
-## Success Metrics
+### Per PR
+- Run baseline script with `--skip-tests` and check service/endpoint drift.
 
-1. **Accuracy**: 100% of counts match implementation
-2. **Currency**: No documentation >30 days out of date
-3. **Executability**: 100% of code examples run
-4. **Completeness**: All components documented
-5. **Consistency**: No conflicting information
+### Nightly
+- Run full baseline including pytest collection and persist markdown artifact.
 
-## Current Status (July 2025)
+### Pre-release / Pre-grant submission
+- Regenerate baseline same day as submission and update all externally visible claim docs.
 
-### Completed Updates
-- [x] protocols/README.md - Updated to 22 services
-- [x] schemas/README.md - Documented 24 directories
-- [x] handler protocols/README.md - Removed non-existent files
-- [x] memory service/README.md - Removed aspirational features
-- [x] service protocols/README.md - Fixed categorizations
+---
 
-### Validation Results
-- Service count: Verified 22 services
-- Dict[str, Any] count: 216 instances (README claim of 0 is false)
-- Schema directories: 24 (verified by LS)
-- Handler count: 10 (verified)
-- API endpoints: 78 (verified)
+## Success Criteria
 
-### Next Steps
-1. Create automated validation scripts
-2. Update main README.md claims
-3. Fix Dict[str, Any] count claim
-4. Update performance benchmarks with real data
-5. Create documentation update checklist for PRs
+1. Every numeric claim in docs is either:
+   - generated from tooling, or
+   - stamped with measurement date and source artifact.
+2. No conflicting endpoint/test/service counts across top-level docs.
+3. Grant-facing counts can be reproduced from commands in this file.

--- a/docs/grant/ROUND1_BASELINE_2026-04-22.md
+++ b/docs/grant/ROUND1_BASELINE_2026-04-22.md
@@ -1,0 +1,27 @@
+# CIRIS Round 1 Baseline
+
+Generated (UTC): 2026-04-22T23:29:00+00:00
+
+## Service taxonomy
+
+- **graph** (7): memory_service, consent_service, config_service, telemetry_service, audit_service, incident_management_service, tsdb_consolidation_service
+- **infrastructure** (4): authentication_service, resource_monitor, database_maintenance_service, secrets_service
+- **lifecycle** (4): time_service, shutdown_service, initialization_service, task_scheduler
+- **governance** (4): wa_auth_system, adaptive_filter_service, visibility_service, self_observation_service
+- **runtime** (2): llm_service, runtime_control_service
+- **tool** (1): secrets_tool_service
+- **total**: 22
+
+## Endpoint inventory
+
+- Total method+path routes: **257**
+- Method split: **{'DELETE': 16, 'GET': 139, 'PATCH': 2, 'POST': 83, 'PUT': 17}**
+- Auth-related routes: **15**
+- OAuth-related routes: **6**
+
+## Test collection
+
+- Collected tests: **10662**
+- Collection errors: **37**
+- Missing plugins observed: **['hypothesis', 'pytest_asyncio']**
+- Raw summary: `10662 tests collected, 37 errors in 20.40s`

--- a/tools/analysis/round1_grant_baseline.py
+++ b/tools/analysis/round1_grant_baseline.py
@@ -132,20 +132,31 @@ def extract_first_match(lines: Iterable[str], pattern: re.Pattern[str]) -> str |
 
 def summarize_test_collection() -> TestCollectionSummary:
     command = ["pytest", "--collect-only", "-q", "tests", "-o", "addopts="]
-    completed = subprocess.run(command, capture_output=True, text=True, check=False)
+    completed = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
 
     combined_output = f"{completed.stdout}\n{completed.stderr}".splitlines()
     summary_line = extract_first_match(
         combined_output,
-        re.compile(r"\d+ tests collected, \d+ errors", re.IGNORECASE),
+        re.compile(r"\d+ tests collected(?:, \d+ errors)?(?: in .+)?", re.IGNORECASE),
     )
     if summary_line is None:
         summary_line = "pytest collection summary not found"
 
-    count_match = re.search(r"(\d+) tests collected, (\d+) errors", summary_line)
+    count_match = re.search(
+        r"(?P<collected>\d+) tests collected(?:, (?P<errors>\d+) errors)?",
+        summary_line,
+        re.IGNORECASE,
+    )
     if count_match:
-        collected = int(count_match.group(1))
-        collection_errors = int(count_match.group(2))
+        collected = int(count_match.group("collected"))
+        errors_text = count_match.group("errors")
+        collection_errors = int(errors_text) if errors_text is not None else 0
     else:
         collected = 0
         collection_errors = 0

--- a/tools/analysis/round1_grant_baseline.py
+++ b/tools/analysis/round1_grant_baseline.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Generate a reproducible Round 1 grant-readiness baseline for CIRISAgent.
+
+This script captures three frequently stale claim surfaces:
+1. Core service taxonomy (22 services)
+2. REST endpoint inventory counts from FastAPI route registration
+3. Test inventory via pytest collection
+
+Outputs:
+- JSON summary to stdout
+- Optional markdown report (--markdown-out)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections import Counter
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from ciris_engine.logic.adapters.api.app import create_app
+from ciris_engine.logic.adapters.api.service_configuration import ApiServiceConfiguration
+
+
+@dataclass
+class CategorySummary:
+    category: str
+    count: int
+    runtime_attributes: list[str]
+
+
+@dataclass
+class EndpointSummary:
+    total_routes: int
+    methods: dict[str, int]
+    auth_related_routes: int
+    oauth_routes: int
+
+
+@dataclass
+class TestCollectionSummary:
+    collected: int
+    collection_errors: int
+    missing_pytest_plugins: list[str]
+    raw_summary_line: str
+
+
+@dataclass
+class Round1Baseline:
+    generated_at_utc: str
+    service_taxonomy: list[CategorySummary]
+    service_total: int
+    endpoint_summary: EndpointSummary
+    test_collection: TestCollectionSummary | None
+
+
+HTTP_METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE"}
+
+
+def summarize_services() -> tuple[list[CategorySummary], int]:
+    categories = [
+        ("graph", ApiServiceConfiguration.GRAPH_SERVICES),
+        ("infrastructure", ApiServiceConfiguration.INFRASTRUCTURE_SERVICES),
+        ("lifecycle", ApiServiceConfiguration.LIFECYCLE_SERVICES),
+        ("governance", ApiServiceConfiguration.GOVERNANCE_SERVICES),
+        ("runtime", ApiServiceConfiguration.RUNTIME_SERVICES),
+        ("tool", ApiServiceConfiguration.TOOL_SERVICES),
+    ]
+
+    results: list[CategorySummary] = []
+    total = 0
+    for category_name, service_mappings in categories:
+        attrs = [mapping.runtime_attr for mapping in service_mappings]
+        count = len(attrs)
+        total += count
+        results.append(CategorySummary(category=category_name, count=count, runtime_attributes=attrs))
+
+    return results, total
+
+
+def summarize_endpoints() -> EndpointSummary:
+    app = create_app()
+
+    method_counter: Counter[str] = Counter()
+    auth_related = 0
+    oauth_related = 0
+    total_routes = 0
+
+    for route in app.routes:
+        methods = getattr(route, "methods", None)
+        if not methods:
+            continue
+
+        filtered_methods = [method for method in methods if method in HTTP_METHODS]
+        if not filtered_methods:
+            continue
+
+        total_routes += 1
+        for method in filtered_methods:
+            method_counter[method] += 1
+
+        route_path = getattr(route, "path", "")
+        if "/auth/" in route_path:
+            auth_related += 1
+        if "/oauth/" in route_path:
+            oauth_related += 1
+
+    return EndpointSummary(
+        total_routes=total_routes,
+        methods=dict(sorted(method_counter.items())),
+        auth_related_routes=auth_related,
+        oauth_routes=oauth_related,
+    )
+
+
+def extract_first_match(lines: Iterable[str], pattern: re.Pattern[str]) -> str | None:
+    for line in lines:
+        if pattern.search(line):
+            return line.strip()
+    return None
+
+
+def summarize_test_collection() -> TestCollectionSummary:
+    command = ["pytest", "--collect-only", "-q", "tests", "-o", "addopts="]
+    completed = subprocess.run(command, capture_output=True, text=True, check=False)
+
+    combined_output = f"{completed.stdout}\n{completed.stderr}".splitlines()
+    summary_line = extract_first_match(
+        combined_output,
+        re.compile(r"\d+ tests collected, \d+ errors", re.IGNORECASE),
+    )
+    if summary_line is None:
+        summary_line = "pytest collection summary not found"
+
+    count_match = re.search(r"(\d+) tests collected, (\d+) errors", summary_line)
+    if count_match:
+        collected = int(count_match.group(1))
+        collection_errors = int(count_match.group(2))
+    else:
+        collected = 0
+        collection_errors = 0
+
+    missing_plugin_pattern = re.compile(r"No module named '([^']+)'", re.IGNORECASE)
+    missing_plugins: set[str] = set()
+    for line in combined_output:
+        plugin_match = missing_plugin_pattern.search(line)
+        if plugin_match:
+            missing_plugins.add(plugin_match.group(1))
+
+    return TestCollectionSummary(
+        collected=collected,
+        collection_errors=collection_errors,
+        missing_pytest_plugins=sorted(missing_plugins),
+        raw_summary_line=summary_line,
+    )
+
+
+def render_markdown(baseline: Round1Baseline) -> str:
+    lines: list[str] = []
+    lines.append("# CIRIS Round 1 Baseline")
+    lines.append("")
+    lines.append(f"Generated (UTC): {baseline.generated_at_utc}")
+    lines.append("")
+    lines.append("## Service taxonomy")
+    lines.append("")
+    for category in baseline.service_taxonomy:
+        lines.append(f"- **{category.category}** ({category.count}): {', '.join(category.runtime_attributes)}")
+    lines.append(f"- **total**: {baseline.service_total}")
+    lines.append("")
+    lines.append("## Endpoint inventory")
+    lines.append("")
+    lines.append(f"- Total method+path routes: **{baseline.endpoint_summary.total_routes}**")
+    lines.append(f"- Method split: **{baseline.endpoint_summary.methods}**")
+    lines.append(f"- Auth-related routes: **{baseline.endpoint_summary.auth_related_routes}**")
+    lines.append(f"- OAuth-related routes: **{baseline.endpoint_summary.oauth_routes}**")
+
+    if baseline.test_collection is not None:
+        lines.append("")
+        lines.append("## Test collection")
+        lines.append("")
+        lines.append(f"- Collected tests: **{baseline.test_collection.collected}**")
+        lines.append(f"- Collection errors: **{baseline.test_collection.collection_errors}**")
+        lines.append(f"- Missing plugins observed: **{baseline.test_collection.missing_pytest_plugins}**")
+        lines.append(f"- Raw summary: `{baseline.test_collection.raw_summary_line}`")
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate CIRIS round-1 baseline metrics")
+    parser.add_argument(
+        "--skip-tests",
+        action="store_true",
+        help="Skip pytest collection (faster, avoids dependency-sensitive collection issues)",
+    )
+    parser.add_argument(
+        "--markdown-out",
+        type=Path,
+        help="Optional markdown output path",
+    )
+    args = parser.parse_args()
+
+    services, total_services = summarize_services()
+    endpoints = summarize_endpoints()
+    test_summary = None if args.skip_tests else summarize_test_collection()
+
+    baseline = Round1Baseline(
+        generated_at_utc=datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        service_taxonomy=services,
+        service_total=total_services,
+        endpoint_summary=endpoints,
+        test_collection=test_summary,
+    )
+
+    if args.markdown_out is not None:
+        args.markdown_out.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown_out.write_text(render_markdown(baseline), encoding="utf-8")
+
+    print(json.dumps(asdict(baseline), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Grant-facing numeric claims (service count, endpoint counts, test totals) were drifting and relied on stale hard-coded values in docs. 
- We need a reproducible, date-stamped baseline that can be run in CI and before grant submissions to produce authoritative artifacts. 
- The baseline must capture three ground-truth surfaces: service taxonomy, API route inventory, and pytest collection totals. 

### Description
- Add `tools/analysis/round1_grant_baseline.py`, a script that enumerates the service taxonomy from `ApiServiceConfiguration`, inspects the FastAPI app (`create_app()`) for method+path routes and method counts, and runs `pytest --collect-only` to report collected tests and collection errors, with optional markdown output. 
- Rewrite `docs/DOCUMENTATION_VALIDATION_PLAN.md` to replace stale static counts with a script-driven measurement methodology, Nightly/PR CI guidance, and a prioritized hygiene checklist for pre-grant work. 
- Add a snapshot artifact `docs/grant/ROUND1_BASELINE_2026-04-22.md` generated by the script showing the run-time baseline (22 core services, 257 method+path routes, 10,662 tests collected with 37 collection errors). 
- The baseline script auto-detects missing pytest plugins and avoids assuming a fixed environment; it also inserts the repo root on `sys.path` to allow local invocation. 

### Testing
- Verified script compiles: `python -m py_compile tools/analysis/round1_grant_baseline.py` (OK). 
- Ran the baseline script in this environment to produce JSON and markdown artifacts: `python tools/analysis/round1_grant_baseline.py --markdown-out docs/grant/ROUND1_BASELINE_2026-04-22.md` (artifact generated). 
- Ran a fast no-tests run: `python tools/analysis/round1_grant_baseline.py --skip-tests > /tmp/round1_skip_tests.json` (OK). 
- Performed full pytest collection via the script (internally runs `pytest --collect-only -q tests -o addopts=`) which reported `10662 tests collected, 37 errors` and detected missing plugins `pytest_asyncio` and `hypothesis` in this environment, indicating plugin/runtime gaps rather than script failure. 
- Runtime observations from the baseline: service taxonomy total = `22` (graph 7, infra 4, lifecycle 4, governance 4, runtime 2, tool 1), API method+path routes = `257` (GET 139, POST 83, PUT 17, PATCH 2, DELETE 16), auth-related routes = `15`, oauth routes = `6`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9579fd6e4832ba1ccc6381c550a87)