### PR TITLE
Add TPM2 TSS deps and enhance memory benchmark/introspection with API message load and concurrency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     gcc \
     libtss2-esys-3.0.2-0t64 \
+    libtss2-tctildr0t64 \
     libtss2-tcti-device0t64 \
     python3-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -501,6 +501,19 @@ install_dependencies() {
         # Version already verified by get_best_python()
     fi
 
+    # TPM2 TSS runtime libraries for CIRISVerify (Linux/apt only)
+    # Use best-effort install to support both Debian-style and Ubuntu t64 package names.
+    if [ "$pkg_mgr" = "apt" ]; then
+        log_info "Ensuring CIRISVerify runtime libraries are present (TPM2 TSS)"
+        if ! sudo apt-get install -y libtss2-esys0 libtss2-tctildr0 libtss2-tcti-device0 >/dev/null 2>&1; then
+            sudo apt-get install -y \
+                libtss2-esys-3.0.2-0t64 \
+                libtss2-tctildr0t64 \
+                libtss2-tcti-device0t64 \
+                >/dev/null 2>&1 || log_warn "Could not auto-install TPM2 TSS libs; install manually if setup fails"
+        fi
+    fi
+
     # Check Node.js
     if ! command_exists node; then
         log_warn "Node.js not found, installing..."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -506,11 +506,17 @@ install_dependencies() {
     if [ "$pkg_mgr" = "apt" ]; then
         log_info "Ensuring CIRISVerify runtime libraries are present (TPM2 TSS)"
         if ! sudo apt-get install -y libtss2-esys0 libtss2-tctildr0 libtss2-tcti-device0 >/dev/null 2>&1; then
-            sudo apt-get install -y \
+            if ! sudo apt-get install -y \
+                libtss2-esys-3.0.2-0 \
+                libtss2-tctildr0 \
+                libtss2-tcti-device0 \
+                >/dev/null 2>&1; then
+                sudo apt-get install -y \
                 libtss2-esys-3.0.2-0t64 \
                 libtss2-tctildr0t64 \
                 libtss2-tcti-device0t64 \
                 >/dev/null 2>&1 || log_warn "Could not auto-install TPM2 TSS libs; install manually if setup fails"
+            fi
         fi
     fi
 

--- a/tools/introspect_memory.py
+++ b/tools/introspect_memory.py
@@ -2,17 +2,12 @@
 """Introspect Python memory usage of running CIRIS agent.
 
 Usage:
-    python3 tools/introspect_memory.py [--adapters ADAPTERS] [--duration SECONDS]
-
-Options:
-    --adapters   Adapter to use (default: cli)
-    --duration   Seconds to run before shutdown (default: 30)
-
-Example:
-    python3 tools/introspect_memory.py
-    python3 tools/introspect_memory.py --adapters api --duration 45
+    python3 tools/introspect_memory.py --adapters api --duration 30
+    python3 tools/introspect_memory.py --adapters api --messages 1000 --concurrency 8
 """
+
 import argparse
+import asyncio
 import os
 import subprocess
 import sys
@@ -65,12 +60,147 @@ def get_children_memory(pid: int) -> int:
         return 0
 
 
-def main(adapters: str = "cli", duration: int = 30) -> int:
+async def _wait_for_server(base_url: str, timeout_seconds: int = 90) -> bool:
+    import httpx
+
+    deadline = time.time() + timeout_seconds
+    async with httpx.AsyncClient(timeout=3.0) as client:
+        while time.time() < deadline:
+            try:
+                response = await client.get(f"{base_url}/v1/system/health")
+                if response.status_code == 200:
+                    return True
+            except Exception:
+                pass
+            await asyncio.sleep(1.0)
+    return False
+
+
+async def _get_auth_token(base_url: str, retries: int = 30) -> str:
+    import httpx
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        for _ in range(retries):
+            try:
+                for username in ["admin", "owner"]:
+                    response = await client.post(
+                        f"{base_url}/v1/auth/login",
+                        json={"username": username, "password": "qa_test_password_12345"},
+                    )
+                    if response.status_code == 200:
+                        return response.json().get("access_token", "")
+            except Exception:
+                pass
+            await asyncio.sleep(0.5)
+    return ""
+
+
+async def _complete_setup(base_url: str, port: int) -> bool:
+    """Complete first-run setup for local benchmark environments."""
+    import httpx
+
+    payload = {
+        "llm_provider": "openai",
+        "llm_api_key": "test-key-for-introspection",
+        "llm_model": "gpt-4",
+        "template_id": "default",
+        "enabled_adapters": ["api"],
+        "adapter_config": {},
+        "admin_username": "owner",
+        "admin_password": "qa_test_password_12345",
+        "agent_port": port,
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(f"{base_url}/v1/setup/complete", json=payload)
+        return response.status_code == 200
+    except Exception:
+        return False
+
+
+async def _wait_for_runtime_ready(base_url: str, token: str, timeout_seconds: int = 120) -> bool:
+    import httpx
+
+    deadline = time.time() + timeout_seconds
+    headers = {"Authorization": f"Bearer {token}"}
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        while time.time() < deadline:
+            try:
+                response = await client.get(f"{base_url}/v1/agent/status", headers=headers)
+                if response.status_code == 200:
+                    return True
+            except Exception:
+                pass
+            await asyncio.sleep(1.0)
+    return False
+
+
+async def _run_message_load(base_url: str, token: str, messages: int, concurrency: int) -> tuple[int, int, float]:
+    import httpx
+
+    queue: asyncio.Queue[int] = asyncio.Queue()
+    for i in range(messages):
+        queue.put_nowait(i)
+
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    success = 0
+    failed = 0
+    lock = asyncio.Lock()
+    start = time.time()
+    client_timeout = httpx.Timeout(connect=5.0, read=10.0, write=10.0, pool=10.0)
+
+    async def worker(worker_id: int) -> None:
+        nonlocal success, failed
+        async with httpx.AsyncClient(timeout=client_timeout) as client:
+            while True:
+                try:
+                    idx = queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    return
+
+                payload = {
+                    "message": f"Introspection benchmark message {idx + 1}/{messages}",
+                    "context": {"channel_id": f"introspection_w{worker_id}_m{idx}"},
+                }
+                try:
+                    accepted = False
+                    for attempt in range(3):
+                        response = await client.post(f"{base_url}/v1/agent/message", headers=headers, json=payload)
+                        if response.status_code == 200:
+                            response_json = response.json()
+                            accepted = bool(
+                                response_json.get("task_id")
+                                or response_json.get("data", {}).get("task_id")
+                            )
+                            if accepted:
+                                break
+                        await asyncio.sleep(0.15 * (attempt + 1))
+
+                    async with lock:
+                        if accepted:
+                            success += 1
+                        else:
+                            failed += 1
+                except Exception:
+                    async with lock:
+                        failed += 1
+
+                queue.task_done()
+
+    workers = [asyncio.create_task(worker(i)) for i in range(max(1, concurrency))]
+    await asyncio.gather(*workers)
+    return success, failed, time.time() - start
+
+
+def main(adapters: str = "cli", duration: int = 30, messages: int = 0, concurrency: int = 8, port: int = 8080) -> int:
     print("=" * 70)
     print("CIRIS 2.0 MEMORY INTROSPECTION")
     print("=" * 70)
     print(f"Adapters: {adapters}")
     print(f"Duration: {duration}s")
+    if messages > 0:
+        print(f"Message load: {messages} (concurrency={concurrency})")
 
     project_root = Path(__file__).parent.parent
     main_py = project_root / "main.py"
@@ -79,19 +209,14 @@ def main(adapters: str = "cli", duration: int = 30) -> int:
         print(f"ERROR: main.py not found at {main_py}")
         return 1
 
-    # Match the working command: python3 main.py --adapter cli --mock-llm --timeout 30
-    cmd = [
-        sys.executable,
-        str(main_py),
-        "--adapter",
-        adapters,
-        "--mock-llm",
-        "--timeout",
-        str(duration),
-    ]
+    cmd = [sys.executable, str(main_py), "--adapter", adapters, "--mock-llm"]
+    if adapters == "api":
+        cmd.extend(["--port", str(port)])
+    else:
+        cmd.extend(["--timeout", str(duration)])
 
     print(f"\nCommand: {' '.join(cmd)}")
-    print(f"\n[1/3] Starting CIRIS agent...")
+    print("\n[1/3] Starting CIRIS agent...")
 
     env = os.environ.copy()
     env["PYTHONUNBUFFERED"] = "1"
@@ -108,35 +233,74 @@ def main(adapters: str = "cli", duration: int = 30) -> int:
     pid = process.pid
     print(f"PID: {pid}")
 
-    print(f"\n[2/3] Monitoring memory for ~{duration}s...")
     samples = []
     start_time = time.time()
 
     try:
-        while process.poll() is None:
-            mem = get_children_memory(pid)
-            if mem > 0:
-                samples.append(mem)
-                elapsed = time.time() - start_time
-                print(f"  {elapsed:5.1f}s: {format_size(mem)}", end="\r")
-            time.sleep(0.1)  # Sample every 100ms for better resolution
+        if adapters == "api" and messages > 0:
+            base_url = f"http://localhost:{port}"
+            if not asyncio.run(_wait_for_server(base_url)):
+                print("ERROR: API server did not become healthy")
+                process.terminate()
+                return 1
 
-        print()  # newline after progress
+            token = asyncio.run(_get_auth_token(base_url))
+            if not token:
+                print("No auth token yet, attempting first-run setup...")
+                setup_ok = asyncio.run(_complete_setup(base_url, port))
+                if setup_ok:
+                    token = asyncio.run(_get_auth_token(base_url))
+            if not token:
+                print("ERROR: Could not authenticate with QA credentials")
+                process.terminate()
+                return 1
+            runtime_ready = asyncio.run(_wait_for_runtime_ready(base_url, token))
+            if not runtime_ready:
+                print("ERROR: Agent runtime did not become ready for authenticated traffic")
+                process.terminate()
+                return 1
 
-        # Process exited
-        exit_code = process.returncode
-        print(f"\n[3/3] Process exited with code: {exit_code}")
+            print("\n[2/3] Running message load...")
+            success, failed, elapsed = asyncio.run(_run_message_load(base_url, token, messages, concurrency))
+            print(f"  Message load complete: {success}/{messages} in {elapsed:.1f}s (failed={failed})")
 
-        # Print summary
+            immediate_mem = get_children_memory(pid)
+            if immediate_mem > 0:
+                samples.append(immediate_mem)
+
+            settle_deadline = time.time() + min(10, duration)
+            while time.time() < settle_deadline and process.poll() is None:
+                mem = get_children_memory(pid)
+                if mem > 0:
+                    samples.append(mem)
+                time.sleep(0.2)
+        else:
+            print(f"\n[2/3] Monitoring memory for ~{duration}s...")
+            end_time = start_time + duration
+            while time.time() < end_time and process.poll() is None:
+                mem = get_children_memory(pid)
+                if mem > 0:
+                    samples.append(mem)
+                    elapsed = time.time() - start_time
+                    print(f"  {elapsed:5.1f}s: {format_size(mem)}", end="\r")
+                time.sleep(0.1)
+            print()
+
+        print("\n[3/3] Shutting down process...")
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+
         print("\n" + "=" * 70)
         print("MEMORY SUMMARY")
         print("=" * 70)
         if samples:
-            initial = samples[0] if samples else 0
-            peak = max(samples) if samples else 0
-            final = samples[-1] if samples else 0
-            avg = sum(samples) / len(samples) if samples else 0
-
+            initial = samples[0]
+            peak = max(samples)
+            final = samples[-1]
+            avg = sum(samples) / len(samples)
             print(f"  Initial:    {format_size(initial)}")
             print(f"  Peak:       {format_size(peak)}")
             print(f"  Final:      {format_size(final)}")
@@ -144,10 +308,10 @@ def main(adapters: str = "cli", duration: int = 30) -> int:
             print(f"  Samples:    {len(samples)}")
         else:
             print("  No memory samples collected")
-        print()
-        print(f"  Adapters:   {adapters}")
-        print(f"  Mock LLM:   True")
-        print(f"  Duration:   {duration}s")
+        print(f"\n  Adapters:   {adapters}")
+        print("  Mock LLM:   True")
+        if messages > 0:
+            print(f"  Messages:   {messages}")
         print("\n" + "=" * 70)
         print("INTROSPECTION COMPLETE")
         print("=" * 70)
@@ -173,9 +337,35 @@ def parse_args() -> argparse.Namespace:
         default=30,
         help="Seconds to run before shutdown (default: 30)",
     )
+    parser.add_argument(
+        "--messages",
+        type=int,
+        default=0,
+        help="Optional message-load count (API adapter only)",
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=8,
+        help="Message-load concurrency (default: 8)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8080,
+        help="API port when adapters=api (default: 8080)",
+    )
     return parser.parse_args()
 
 
 if __name__ == "__main__":
     args = parse_args()
-    sys.exit(main(adapters=args.adapters, duration=args.duration))
+    sys.exit(
+        main(
+            adapters=args.adapters,
+            duration=args.duration,
+            messages=max(0, args.messages),
+            concurrency=max(1, args.concurrency),
+            port=args.port,
+        )
+    )

--- a/tools/introspect_memory.py
+++ b/tools/introspect_memory.py
@@ -233,6 +233,16 @@ def main(adapters: str = "cli", duration: int = 30, messages: int = 0, concurren
     pid = process.pid
     print(f"PID: {pid}")
 
+    def shutdown_process() -> None:
+        if process.poll() is not None:
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+
     samples = []
     start_time = time.time()
 
@@ -241,7 +251,7 @@ def main(adapters: str = "cli", duration: int = 30, messages: int = 0, concurren
             base_url = f"http://localhost:{port}"
             if not asyncio.run(_wait_for_server(base_url)):
                 print("ERROR: API server did not become healthy")
-                process.terminate()
+                shutdown_process()
                 return 1
 
             token = asyncio.run(_get_auth_token(base_url))
@@ -252,12 +262,12 @@ def main(adapters: str = "cli", duration: int = 30, messages: int = 0, concurren
                     token = asyncio.run(_get_auth_token(base_url))
             if not token:
                 print("ERROR: Could not authenticate with QA credentials")
-                process.terminate()
+                shutdown_process()
                 return 1
             runtime_ready = asyncio.run(_wait_for_runtime_ready(base_url, token))
             if not runtime_ready:
                 print("ERROR: Agent runtime did not become ready for authenticated traffic")
-                process.terminate()
+                shutdown_process()
                 return 1
 
             print("\n[2/3] Running message load...")
@@ -287,11 +297,7 @@ def main(adapters: str = "cli", duration: int = 30, messages: int = 0, concurren
             print()
 
         print("\n[3/3] Shutting down process...")
-        process.terminate()
-        try:
-            process.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            process.kill()
+        shutdown_process()
 
         print("\n" + "=" * 70)
         print("MEMORY SUMMARY")

--- a/tools/memory_benchmark.py
+++ b/tools/memory_benchmark.py
@@ -1,19 +1,12 @@
 #!/usr/bin/env python3
 """Memory benchmark for CIRIS agent under message load.
 
-Measures RSS memory after processing N messages via the API.
-
-Usage:
-    python3 tools/memory_benchmark.py --messages 100 --adapter api
-    python3 tools/memory_benchmark.py --messages 1000 --adapter api
-
-Prerequisites:
-    - API server must be running or will be started automatically
-    - Mock LLM mode recommended for reproducible benchmarks
+Measures RSS memory growth while submitting N async messages to the API.
+Designed for fast, reliable mock LLM profiling up to 1k+ messages.
 """
+
 import argparse
 import asyncio
-import json
 import os
 import subprocess
 import sys
@@ -67,49 +60,151 @@ def get_children_memory(pid: int) -> int:
         return 0
 
 
-async def send_messages(base_url: str, messages: int, token: str) -> tuple[int, float]:
-    """Send N messages to the API and return (success_count, elapsed_time)."""
+async def wait_for_server(base_url: str, timeout_seconds: int = 90) -> bool:
+    """Wait for API server to become healthy."""
     import httpx
 
-    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
-    success = 0
-    start = time.time()
-
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        for i in range(messages):
+    deadline = time.time() + timeout_seconds
+    async with httpx.AsyncClient(timeout=3.0) as client:
+        while time.time() < deadline:
             try:
-                response = await client.post(
-                    f"{base_url}/v1/agent/interact",
-                    json={"message": f"Test message {i + 1} of {messages}"},
-                    headers=headers,
-                )
+                response = await client.get(f"{base_url}/v1/system/health")
                 if response.status_code == 200:
-                    success += 1
-                if (i + 1) % 100 == 0:
-                    print(f"  Sent {i + 1}/{messages} messages...")
-            except Exception as e:
-                print(f"  Error sending message {i + 1}: {e}")
-
-    elapsed = time.time() - start
-    return success, elapsed
+                    return True
+            except Exception:
+                pass
+            await asyncio.sleep(1.0)
+    return False
 
 
-async def get_auth_token(base_url: str) -> str:
-    """Get auth token from API."""
+async def wait_for_runtime_ready(base_url: str, token: str, timeout_seconds: int = 120) -> bool:
+    """Wait for agent runtime endpoints to accept authenticated traffic."""
+    import httpx
+
+    deadline = time.time() + timeout_seconds
+    headers = {"Authorization": f"Bearer {token}"}
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        while time.time() < deadline:
+            try:
+                response = await client.get(f"{base_url}/v1/agent/status", headers=headers)
+                if response.status_code == 200:
+                    return True
+            except Exception:
+                pass
+            await asyncio.sleep(1.0)
+    return False
+
+
+async def get_auth_token(base_url: str, retries: int = 30) -> str:
+    """Get auth token from API with retries."""
     import httpx
 
     async with httpx.AsyncClient(timeout=10.0) as client:
-        # Try to login with default QA credentials
-        response = await client.post(
-            f"{base_url}/v1/auth/login",
-            json={"username": "admin", "password": "qa_test_password_12345"},
-        )
-        if response.status_code == 200:
-            return response.json().get("access_token", "")
+        for _ in range(retries):
+            try:
+                for username in ["admin", "owner"]:
+                    response = await client.post(
+                        f"{base_url}/v1/auth/login",
+                        json={"username": username, "password": "qa_test_password_12345"},
+                    )
+                    if response.status_code == 200:
+                        return response.json().get("access_token", "")
+            except Exception:
+                pass
+            await asyncio.sleep(0.5)
     return ""
 
 
-def main(messages: int = 100, adapter: str = "api", port: int = 8080) -> int:
+async def complete_setup(base_url: str, port: int) -> bool:
+    """Complete first-run setup for benchmark environments."""
+    import httpx
+
+    payload = {
+        "llm_provider": "openai",
+        "llm_api_key": "test-key-for-benchmark",
+        "llm_model": "gpt-4",
+        "template_id": "default",
+        "enabled_adapters": ["api"],
+        "adapter_config": {},
+        "admin_username": "owner",
+        "admin_password": "qa_test_password_12345",
+        "agent_port": port,
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(f"{base_url}/v1/setup/complete", json=payload)
+        return response.status_code == 200
+    except Exception:
+        return False
+
+
+async def send_messages(base_url: str, messages: int, token: str, concurrency: int) -> tuple[int, int, float]:
+    """Submit messages concurrently using unique channel_id values."""
+    import httpx
+
+    queue: asyncio.Queue[int] = asyncio.Queue()
+    for i in range(messages):
+        queue.put_nowait(i)
+
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    success = 0
+    failed = 0
+    counter_lock = asyncio.Lock()
+    start = time.time()
+
+    limits = httpx.Limits(max_keepalive_connections=max(20, concurrency * 2), max_connections=max(40, concurrency * 4))
+    client_timeout = httpx.Timeout(connect=5.0, read=10.0, write=10.0, pool=10.0)
+
+    async def worker(worker_id: int) -> None:
+        nonlocal success, failed
+        async with httpx.AsyncClient(timeout=client_timeout, limits=limits) as client:
+            while True:
+                try:
+                    idx = queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    return
+
+                payload = {
+                    "message": f"Memory benchmark message {idx + 1} of {messages}",
+                    "context": {"channel_id": f"memory_benchmark_w{worker_id}_m{idx}"},
+                }
+
+                try:
+                    accepted = False
+                    for attempt in range(3):
+                        response = await client.post(f"{base_url}/v1/agent/message", json=payload, headers=headers)
+                        if response.status_code == 200:
+                            response_json = response.json()
+                            accepted = bool(
+                                response_json.get("task_id")
+                                or response_json.get("data", {}).get("task_id")
+                            )
+                            if accepted:
+                                break
+                        await asyncio.sleep(0.15 * (attempt + 1))
+
+                    async with counter_lock:
+                        if accepted:
+                            success += 1
+                        else:
+                            failed += 1
+                except Exception:
+                    async with counter_lock:
+                        failed += 1
+
+                if (idx + 1) % 100 == 0:
+                    print(f"  Submitted {idx + 1}/{messages} messages...")
+
+                queue.task_done()
+
+    workers = [asyncio.create_task(worker(i)) for i in range(max(1, concurrency))]
+    await asyncio.gather(*workers)
+    elapsed = time.time() - start
+    return success, failed, elapsed
+
+
+def main(messages: int = 100, adapter: str = "api", port: int = 8080, concurrency: int = 8) -> int:
     """Run memory benchmark with N messages."""
     print("=" * 70)
     print(f"CIRIS MEMORY BENCHMARK - {messages} MESSAGES")
@@ -119,8 +214,7 @@ def main(messages: int = 100, adapter: str = "api", port: int = 8080) -> int:
     main_py = project_root / "main.py"
     base_url = f"http://localhost:{port}"
 
-    # Start server
-    print(f"\n[1/4] Starting CIRIS API server...")
+    print("\n[1/4] Starting CIRIS API server...")
     env = os.environ.copy()
     env["PYTHONUNBUFFERED"] = "1"
 
@@ -145,46 +239,41 @@ def main(messages: int = 100, adapter: str = "api", port: int = 8080) -> int:
     pid = process.pid
     print(f"  PID: {pid}")
 
-    # Wait for server to be ready
-    print(f"\n[2/4] Waiting for server...")
-    import httpx
-
-    for _ in range(30):
-        try:
-            r = httpx.get(f"{base_url}/health", timeout=2.0)
-            if r.status_code == 200:
-                print("  Server ready!")
-                break
-        except Exception:
-            pass
-        time.sleep(1)
-    else:
+    print("\n[2/4] Waiting for server...")
+    if not asyncio.run(wait_for_server(base_url)):
         print("  ERROR: Server failed to start")
         process.terminate()
         return 1
+    print("  Server ready!")
 
-    # Measure initial memory
     initial_mem = get_children_memory(pid)
     print(f"\n  Initial memory: {format_size(initial_mem)}")
 
-    # Get auth token
-    print(f"\n[3/4] Authenticating...")
-    try:
-        token = asyncio.run(get_auth_token(base_url))
-        if not token:
-            print("  WARNING: Could not get auth token, using unauthenticated requests")
-    except Exception as e:
-        print(f"  WARNING: Auth failed: {e}")
-        token = ""
+    print("\n[3/4] Authenticating...")
+    token = asyncio.run(get_auth_token(base_url))
+    if not token:
+        print("  No auth token yet, attempting first-run setup...")
+        setup_ok = asyncio.run(complete_setup(base_url, port))
+        if setup_ok:
+            token = asyncio.run(get_auth_token(base_url))
+    if not token:
+        print("  ERROR: Could not get auth token with QA credentials")
+        process.terminate()
+        return 1
+    runtime_ready = asyncio.run(wait_for_runtime_ready(base_url, token))
+    if not runtime_ready:
+        print("  ERROR: Agent runtime did not become ready for authenticated traffic")
+        process.terminate()
+        return 1
 
-    # Send messages
-    print(f"\n[4/4] Sending {messages} messages...")
+    print(f"\n[4/4] Sending {messages} messages (concurrency={concurrency})...")
     samples = []
+    success = 0
+    failed = 0
     try:
-        success, elapsed = asyncio.run(send_messages(base_url, messages, token))
-        print(f"  Sent {success}/{messages} messages in {elapsed:.1f}s")
+        success, failed, elapsed = asyncio.run(send_messages(base_url, messages, token, concurrency))
+        print(f"  Submitted {success}/{messages} messages in {elapsed:.1f}s")
 
-        # Sample memory a few times after load
         for _ in range(5):
             mem = get_children_memory(pid)
             if mem > 0:
@@ -194,7 +283,6 @@ def main(messages: int = 100, adapter: str = "api", port: int = 8080) -> int:
     except Exception as e:
         print(f"  ERROR: {e}")
     finally:
-        # Shutdown
         print("\nShutting down server...")
         process.terminate()
         try:
@@ -202,7 +290,6 @@ def main(messages: int = 100, adapter: str = "api", port: int = 8080) -> int:
         except subprocess.TimeoutExpired:
             process.kill()
 
-    # Report
     print("\n" + "=" * 70)
     print("MEMORY BENCHMARK RESULTS")
     print("=" * 70)
@@ -219,11 +306,13 @@ def main(messages: int = 100, adapter: str = "api", port: int = 8080) -> int:
         print(f"  Per Message:    {format_size(per_msg)}")
 
     print(f"\n  Adapter:        {adapter}")
-    print(f"  Mock LLM:       True")
-    print(f"  Success Rate:   {success}/{messages} ({100*success/messages:.1f}%)")
+    print("  Mock LLM:       True")
+    print(f"  Concurrency:    {concurrency}")
+    print(f"  Success Rate:   {success}/{messages} ({100 * success / messages:.1f}%)")
+    print(f"  Failures:       {failed}")
     print("=" * 70)
 
-    return 0
+    return 0 if success == messages else 1
 
 
 def parse_args() -> argparse.Namespace:
@@ -245,9 +334,22 @@ def parse_args() -> argparse.Namespace:
         default=8080,
         help="Port for API server (default: 8080)",
     )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=8,
+        help="Number of concurrent submit workers (default: 8)",
+    )
     return parser.parse_args()
 
 
 if __name__ == "__main__":
     args = parse_args()
-    sys.exit(main(messages=args.messages, adapter=args.adapter, port=args.port))
+    sys.exit(
+        main(
+            messages=args.messages,
+            adapter=args.adapter,
+            port=args.port,
+            concurrency=max(1, args.concurrency),
+        )
+    )

--- a/tools/memory_benchmark.py
+++ b/tools/memory_benchmark.py
@@ -239,10 +239,20 @@ def main(messages: int = 100, adapter: str = "api", port: int = 8080, concurrenc
     pid = process.pid
     print(f"  PID: {pid}")
 
+    def shutdown_process() -> None:
+        if process.poll() is not None:
+            return
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=5)
+
     print("\n[2/4] Waiting for server...")
     if not asyncio.run(wait_for_server(base_url)):
         print("  ERROR: Server failed to start")
-        process.terminate()
+        shutdown_process()
         return 1
     print("  Server ready!")
 
@@ -258,12 +268,12 @@ def main(messages: int = 100, adapter: str = "api", port: int = 8080, concurrenc
             token = asyncio.run(get_auth_token(base_url))
     if not token:
         print("  ERROR: Could not get auth token with QA credentials")
-        process.terminate()
+        shutdown_process()
         return 1
     runtime_ready = asyncio.run(wait_for_runtime_ready(base_url, token))
     if not runtime_ready:
         print("  ERROR: Agent runtime did not become ready for authenticated traffic")
-        process.terminate()
+        shutdown_process()
         return 1
 
     print(f"\n[4/4] Sending {messages} messages (concurrency={concurrency})...")
@@ -284,11 +294,7 @@ def main(messages: int = 100, adapter: str = "api", port: int = 8080, concurrenc
         print(f"  ERROR: {e}")
     finally:
         print("\nShutting down server...")
-        process.terminate()
-        try:
-            process.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            process.kill()
+        shutdown_process()
 
     print("\n" + "=" * 70)
     print("MEMORY BENCHMARK RESULTS")

--- a/tools/qa_runner/modules/memory_benchmark_tests.py
+++ b/tools/qa_runner/modules/memory_benchmark_tests.py
@@ -141,6 +141,7 @@ class MemoryBenchmarkTests(BaseTestModule):
         self.concurrent_channels = max(1, concurrent_channels)
         self.snapshots: List[MemorySnapshot] = []
         self.channel_stats: Dict[str, ChannelStats] = {}
+        self._global_messages_sent = 0
 
     def _take_snapshot(self, messages_sent: int) -> Optional[MemorySnapshot]:
         """Take a memory snapshot."""
@@ -159,6 +160,11 @@ class MemoryBenchmarkTests(BaseTestModule):
         )
         self.snapshots.append(snapshot)
         return snapshot
+
+    def _increment_global_message_count(self) -> int:
+        """Increment and return global sent counter across all channels."""
+        self._global_messages_sent += 1
+        return self._global_messages_sent
 
     async def run(self) -> List[Dict]:
         """Run memory benchmark tests."""
@@ -344,13 +350,16 @@ class MemoryBenchmarkTests(BaseTestModule):
 
                 # Progress update at intervals
                 if (i + 1) % snapshot_interval == 0:
-                    snapshot = self._take_snapshot(stats.messages_sent)
+                    global_count = self._increment_global_message_count()
+                    snapshot = self._take_snapshot(global_count)
                     if snapshot:
                         growth = snapshot.rss_bytes - self.snapshots[0].rss_bytes
                         self.console.print(
                             f"    [{channel_id}] {i + 1}/{message_count}: "
                             f"{format_size(snapshot.rss_bytes)} (+{format_size(growth)})"
                         )
+                else:
+                    self._increment_global_message_count()
 
             except Exception as e:
                 stats.messages_failed += 1


### PR DESCRIPTION
### Motivation

- Ensure TPM2 TSS runtime libraries are available in Debian/Ubuntu and Docker images for CIRISVerify attestation.
- Improve memory introspection and benchmarking tools to support realistic API loads, authenticated first-run setup, and concurrent message submission.

### Description

- Dockerfile: include `libtss2-tctildr0t64` so the container has TPM2 TSS runtime pieces required by CIRISVerify. 
- scripts/install.sh: attempt to install TPM2 TSS runtime libraries on `apt` systems using both generic and `-t64` package names with best-effort fallback and warning on failure.
- tools/introspect_memory.py: add async HTTP helpers using `httpx` to wait for server health, perform first-run setup, obtain auth token, run concurrent message load (`--messages`, `--concurrency`, `--port` flags), and adapt memory sampling for both `cli` and `api` adapters.
- tools/memory_benchmark.py: rework to wait for server health, complete setup if needed, obtain auth token, submit messages concurrently with configurable `--concurrency`, sample memory after load, and return non-zero when not all messages succeed.
- tools/qa_runner/modules/memory_benchmark_tests.py: add a global message counter across channels and update snapshotting logic so snapshots reflect total messages sent across concurrent channels.

### Testing

- Ran `pytest -q` locally and the test suite completed successfully. 
- Executed automated smoke runs of the benchmark/introspection tools: `tools/memory_benchmark.py --messages 10 --concurrency 2` and `tools/introspect_memory.py --adapters api --messages 10 --concurrency 2`, both of which completed and produced expected memory sampling and success/failure reporting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9621c6f4c832ba2757a23336371e8)