### PR TITLE
Release 2.7.5: chore bump + CI fail-loud on PyPI publish errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -421,12 +421,17 @@ jobs:
 
       - name: Publish to PyPI
         if: github.ref == 'refs/heads/main' && github.repository == 'CIRISAI/CIRISAgent'
-        continue-on-error: true
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          # Use verbose to diagnose any failures, continue-on-error allows CD to proceed
+          # NO continue-on-error: a 2.7.4 incident hid the PyPI project-size
+          # quota rejection (`400 Project size too large`) behind a green
+          # build for two releases — only the 9.2 MB headless wheel made
+          # it to PyPI, the three platform-specific wheels (~65-70 MB each)
+          # were silently dropped, and Linux/macOS/Windows desktop installs
+          # got the headless wheel with no JAR. If twine fails now, this
+          # step fails — visible in CI, not buried.
           python -m twine upload dist/*.whl --skip-existing --verbose
 
       - name: Build and publish alias packages

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 **A type-safe, auditable AI agent framework with built-in ethical reasoning**
 
-**BETA RELEASE 2.7.4-stable** | [Release Notes](CHANGELOG.md) | [Documentation Hub](docs/README.md)
+**BETA RELEASE 2.7.5-stable** | [Release Notes](CHANGELOG.md) | [Documentation Hub](docs/README.md)
 
 CIRIS lets you run AI agents that explain their decisions, defer to humans when uncertain, and maintain complete audit trails. Currently powering Discord community moderation, designed to scale to healthcare and education.
 

--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -3,11 +3,11 @@
 from pathlib import Path
 
 # Version information
-CIRIS_VERSION = "2.7.4-stable"
+CIRIS_VERSION = "2.7.5-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
 CIRIS_VERSION_MINOR = 7
-CIRIS_VERSION_PATCH = 4
+CIRIS_VERSION_PATCH = 5
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/client/androidApp/build.gradle
+++ b/client/androidApp/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 35
-        versionCode 106
-        versionName "2.7.4"
+        versionCode 107
+        versionName "2.7.5"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/client/androidApp/src/main/python/version.py
+++ b/client/androidApp/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.7.4"
+__version__ = "android-2.7.5"
 
 
 def get_version() -> str:

--- a/client/iosApp/iosApp/Info.plist
+++ b/client/iosApp/iosApp/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.7.4</string>
+	<string>2.7.5</string>
 	<key>CFBundleVersion</key>
-	<string>260</string>
+	<string>261</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
## Summary

Patch bump on top of release/2.7.4 with one CI hardening change: removes `continue-on-error: true` from the Publish-to-PyPI step in `.github/workflows/build.yml` so the next storage-quota failure fails loudly instead of silently dropping platform wheels.

## What broke in 2.7.3 / 2.7.4

The "Publish to PyPI" step had `continue-on-error: true`, which masked PyPI's `400 Project size too large. Limit for project 'ciris-agent' total` rejection. Twine's upload order is alphabetical:

```
ciris_agent-2.7.4-py3-none-any.whl                 ← 9.2 MB ✅ uploaded first
ciris_agent-2.7.4-py3-none-macosx_11_0_arm64.whl   ← 70 MB  ❌ 400 quota error
ciris_agent-2.7.4-py3-none-manylinux2014_x86_64.whl ← 65 MB  ❌ stranded
ciris_agent-2.7.4-py3-none-win_amd64.whl           ← 63 MB  ❌ stranded
```

The headless 9.2 MB wheel made it; the three JAR-bundled platform wheels were silently dropped. Result: every `pip install ciris-agent` on Linux/macOS/Windows got the JAR-less wheel and `ciris-agent` desktop launch failed with **"ERROR: Desktop app JAR not found"**.

Same thing happened on 2.7.3 — only `py3-none-any` exists on PyPI for both versions.

## What's in this release

- **Version bump 2.7.4 → 2.7.5-stable** via `tools/dev/bump_version.py patch` (constants.py, README.md, iOS CFBundleVersion 260→261, Android versionCode 106→107, KMP version.py).
- **Drop `continue-on-error: true`** from `.github/workflows/build.yml:424`. Twine failures now fail the job. Comment block above the step explains the 2.7.4 incident so future maintainers don't re-add the flag.
- **Carries forward all 2.7.4 fixes**: DSDMA prompt cleanup + DSDMAResult-direct response model + 28-locale propagation, per-endpoint reasoning-off dispatcher (Groq 422 fix, gemma-4 dual-key), CIRISVerify loader wheel-bundle search (desktop init no longer fails on fresh `pip install`), BadRequestError reaches the retry-with-remediation loop, memory_benchmark client read-timeout 10s→30s.

PyPI project quota was cleared via the web UI prior to this release.

## Test plan
- [x] `pytest -n 16 tests/ciris_engine/logic/services/runtime/llm_service/ tests/ciris_engine/logic/dma/` — 298 pass
- [x] Live A/B: per-endpoint reasoning dispatcher confirmed 10× speedup on Together gemma-4 (`{"thinking":{"type":"disabled"}}` alone is silently ignored; dual-key drops latency from ~20s → ~3s)
- [x] Live `tools.qa_runner model_eval` × 3 providers × 2 question suites — 6/6 cells passing on 2.7.4 baseline
- [x] CIRISVerify loader hot-patched + verified: imports `ciris_verify` package, finds `libciris_verify_ffi.so` at the wheel-shipped location
- [ ] **Verify on first PyPI release**: confirm all 4 wheel artifacts upload (Linux/macOS-arm64/Windows + headless), `pip install ciris-agent` on Linux pulls `manylinux2014_x86_64.whl`, `ciris-agent` desktop launch succeeds with the bundled JAR

🤖 Generated with [Claude Code](https://claude.com/claude-code)