### PR TITLE
fix(ci): bump ciris-verify pin 1.8.1 → 1.8.6 (ships ciris-build-sign CLI)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -668,12 +668,19 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install ciris-build-sign (CIRISVerify v1.8.1+)
-        # Provides the `ciris-build-sign` binary on PATH. Required for the
-        # --tree manifest shape that replaces register_agent_build.py's
-        # in-Python file-tree hashing + signing as of 2.7.8.4 (issue #707).
+      - name: Install ciris-build-sign (CIRISVerify v1.8.6+)
+        # Provides the `ciris-build-sign` + `ciris-build-verify` binaries on
+        # PATH. Required for the --tree manifest shape that replaces
+        # register_agent_build.py's in-Python file-tree hashing + signing as
+        # of 2.7.8.4 (issue #707).
+        #
+        # v1.8.6 is the floor: ciris-verify wheels 1.8.0-1.8.5 did not ship
+        # the CLI binaries as console_scripts entry points (the register-build
+        # job on the 2.7.8 merge failed on `which ciris-build-sign` exit 1).
+        # v1.8.6 adds them across all 5 platforms (linux x86_64/aarch64,
+        # macos x86_64/arm64, windows x86_64).
         run: |
-          pip install --upgrade "ciris-verify>=1.8.1"
+          pip install --upgrade "ciris-verify>=1.8.6"
           which ciris-build-sign && ciris-build-sign --version
 
       - name: Emit build-secrets hash file

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ pycryptodome>=3.20.0,<4.0.0  # Keccak-256 for EVM address checksums (EIP-55)
 PyJWT[crypto]>=2.8.0,<3.0.0
 bcrypt>=4.0.0,<5.0.0
 PyNaCl>=1.5.0,<2.0.0
-ciris-verify>=1.8.1  # Hardware-rooted license verification, wallet signing, native encryption (CIRISVerify FFI bindings) + ciris-build-sign CLI. v1.8.1 adds --tree manifest shape (file-tree extras) — replaces tools/legacy/register_agent_build.py's in-Python file-tree hashing in CI per #707. v1.8.0 floor: HardwareSigner.storage_descriptor() (PoB substrate primitive, see #708). v1.6.4 was the iOS SQLite-symbol-fix floor.
+ciris-verify>=1.8.6  # Hardware-rooted license verification, wallet signing, native encryption (CIRISVerify FFI bindings) + ciris-build-sign / ciris-build-verify CLIs. v1.8.6 floor: ships ciris-build-sign + ciris-build-verify as console_scripts entry points across all 5 platforms (linux x86_64/aarch64, macos x86_64/arm64, windows x86_64) — earlier 1.8.x wheels were missing the binaries which broke the register-build CI step on the 2.7.8 merge. v1.8.1 added --tree manifest shape (file-tree extras) — replaces tools/legacy/register_agent_build.py's in-Python file-tree hashing per #707. v1.8.0 floor: HardwareSigner.storage_descriptor() (PoB substrate primitive, see #708). v1.6.4 was the iOS SQLite-symbol-fix floor.
 
 # Web Framework (API)
 fastapi>=0.111.0,<1.0.0


### PR DESCRIPTION
## Summary

Closes the post-merge automation regression on the 2.7.8 release.

The 2.7.8 merge into main (commit `50bf5c8b9`) failed the **Register Build with CIRISRegistry** job because `which ciris-build-sign` returned exit 1 after `pip install ciris-verify>=1.8.1`. The downstream **Publish Release** and **Notify CIRISManager** jobs were skipped as a result.

Verified locally against PyPI: ciris-verify wheels 1.8.0 / 1.8.1 / 1.8.3 / 1.8.4 / 1.8.5 ship **zero** `console_scripts` entry points — the CLI binary was specced in 2.7.8.4 but the packaging never landed.

CIRISVerify v1.8.6 (released 2026-05-02) adds `ciris-build-sign` + `ciris-build-verify` as console_scripts entry points across all 5 platforms (linux x86_64/aarch64, macos x86_64/arm64, windows x86_64). Verified:

```
$ pip install "ciris-verify==1.8.6"
$ which ciris-build-sign
/tmp/cv186_venv/bin/ciris-build-sign
$ ciris-build-sign --version
ciris-build-sign 1.8.6
```

## Changes

| File | Δ |
|---|---|
| `requirements.txt` | `ciris-verify>=1.8.1` → `>=1.8.6` + comment documenting the v1.8.6 binary-shipping floor and the missing-binary history |
| `.github/workflows/build.yml:676` | same pin bump + expanded comment |

## Test plan

- [ ] CI green on this PR (build + test shards + memory benchmark + CodeQL — register-build doesn't run on PRs, only on main pushes)
- [ ] After merge, observe the next main-push triggered run: `Register Build with CIRISRegistry` should pass, `Publish Release` and `Notify CIRISManager` should run instead of skip
- [ ] If a 2.7.8.X re-publication is needed, can be triggered by a docs-only nudge commit to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)