### PR TITLE
fix(ci): read CIRIS_VERSION without importing ciris_engine (Register Build aiofiles regression)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -436,7 +436,13 @@ jobs:
         # match what the bundled binaries report. Read from constants.py
         # to keep one source of truth.
         run: |
-          $version = python -c "from ciris_engine.constants import CIRIS_VERSION; print(CIRIS_VERSION.replace('-stable',''))"
+          # Read CIRIS_VERSION without importing the `ciris_engine`
+          # package — the package's __init__ pulls full runtime + deps
+          # not installed in this job (only ciris-verify is). exec()'ing
+          # constants.py directly runs only its stdlib imports +
+          # constant assignments. Strip "-stable" suffix to match the
+          # installer-name convention.
+          $version = python -c "exec(open('ciris_engine/constants.py').read()); print(CIRIS_VERSION.replace('-stable',''))"
           Write-Host "Building installer for CIRIS $version"
           & "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe" `
               "/DCirisVersion=$version" `
@@ -690,7 +696,17 @@ jobs:
           CIRIS_BUILD_ED25519_SEED: ${{ secrets.CIRIS_BUILD_ED25519_SEED }}
           CIRIS_BUILD_MLDSA_SECRET: ${{ secrets.CIRIS_BUILD_MLDSA_SECRET }}
         run: |
-          VERSION=$(python -c "from ciris_engine.constants import CIRIS_VERSION; print(CIRIS_VERSION)")
+          # Read CIRIS_VERSION as a string literal without importing the
+          # `ciris_engine` package — the package's __init__ pulls in the
+          # full runtime which transitively imports aiofiles + other
+          # runtime-only deps not installed in this signing job (only
+          # ciris-verify is). awk on the literal stays robust as more
+          # runtime deps get added. Format: `CIRIS_VERSION = "x.y.z-stage"`
+          VERSION=$(awk -F'"' '/^CIRIS_VERSION = /{print $2; exit}' ciris_engine/constants.py)
+          if [ -z "$VERSION" ]; then
+            echo "ERROR: failed to extract CIRIS_VERSION from ciris_engine/constants.py"; exit 1
+          fi
+          echo "CIRIS_VERSION = $VERSION"
           GIT_SHA=$(git rev-parse HEAD)
           ciris-build-sign sign \
             --primitive agent \
@@ -745,7 +761,17 @@ jobs:
           CIRIS_BUILD_ED25519_SEED: ${{ secrets.CIRIS_BUILD_ED25519_SEED }}
           CIRIS_BUILD_MLDSA_SECRET: ${{ secrets.CIRIS_BUILD_MLDSA_SECRET }}
         run: |
-          VERSION=$(python -c "from ciris_engine.constants import CIRIS_VERSION; print(CIRIS_VERSION)")
+          # Read CIRIS_VERSION as a string literal without importing the
+          # `ciris_engine` package — the package's __init__ pulls in the
+          # full runtime which transitively imports aiofiles + other
+          # runtime-only deps not installed in this signing job (only
+          # ciris-verify is). awk on the literal stays robust as more
+          # runtime deps get added. Format: `CIRIS_VERSION = "x.y.z-stage"`
+          VERSION=$(awk -F'"' '/^CIRIS_VERSION = /{print $2; exit}' ciris_engine/constants.py)
+          if [ -z "$VERSION" ]; then
+            echo "ERROR: failed to extract CIRIS_VERSION from ciris_engine/constants.py"; exit 1
+          fi
+          echo "CIRIS_VERSION = $VERSION"
           GIT_SHA=$(git rev-parse HEAD)
           ciris-build-sign sign \
             --primitive agent \


### PR DESCRIPTION
## Summary

- Build & Deploy's **Register Build with CIRISRegistry** job fails on every push to `main` since 2.7.8-RC1 (`50bf5c8b9`) with `ModuleNotFoundError: No module named 'aiofiles'`.
- Root cause: the version-extraction step uses `python -c "from ciris_engine.constants import ..."` which runs `ciris_engine/__init__.py` and transitively imports the full runtime → `bootstrap.py` → `aiofiles` (a runtime-only dep, not installed in the signing job which carries only `ciris-verify`).
- Fix: read `CIRIS_VERSION` as a string literal without importing the package. Three call sites converted (2 bash via `awk`, 1 PowerShell via `python -c "exec(open(...).read())"`).
- Tonight's 2.7.9 merge to main (`d47a8ed55`) reproduces the same failure (run [25295187992](https://github.com/CIRISAI/CIRISAgent/actions/runs/25295187992)).

## Test plan

- [x] Local validation: bash awk extracts `2.7.9-stable`, PowerShell-equivalent `exec` form extracts `2.7.9` (with `-stable` stripped per existing convention)
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build.yml'))"` — valid YAML
- [ ] CI on this PR passes the Register Build job (gating signal)
- [ ] After merge, next push to main succeeds the Register Build job

🤖 Generated with [Claude Code](https://claude.com/claude-code)