### PR TITLE
fix(ci): rename secrets.CIRIS_BUILD_ED25519_SEED → SECRET (fleet convention typo)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -693,7 +693,12 @@ jobs:
 
       - name: Sign build manifest (Python source tree)
         env:
-          CIRIS_BUILD_ED25519_SEED: ${{ secrets.CIRIS_BUILD_ED25519_SEED }}
+          # Fleet convention: secret is named CIRIS_BUILD_ED25519_SECRET (not _SEED).
+          # Bridge-provisioned across all 6 onboarded repos (Persist/Lens/Agent/
+          # Verify/Registry/Edge) on 2026-05-01. Env-var name CIRIS_BUILD_ED25519_SEED
+          # stays since ciris-build-sign reads from it via --ed25519-seed; only the
+          # secrets.* source is renamed.
+          CIRIS_BUILD_ED25519_SEED: ${{ secrets.CIRIS_BUILD_ED25519_SECRET }}
           CIRIS_BUILD_MLDSA_SECRET: ${{ secrets.CIRIS_BUILD_MLDSA_SECRET }}
         run: |
           # Read CIRIS_VERSION as a string literal without importing the
@@ -758,7 +763,12 @@ jobs:
 
       - name: Sign mobile build manifest
         env:
-          CIRIS_BUILD_ED25519_SEED: ${{ secrets.CIRIS_BUILD_ED25519_SEED }}
+          # Fleet convention: secret is named CIRIS_BUILD_ED25519_SECRET (not _SEED).
+          # Bridge-provisioned across all 6 onboarded repos (Persist/Lens/Agent/
+          # Verify/Registry/Edge) on 2026-05-01. Env-var name CIRIS_BUILD_ED25519_SEED
+          # stays since ciris-build-sign reads from it via --ed25519-seed; only the
+          # secrets.* source is renamed.
+          CIRIS_BUILD_ED25519_SEED: ${{ secrets.CIRIS_BUILD_ED25519_SECRET }}
           CIRIS_BUILD_MLDSA_SECRET: ${{ secrets.CIRIS_BUILD_MLDSA_SECRET }}
         run: |
           # Read CIRIS_VERSION as a string literal without importing the


### PR DESCRIPTION
## Summary

- Diagnosed by CIRISBridge: `CIRIS_BUILD_ED25519_SECRET` is provisioned across **all 6 onboarded fleet repos** (Persist/Lens/Agent/Verify/Registry/Edge) since 2026-05-01T20:34:02Z. CIRISAgent's workflow was the only caller using `_SEED` instead of `_SECRET` — author typo, the MLDSA line on the same env block correctly uses `_SECRET`.
- Symptom on main HEAD `e49b65a7f7` ([run 25296636527](https://github.com/CIRISAI/CIRISAgent/actions/runs/25296636527)): Register Build job exits with `error: a value is required for '--ed25519-seed' but none was supplied`. Env block confirms `CIRIS_BUILD_ED25519_SEED: ` (empty, no `***` mask).
- Fix: change `secrets.CIRIS_BUILD_ED25519_SEED` → `secrets.CIRIS_BUILD_ED25519_SECRET` at lines 696 + 761. Env-var name unchanged so downstream `--ed25519-seed "$CIRIS_BUILD_ED25519_SEED"` resolves correctly.
- Cross-check: matches `CIRISPersist/.github/workflows/ci.yml` canonical pattern.

## Out of scope (follow-up cleanup)

- Lines 249, 593 reference `secrets.CIRIS_BUILD_SIGN_KEY` which doesn't exist on any repo. Verified non-load-bearing: `version.py:130` reads it via `os.environ.get(...)` with `None` fallback, and the HMAC-sign path is optional. Build succeeds past those steps; the actual blocker was the `--ed25519-seed` hard-fail.

## Test plan

- [x] Both sites now reference canonical fleet-convention secret name
- [x] YAML parses cleanly
- [x] Env-var name preserved → downstream `--ed25519-seed` invocation unchanged
- [x] Pattern matches Persist's reference impl
- [ ] After merge, next push to main has Build & Deploy → Register Build job succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)