### PR TITLE
fix(ci): emit sha256: prefix in build-secrets.json (multihash convention)

### DIFF
--- a/tools/ops/build_agent_extras.py
+++ b/tools/ops/build_agent_extras.py
@@ -55,7 +55,14 @@ BUILD_SECRETS_HASHES: Dict[str, str] = {
 
 
 def main() -> int:
-    json.dump(BUILD_SECRETS_HASHES, sys.stdout, indent=2, sort_keys=True)
+    # ciris-build-sign --tree-extra-hashes-file requires the multihash-style
+    # `sha256:<hex>` prefix, not bare hex. Cross-fleet convention: see
+    # CIRISPersist/tools/legacy/ciris_manifest.py + that repo's CI which
+    # emits `sha256:$(sha256sum ...)`. Prefix at emit time so
+    # BUILD_SECRETS_HASHES stays a clean {path: hex} dict for human editing
+    # while the wire format ships the canonical multihash form.
+    prefixed = {path: f"sha256:{hex_hash}" for path, hex_hash in BUILD_SECRETS_HASHES.items()}
+    json.dump(prefixed, sys.stdout, indent=2, sort_keys=True)
     sys.stdout.write("\n")
     return 0
 


### PR DESCRIPTION
## Summary

Third stage of the post-2.7.9 build-deploy chain. Register Build job advanced past the aiofiles + secret-name fixes but hit:

```
Error: extra hash for ciris_adapters/wallet/providers/_build_secrets.py
must be sha256:<64 hex chars>, got 45bf41f04082...49518dd2fb6b
```

64 hex chars correct — `sha256:` multihash prefix missing. Cross-fleet convention: Persist's `tools/legacy/ciris_manifest.py:137` and `ci.yml:480` both prefix.

Fix: prefix at emit time in `build_agent_extras.py::main()` so the on-disk dict stays `{path: hex}` for human editing (matching the docstring instruction: `sha256sum file # paste new hex into dict`) while the JSON wire output gets the canonical `sha256:<hex>` form.

## Cumulative regression chain

| Stage | Issue | Status |
|---|---|---|
| 1 | aiofiles ImportError via `from ciris_engine.constants import` | ✅ fixed (e49b65a7f) |
| 2 | `CIRIS_BUILD_ED25519_SEED` typo (canonical: `_SECRET`) | ✅ fixed (55c3d1d5e) |
| 3 | extra-hashes JSON missing `sha256:` multihash prefix | ✅ this PR |

## Test plan

- [x] Local: `python3 tools/ops/build_agent_extras.py` emits `"sha256:45bf41f0..."` (was bare hex)
- [ ] After merge, next push to main has Build & Deploy → Register Build → sign step succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)