### PR TITLE
docs(fsd): correlation_risk is numeric f64, not categorical string (#724)

### DIFF
--- a/FSD/TRACE_WIRE_FORMAT.md
+++ b/FSD/TRACE_WIRE_FORMAT.md
@@ -599,7 +599,7 @@ margins. Schema is rich; see `IDMAResult` in
   "thought_id": "...", "task_id": "...", "timestamp": "...",
   "k_eff": 3.0, "k_raw": 4, "raw_source_count": 4,
   "effective_source_count": 3.0,
-  "correlation_risk": "low", "fragility_flag": false,
+  "correlation_risk": 0.18, "fragility_flag": false,
   "reasoning_is_fragile": false, "phase": "healthy",
   "phase_confidence": 0.92, "reasoning_state": "stable",
   "collapse_margin": 1.5, "safety_margin": 0.8,


### PR DESCRIPTION
## Summary

`FSD/TRACE_WIRE_FORMAT.md` §5.4 example showed `"correlation_risk": "low"` (string). Empirical reality across 6,465 corpus traces + 103/103 in 2.7.9 QA export is `float ∈ [0,1]`. Schema source of truth (`IDMAResult.correlation_risk: float = Field(..., ge=0.0, le=1.0)`) confirms numeric.

Federation peers writing parsers from this example would fail to deserialize 100% of real traffic.

Fix: change example to `0.18` (matches the `rho_mean: 0.18` on the same example for visual consistency).

Closes #724.

## Test plan

- [x] FSD example now matches `IDMAResult` schema (`float`, not `str`)
- [x] Value `0.18` inside the [0, 1] valid range and consistent with the example's `rho_mean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)