### PR TITLE
Release 2.8.0: trust release — ciris-verify >=1.10.1 + register cutover + plain-semver binary_version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -674,12 +674,14 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install ciris-build-sign (CIRISVerify v1.8.1+)
-        # Provides the `ciris-build-sign` binary on PATH. Required for the
-        # --tree manifest shape that replaces register_agent_build.py's
-        # in-Python file-tree hashing + signing as of 2.7.8.4 (issue #707).
+      - name: Install ciris-build-sign (CIRISVerify v1.10.1+)
+        # v1.10.1 ships the `register` subcommand which writes all 3 registry
+        # tables (builds + binary_manifests + function_manifests) — closes
+        # the parent-row gap that left 2.7.8/2.7.9 with only function_manifests
+        # rows (#727). Also cuts over from gRPC RegisterBuild → HTTP POST
+        # /v1/builds; drops REGISTRY_JWT_SECRET requirement.
         run: |
-          pip install --upgrade "ciris-verify>=1.8.1"
+          pip install --upgrade "ciris-verify>=1.10.1"
           which ciris-build-sign && ciris-build-sign --version
 
       - name: Emit build-secrets hash file
@@ -720,13 +722,16 @@ jobs:
           # Read CIRIS_VERSION as a string literal without importing the
           # `ciris_engine` package (transitive import chain pulls runtime
           # deps not installed in this signing job; only ciris-verify is).
-          # awk on the literal stays robust as more runtime deps are added.
-          # Format: `CIRIS_VERSION = "x.y.z-stage"`
-          VERSION=$(awk -F'"' '/^CIRIS_VERSION = /{print $2; exit}' ciris_engine/constants.py)
+          # Strip the channel suffix (-stable / -rc / -beta) so the
+          # registry receives plain semver in `binary_version` per #726
+          # — every other primitive ships plain semver, and the registry
+          # does exact-string match on the column. Format in source:
+          # `CIRIS_VERSION = "x.y.z-stage"`.
+          VERSION=$(awk -F'"' '/^CIRIS_VERSION = /{print $2; exit}' ciris_engine/constants.py | sed -E 's/-(stable|rc[0-9]*|beta[0-9]*|alpha[0-9]*)$//')
           if [ -z "$VERSION" ]; then
             echo "ERROR: failed to extract CIRIS_VERSION from ciris_engine/constants.py"; exit 1
           fi
-          echo "CIRIS_VERSION = $VERSION"
+          echo "CIRIS_VERSION (stripped of channel suffix) = $VERSION"
           GIT_SHA=$(git rev-parse HEAD)
           ciris-build-sign sign \
             --primitive agent \
@@ -744,34 +749,6 @@ jobs:
             --output build-manifest.json
           # Wipe key files immediately after signing.
           shred -uz "$ED_KEY_PATH" "$MLDSA_KEY_PATH" 2>/dev/null || rm -f "$ED_KEY_PATH" "$MLDSA_KEY_PATH"
-
-      - name: Push signed manifest to Registry (Python source tree)
-        # Posts the raw signed BuildManifest JSON to /v1/verify/build-manifest.
-        # Auth: Bearer ${{ secrets.REGISTRY_ADMIN_TOKEN }} (same admin token
-        # the function-manifest endpoint uses; not the gRPC HS256 JWT, which
-        # was retired with register_signed_manifest.py).
-        # Pre-flight: the agent-steward pubkey must already be registered as
-        # a trusted key for project='ciris-agent' via RegisterTrustedPrimitiveKey
-        # admin RPC. Without it: HTTP 403 no_trusted_key.
-        env:
-          REGISTRY_URL: ${{ vars.REGISTRY_URL }}
-          REGISTRY_ADMIN_TOKEN: ${{ secrets.REGISTRY_ADMIN_TOKEN }}
-        run: |
-          HTTP_CODE=$(curl -sw "%{http_code}" -o response.json \
-            -X POST "$REGISTRY_URL/v1/verify/build-manifest" \
-            -H "Authorization: Bearer $REGISTRY_ADMIN_TOKEN" \
-            -H "Content-Type: application/json" \
-            --data-binary @build-manifest.json)
-          echo "HTTP $HTTP_CODE"
-          cat response.json
-          echo
-          case "$HTTP_CODE" in
-            200) echo "✓ Stored";;
-            401) echo "ERROR 401 unauthorized — verify REGISTRY_ADMIN_TOKEN matches production env var"; exit 1;;
-            403) echo "ERROR 403 no_trusted_key — operator must register the agent-steward pubkey via RegisterTrustedPrimitiveKey admin RPC for project='ciris-agent'"; exit 1;;
-            400) echo "ERROR 400 — body invalid (verification_failed = pubkey mismatch; invalid_manifest = body shape)"; exit 1;;
-            *) echo "ERROR unexpected HTTP $HTTP_CODE"; exit 1;;
-          esac
 
       - name: Extract mobile Resources.zip
         run: |
@@ -795,11 +772,12 @@ jobs:
           printf '%s' "${CIRIS_BUILD_ED25519_SECRET}" | base64 -d > "$ED_KEY_PATH"
           printf '%s' "${CIRIS_BUILD_MLDSA_SECRET}" | base64 -d > "$MLDSA_KEY_PATH"
 
-          VERSION=$(awk -F'"' '/^CIRIS_VERSION = /{print $2; exit}' ciris_engine/constants.py)
+          # Strip channel suffix per #726 (plain semver to registry).
+          VERSION=$(awk -F'"' '/^CIRIS_VERSION = /{print $2; exit}' ciris_engine/constants.py | sed -E 's/-(stable|rc[0-9]*|beta[0-9]*|alpha[0-9]*)$//')
           if [ -z "$VERSION" ]; then
             echo "ERROR: failed to extract CIRIS_VERSION from ciris_engine/constants.py"; exit 1
           fi
-          echo "CIRIS_VERSION = $VERSION"
+          echo "CIRIS_VERSION (stripped of channel suffix) = $VERSION"
           GIT_SHA=$(git rev-parse HEAD)
           ciris-build-sign sign \
             --primitive agent \
@@ -818,26 +796,79 @@ jobs:
           # Wipe key files immediately after signing.
           shred -uz "$ED_KEY_PATH" "$MLDSA_KEY_PATH" 2>/dev/null || rm -f "$ED_KEY_PATH" "$MLDSA_KEY_PATH"
 
-      - name: Push signed mobile manifest to Registry
+      - name: Register release with CIRISRegistry (file mode + binary mode)
+        # Single-step replacement for the legacy two-curl-POST flow, per
+        # CIRISAgent#727. ciris-build-sign register (v1.10.1+) writes all
+        # 3 registry tables — builds + binary_manifests + function_manifests —
+        # in one call, closing the parent-row gap that left every release
+        # ≥ 2.7.8 with only function_manifests rows. Mode auto-detected
+        # from the BuildManifest:
+        #   - python-source-tree → FILE mode (FileTreeExtras present)
+        #     → writes builds row + function_manifests
+        #   - ios-mobile-bundle  → BINARY mode (binary hash present)
+        #     → writes builds row + binary_manifests + function_manifests
+        # Mixed modes in a single register call are rejected, so we run
+        # two calls per release (#727 § "single mode per release call").
+        # REGISTRY_JWT_SECRET no longer needed (v1.10.1 cut over to HTTP
+        # POST /v1/builds with REGISTRY_ADMIN_TOKEN bearer).
+        # Pre-flight requirement: agent-steward pubkey must be registered
+        # as a trusted key for project='ciris-agent' via
+        # RegisterTrustedPrimitiveKey admin RPC (otherwise HTTP 403
+        # no_trusted_key).
         env:
           REGISTRY_URL: ${{ vars.REGISTRY_URL }}
           REGISTRY_ADMIN_TOKEN: ${{ secrets.REGISTRY_ADMIN_TOKEN }}
+          CIRIS_BUILD_ED25519_SECRET: ${{ secrets.CIRIS_BUILD_ED25519_SECRET }}
+          CIRIS_BUILD_MLDSA_SECRET: ${{ secrets.CIRIS_BUILD_MLDSA_SECRET }}
         run: |
-          HTTP_CODE=$(curl -sw "%{http_code}" -o response-mobile.json \
-            -X POST "$REGISTRY_URL/v1/verify/build-manifest" \
-            -H "Authorization: Bearer $REGISTRY_ADMIN_TOKEN" \
-            -H "Content-Type: application/json" \
-            --data-binary @build-manifest-mobile.json)
-          echo "HTTP $HTTP_CODE"
-          cat response-mobile.json
-          echo
-          case "$HTTP_CODE" in
-            200) echo "✓ Stored";;
-            401) echo "ERROR 401 unauthorized — verify REGISTRY_ADMIN_TOKEN matches production env var"; exit 1;;
-            403) echo "ERROR 403 no_trusted_key — operator must register the agent-steward pubkey via RegisterTrustedPrimitiveKey admin RPC for project='ciris-agent'"; exit 1;;
-            400) echo "ERROR 400 — body invalid (verification_failed = pubkey mismatch; invalid_manifest = body shape)"; exit 1;;
-            *) echo "ERROR unexpected HTTP $HTTP_CODE"; exit 1;;
-          esac
+          if [ -z "${CIRIS_BUILD_ED25519_SECRET}" ] || [ -z "${CIRIS_BUILD_MLDSA_SECRET}" ]; then
+            echo "::error::Hybrid signing secrets not configured (register step)."
+            exit 1
+          fi
+          umask 077
+          ED_KEY_PATH=$(mktemp)
+          MLDSA_KEY_PATH=$(mktemp)
+          printf '%s' "${CIRIS_BUILD_ED25519_SECRET}" | base64 -d > "$ED_KEY_PATH"
+          printf '%s' "${CIRIS_BUILD_MLDSA_SECRET}" | base64 -d > "$MLDSA_KEY_PATH"
+
+          # Strip channel suffix per #726 (plain semver to registry).
+          VERSION=$(awk -F'"' '/^CIRIS_VERSION = /{print $2; exit}' ciris_engine/constants.py | sed -E 's/-(stable|rc[0-9]*|beta[0-9]*|alpha[0-9]*)$//')
+          GIT_SHA=$(git rev-parse HEAD)
+
+          # Call 1: python-source-tree (file mode → builds row, file_manifest_json populated).
+          echo "::group::register python-source-tree (file mode)"
+          ciris-build-sign register \
+            --project ciris-agent \
+            --binary-version "$VERSION" \
+            --build-id "$GIT_SHA" \
+            --target python-source-tree:./build-manifest.json \
+            --modules core \
+            --source-repo "https://github.com/CIRISAI/CIRISAgent" \
+            --source-commit "$GIT_SHA" \
+            --ed25519-seed "$ED_KEY_PATH" \
+            --mldsa-secret "$MLDSA_KEY_PATH" \
+            --key-id "agent-steward-2026"
+          echo "::endgroup::"
+
+          # Call 2: ios-mobile-bundle (binary mode → builds + binary_manifests + function_manifests).
+          # Two separate `builds` rows per release is fine; they're keyed on
+          # build_hash which differs because the `binaries` map differs.
+          echo "::group::register ios-mobile-bundle (binary mode)"
+          ciris-build-sign register \
+            --project ciris-agent \
+            --binary-version "$VERSION" \
+            --build-id "$GIT_SHA-mobile" \
+            --target ios-mobile-bundle:./build-manifest-mobile.json \
+            --modules ios \
+            --source-repo "https://github.com/CIRISAI/CIRISAgent" \
+            --source-commit "$GIT_SHA" \
+            --ed25519-seed "$ED_KEY_PATH" \
+            --mldsa-secret "$MLDSA_KEY_PATH" \
+            --key-id "agent-steward-2026"
+          echo "::endgroup::"
+
+          # Wipe key files immediately after register.
+          shred -uz "$ED_KEY_PATH" "$MLDSA_KEY_PATH" 2>/dev/null || rm -f "$ED_KEY_PATH" "$MLDSA_KEY_PATH"
 
   deploy:
     name: Notify CIRISManager of Update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to CIRIS Agent will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.0] - 2026-05-04
+
+Trust release. First CIRISAgent release on the new signing infrastructure (`ciris-build-sign register`). No wire-format / runtime / agent-behavior changes — 2.8.0 inherits 2.7.9's deployment_profile cohort taxonomy, conscience verb-scope expansion, and per-locale Coherence dignity anchor unchanged. The version bump exists to mark the cutover from per-target curl-POST registration to single-call `register`, which closes the parent-row gap that affected every release ≥ 2.7.8.
+
+### Build / signing infrastructure
+
+- **`ciris-verify` floor lifted >=1.8.1 → >=1.10.1** (#727). v1.10.1 ships the `ciris-build-sign register` subcommand which writes all 3 registry tables — `builds` + `binary_manifests` + `function_manifests` — in one call. Closes the parent-row gap: every release between 2.7.8 and 2.7.9 landed in the registry with only `function_manifests` rows, leaving `/v1/builds/<v>` and `/v1/verify/binary-manifest/<v>` returning 404 for verify-clients. v1.10.1 also cuts over from gRPC RegisterBuild to HTTP `POST /v1/builds`, dropping the `REGISTRY_JWT_SECRET` requirement and the `grpcurl` install — single bearer token (`REGISTRY_ADMIN_TOKEN`) for all 3 endpoints.
+- **`build.yml` cut over to `register`** (#727). Replaced the two per-target `curl POST /v1/verify/build-manifest` steps with a single `ciris-build-sign register` step that runs two register calls — file mode for `python-source-tree` (writes `builds` row + `function_manifests`) and binary mode for `ios-mobile-bundle` (writes `builds` + `binary_manifests` + `function_manifests`). Mode auto-detected from the BuildManifest shape; mixed modes in one call are rejected by design, so two calls per release.
+- **`binary_version` channel-suffix strip** (#726). Build manifests now ship plain semver in `binary_version` (e.g. `2.8.0`), not the channel-suffixed form (`2.8.0-stable`). Every other primitive's manifest already uses plain semver; the registry does exact-string matching, so verify URLs of the natural form `/v1/verify/function-manifest/<version>/<target>` returned 404 for 2.7.9 specifically (manually patched in both regions, but won't recur). awk extraction at both bash sign sites + the existing PowerShell installer step now strip `-(stable|rc[0-9]*|beta[0-9]*|alpha[0-9]*)$` from the version literal before passing to `ciris-build-sign --binary-version`.
+
+### Inherited from 2.7.9 (no change)
+
+- `deployment_profile` cohort-taxonomy block on the CompleteTrace envelope (#718)
+- `agent_id_hash` canonical-derivation fallback at trace emission (#716)
+- Conscience verb-scope expansion (CONSCIENCE_V3 Stage 1 + Phase 2): Entropy on `{SPEAK, TOOL}`, Coherence on `{SPEAK, TOOL, DEFER}`
+- Universal `DIGNITY AND NON-HARM` principle in all 29 Coherence prompts + per-locale stigma class enumeration in 13 (am/ar/bn/fa/ha/hi/mr/my/pa/sw/ta/te/ur/yo)
+- Tier-2 RTL safety harness onboarding (ar/fa/ur v3 MH-ARC corpus + scoring rubric drafts)
+- FSD/TRACE_WIRE_FORMAT.md §5.4 `correlation_risk` example corrected to numeric f64 (#724)
+
+### CI fixes carried forward
+
+The 2.7.9-cycle CI hotfixes for the agent's first signing-infra cycle stay in place:
+
+- aiofiles ImportError on package init (constants.py read via awk/exec)
+- `CIRIS_BUILD_ED25519_SECRET` fleet-convention secret name
+- `sha256:` multihash prefix on extras JSON
+- ed25519/mldsa secret materialization to `mktemp` paths
+
+These all become moot for non-2.8.0 follow-up cycles once the toolchain stabilizes on the `register`-based shape.
+
 ## [2.7.9] - 2026-05-03
 
 Architectural follow-up to 2.7.8 that closes three structural gaps surfaced by the Tier-1 sweep cycle: cohort taxonomy on the trace envelope, conscience verb-scope coverage on DEFER, and a localized place for "hurtful words always hurt." Plus the Tier-2 RTL onboarding (ar/fa/ur) and the persist-side `agent_id_hash='unknown'` regression close.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 **A type-safe, auditable AI agent framework with built-in ethical reasoning**
 
-**BETA RELEASE 2.7.9-stable** | [Release Notes](CHANGELOG.md) | [Documentation Hub](docs/README.md)
+**BETA RELEASE 2.8.0-stable** | [Release Notes](CHANGELOG.md) | [Documentation Hub](docs/README.md)
 
 CIRIS lets you run AI agents that explain their decisions, defer to humans when uncertain, and maintain complete audit trails. Currently powering Discord community moderation, designed to scale to healthcare and education.
 

--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -3,11 +3,11 @@
 from pathlib import Path
 
 # Version information
-CIRIS_VERSION = "2.7.9-stable"
+CIRIS_VERSION = "2.8.0-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
-CIRIS_VERSION_MINOR = 7
-CIRIS_VERSION_PATCH = 9
+CIRIS_VERSION_MINOR = 8
+CIRIS_VERSION_PATCH = 0
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/client/androidApp/build.gradle
+++ b/client/androidApp/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 35
-        versionCode 123
-        versionName "2.7.9"
+        versionCode 124
+        versionName "2.8.0"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/client/androidApp/src/main/python/version.py
+++ b/client/androidApp/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.7.9"
+__version__ = "android-2.8.0"
 
 
 def get_version() -> str:

--- a/client/iosApp/iosApp/Info.plist
+++ b/client/iosApp/iosApp/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.7.9</string>
+	<string>2.8.0</string>
 	<key>CFBundleVersion</key>
-	<string>276</string>
+	<string>277</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ pycryptodome>=3.20.0,<4.0.0  # Keccak-256 for EVM address checksums (EIP-55)
 PyJWT[crypto]>=2.8.0,<3.0.0
 bcrypt>=4.0.0,<5.0.0
 PyNaCl>=1.5.0,<2.0.0
-ciris-verify>=1.8.1  # Hardware-rooted license verification, wallet signing, native encryption (CIRISVerify FFI bindings) + ciris-build-sign CLI. v1.8.1 adds --tree manifest shape (file-tree extras) — replaces tools/legacy/register_agent_build.py's in-Python file-tree hashing in CI per #707. v1.8.0 floor: HardwareSigner.storage_descriptor() (PoB substrate primitive, see #708). v1.6.4 was the iOS SQLite-symbol-fix floor.
+ciris-verify>=1.10.1  # Hardware-rooted license verification, wallet signing, native encryption (CIRISVerify FFI bindings) + ciris-build-sign CLI. v1.10.1 adds `register` subcommand (writes all 3 registry tables: builds + binary_manifests + function_manifests; closes parent-row gap that left 2.7.8/2.7.9 with only function_manifests rows). v1.10.1 also cuts over from gRPC RegisterBuild to HTTP POST /v1/builds — drops REGISTRY_JWT_SECRET requirement, single bearer token (REGISTRY_ADMIN_TOKEN) for all 3 endpoints. Earlier history: v1.8.1 added --tree manifest shape (#707), v1.8.0 floor HardwareSigner.storage_descriptor() (#708), v1.6.4 iOS SQLite-symbol-fix.
 
 # Web Framework (API)
 fastapi>=0.111.0,<1.0.0


### PR DESCRIPTION
## Summary

First CIRISAgent release on the new signing infrastructure. **No wire-format, runtime, or agent-behavior changes** — 2.8.0 inherits 2.7.9's `deployment_profile` cohort taxonomy, conscience verb-scope expansion, and per-locale Coherence dignity anchor unchanged.

The version bump exists to mark the cutover from per-target curl-POST registration to single-call `ciris-build-sign register`, which closes the parent-row gap that affected every release ≥ 2.7.8.

Closes:
- **#727** — Lift ciris-verify floor to >=1.10.1 + cut over build.yml to `register`
- **#726** — `binary_version` channel-suffix strip (plain semver to registry)

## Build / signing changes

**`requirements.txt`**: `ciris-verify>=1.8.1` → `>=1.10.1`. v1.10.1 ships `register` which writes all 3 registry tables in one call (builds + binary_manifests + function_manifests). Cuts over from gRPC RegisterBuild to HTTP `POST /v1/builds`, drops `REGISTRY_JWT_SECRET` requirement.

**`.github/workflows/build.yml`**:
- Install pin v1.8.1+ → v1.10.1+
- Sign steps strip channel suffix via `sed -E 's/-(stable|rc[0-9]*|beta[0-9]*|alpha[0-9]*)$//'` before passing `--binary-version` (matches every other primitive's plain-semver convention; #726)
- Register step replaces two `curl POST /v1/verify/build-manifest` calls with a single `ciris-build-sign register` step running two register calls — file mode for `python-source-tree` + binary mode for `ios-mobile-bundle` (mode auto-detected from BuildManifest, mixed modes in one call rejected by design)

## Inherited from 2.7.9 (no change)

- `deployment_profile` cohort-taxonomy block (#718)
- canonical `agent_id_hash` fallback (#716)
- Conscience verb-scope: Entropy on `{SPEAK,TOOL}`, Coherence on `{SPEAK,TOOL,DEFER}`
- `DIGNITY AND NON-HARM` principle in 29 Coherence prompts + per-locale stigma enumeration in 13
- Tier-2 RTL safety harnesses (ar/fa/ur)

## Version bump

| | from | to |
|---|---|---|
| `CIRIS_VERSION` | `2.7.9-stable` | `2.8.0-stable` |
| iOS `CFBundleShortVersionString` | `2.7.9` | `2.8.0` |
| iOS `CFBundleVersion` | `276` | `277` |
| Android `versionName` | `2.7.9` | `2.8.0` |
| Android `versionCode` | `123` | `124` |

## Test plan

- [x] `pytest -n 28 --timeout=300` — 13,609 passed / 134 skipped / 2 xfailed
- [x] `mypy` clean across `ciris_adapters/ciris_accord_metrics/` + `ciris_engine/logic/conscience/`
- [x] Channel-suffix strip verified against `2.8.0-stable` / `2.8.0-rc3` / `2.8.0-beta` / `2.8.0` inputs — all yield `2.8.0`
- [x] `build.yml` YAML parses cleanly
- [ ] Build & Deploy → Register Build job runs the new `ciris-build-sign register` calls successfully on main (gated to `refs/heads/main`, can't validate via PR CI — same blocker pattern as 2.7.9 hotfixes)
- [ ] Registry rows for 2.8.0 land in all 3 tables: `builds`, `binary_manifests`, `function_manifests` (closes the parent-row gap)
- [ ] Verify URL `/v1/verify/function-manifest/2.8.0/python-source-tree` returns 200 (was 404 for `2.7.9` due to `2.7.9-stable` row mismatch — manually patched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)