### PR TITLE
v2.8.3: regenerate startup_python_hashes.json at CI bake time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -595,6 +595,18 @@ jobs:
           python version.py
           cat BUILD_INFO.txt || echo "No BUILD_INFO.txt created"
 
+      - name: Regenerate startup_python_hashes.json
+        # Bridge step (option A) until CIRISVerify FFI gains a runtime tree
+        # walker (option B). The agent reads this JSON at boot to populate
+        # `python_integrity` in attestation; its `agent_version` field is
+        # the registry lookup key. Regenerating here ensures the docker
+        # image always carries hashes matching the source tree being baked
+        # — eliminates the staleness that capped CIRISVerify at Level 3 in
+        # 2.8.2 (#TBD). Algorithm matches mobile_main.py byte-for-byte.
+        run: |
+          python3 tools/dev/regenerate_python_hashes.py
+          python3 -c "import json; d=json.load(open('startup_python_hashes.json')); print(f'agent_version={d[\"agent_version\"]} modules={d[\"modules_hashed\"]} total_hash={d[\"total_hash\"][:16]}...')"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 **A type-safe, auditable AI agent framework with built-in ethical reasoning**
 
-**BETA RELEASE 2.8.2-stable** | [Release Notes](CHANGELOG.md) | [Documentation Hub](docs/README.md)
+**BETA RELEASE 2.8.3-stable** | [Release Notes](CHANGELOG.md) | [Documentation Hub](docs/README.md)
 
 CIRIS lets you run AI agents that explain their decisions, defer to humans when uncertain, and maintain complete audit trails. Currently powering Discord community moderation, designed to scale to healthcare and education.
 

--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -3,11 +3,11 @@
 from pathlib import Path
 
 # Version information
-CIRIS_VERSION = "2.8.2-stable"
+CIRIS_VERSION = "2.8.3-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
 CIRIS_VERSION_MINOR = 8
-CIRIS_VERSION_PATCH = 2
+CIRIS_VERSION_PATCH = 3
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/client/androidApp/build.gradle
+++ b/client/androidApp/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 35
-        versionCode 126
-        versionName "2.8.2"
+        versionCode 127
+        versionName "2.8.3"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/client/androidApp/src/main/python/version.py
+++ b/client/androidApp/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.8.2"
+__version__ = "android-2.8.3"
 
 
 def get_version() -> str:

--- a/client/iosApp/iosApp/Info.plist
+++ b/client/iosApp/iosApp/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.8.2</string>
+	<string>2.8.3</string>
 	<key>CFBundleVersion</key>
-	<string>279</string>
+	<string>280</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/tools/dev/regenerate_python_hashes.py
+++ b/tools/dev/regenerate_python_hashes.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Regenerate startup_python_hashes.json from the source tree.
+
+Bridge implementation (option A) while CIRISVerify FFI gains a runtime
+tree-walking verifier (option B, tracked in CIRISVerify issue). Algorithm
+is byte-for-byte identical to the mobile canonical hashing in
+client/androidApp/src/main/python/mobile_main.py (`verify_code_integrity`
++ `_save_hashes_to_file`) so desktop, mobile, and CI all produce the
+same total_hash for a given source tree.
+
+Run from CI in `.github/workflows/build.yml` immediately before docker
+image bake so:
+  - the bundled JSON's `agent_version` matches CIRIS_VERSION at build time
+  - the JSON's `total_hash` matches what mobile reports at boot
+  - the registry's signed file_manifest_json is the source of truth;
+    this JSON is a runtime cache for telemetry/attestation
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+PACKAGES = ["ciris_engine", "ciris_adapters"]
+OUTPUT_FILE = REPO_ROOT / "startup_python_hashes.json"
+SCHEMA_VERSION = "1.2"
+
+
+def get_agent_version() -> str:
+    constants = (REPO_ROOT / "ciris_engine" / "constants.py").read_text(encoding="utf-8")
+    match = re.search(r'CIRIS_VERSION\s*=\s*"([^"]+)"', constants)
+    if not match:
+        sys.exit("ERROR: CIRIS_VERSION not found in ciris_engine/constants.py")
+    return match.group(1)
+
+
+def hash_packages() -> dict:
+    module_hashes: dict[str, str] = {}
+    all_hashes: list[str] = []
+    modules_checked = 0
+    modules_hashed = 0
+
+    for package_name in PACKAGES:
+        package_path = REPO_ROOT / package_name
+        if not package_path.is_dir():
+            sys.exit(f"ERROR: package directory not found: {package_path}")
+        for py_file in package_path.rglob("*.py"):
+            modules_checked += 1
+            rel_path = str(py_file.relative_to(REPO_ROOT)).replace("\\", "/")
+            file_hash = hashlib.sha256(py_file.read_bytes()).hexdigest()
+            module_hashes[rel_path] = file_hash
+            all_hashes.append(f"{rel_path}:{file_hash}")
+            modules_hashed += 1
+
+    combined = "\n".join(sorted(all_hashes))
+    total_hash = hashlib.sha256(combined.encode()).hexdigest()
+
+    return {
+        "module_hashes": module_hashes,
+        "modules_checked": modules_checked,
+        "modules_hashed": modules_hashed,
+        "total_hash": total_hash,
+    }
+
+
+def main() -> int:
+    agent_version = get_agent_version()
+    results = hash_packages()
+
+    output_data = {
+        "version": SCHEMA_VERSION,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "computed_at": int(time.time()),
+        "agent_version": agent_version,
+        "packages": PACKAGES,
+        "modules_checked": results["modules_checked"],
+        "modules_hashed": results["modules_hashed"],
+        "unavailable_count": 0,
+        "total_hash": results["total_hash"],
+        "module_hashes": results["module_hashes"],
+        "unavailable_modules": [],
+    }
+
+    with open(OUTPUT_FILE, "w") as f:
+        json.dump(output_data, f, indent=2, sort_keys=True)
+
+    print(
+        f"Regenerated {OUTPUT_FILE.relative_to(REPO_ROOT)}: "
+        f"agent_version={agent_version}, "
+        f"modules={results['modules_hashed']}, "
+        f"total_hash={results['total_hash'][:16]}..."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds `tools/dev/regenerate_python_hashes.py` — canonical algorithm matching `client/androidApp/src/main/python/mobile_main.py` byte-for-byte (pathlib.rglob, sha256 per file, sorted total_hash, schema v1.2)
- Adds CI step in `.github/workflows/build.yml` docker `build` job to regenerate the JSON from the merged-commit source tree before docker bake
- Bumps 2.8.2 → 2.8.3

## Why

After the 2.8.2 admin-merge, QA reported CIRISVerify capping at Level 3 with `validation_status: PartialAgreement` and `expected_total_hash: None`. Root cause: `startup_python_hashes.json` carried `agent_version=2.8.0-stable` because nothing kept the runtime cache in sync with `CIRIS_VERSION`. Registry queries used the stale lookup key.

This is the **bridge fix (option A)**: regenerate the JSON at CI bake time so every docker image carries hashes matching its source tree + `CIRIS_VERSION`. The file is correctly gitignored (runtime artifact); the docker `COPY . .` is the path that bundles it into images.

The **end state (option B)** is a CIRISVerify FFI runtime tree-walker that drops the JSON entirely — tracked in a separate CIRISVerify issue.

## Why CI cut time, not bump time

Between bump and merge there can be review-fix commits that change file hashes. Regen at bump → locks stale hashes the moment a follow-up commit lands. Regen at CI bind → ships from the actual signed source tree.

## Test plan

- [ ] CI green (typecheck, tests, build, register-build, deploy, android-release)
- [ ] After merge: docker image at `ghcr.io/cirisai/ciris-agent:2.8.3` carries `startup_python_hashes.json` with `agent_version=2.8.3` and modules count matching the 2.8.3 source tree
- [ ] QA runner against 2.8.3 reports `agent_version=2.8.3` to attestation (no longer 2.8.0)
- [ ] CIRISVerify level reaches 4/5 if registry-side `expected_total_hash` is also populated; if it's still None, that surfaces as a follow-up issue not gated on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)