### PR TITLE
Add explicit compliance documentation stubs

### DIFF
--- a/compliance/D01_non_maleficence.md
+++ b/compliance/D01_non_maleficence.md
@@ -1,0 +1,63 @@
+# D01 — `non_maleficence:*` (STRONG-4)
+
+> Soft-harm-avoidance baseline (the soft-scalar above the prohibited:* floor)
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D01` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: non_maleficence
+**Attestation density**: MH=28 · EU=29 · IEEE=33 · ASEAN=27 · total=117
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§107*
+    > "deception as dignity-violation"
+    Wire form: `non_maleficence:epistemic_environment_degradation + prohibited:deception_fraud`
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§1.2 Technical robustness*
+    > "AI systems must prevent harm, ensure reliable behaviour, respect physical/mental integrity"
+    Wire form: `non_maleficence:no_cause_or_exacerbate_harm`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch4 §0.a*
+    > "human well-being requires AI development that does not cause unintended harm"
+    Wire form: `non_maleficence:wellbeing_dimensions_harm_class`
+- **ASEAN** (ASEAN Guide on AI Governance and Ethics) — *§B.3 Security/Safety*
+    > "AI should be safe and secure, and not cause harm to users; resilient to attack and failure"
+    Wire form: `non_maleficence:safe_and_secure_baseline`
+
+## Wire primitives
+
+- `non_maleficence:* (soft scalar)`
+- `prohibited:* (constitutional floor)`
+
+## Convergence note
+
+All four agree polarity-+1 / cohort-species / mutability-amendable for the soft form; absolute floor at prohibited:* polarity-(-1)/constitutional.
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `CIRISAgent/compliance/D01_non_maleficence.md`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D01"]`
+
+Proposed pointer (from seed): `CIRISLensCore F-3 detector family`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D01_non_maleficence.md
+++ b/compliance/D01_non_maleficence.md
@@ -8,7 +8,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§107*
     > "deception as dignity-violation"

--- a/compliance/D02_integrity.md
+++ b/compliance/D02_integrity.md
@@ -1,0 +1,66 @@
+# D02 — `integrity:*` (STRONG-4)
+
+> 'System holds together' structural anchor — auditable, reproducible, lifecycle integrity
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D02` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: integrity
+**Attestation density**: MH=10 · EU=36 · IEEE=42 · ASEAN=44 · total=132
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§40*
+    > "doctrinal continuity is the integrity of the Magisterium"
+    Wire form: `integrity:doctrinal_continuity`
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§1.4 Transparency*
+    > "transparency requirement is linked with the explicability principle — data, system, and business models"
+    Wire form: `integrity:explicability_for_trust`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch11 §I6*
+    > "state accountability under public scrutiny is a constitutional integrity property of A/IS regulation"
+    Wire form: `integrity:state_accountability_public_scrutiny`
+- **ASEAN** (ASEAN Guide on AI Governance and Ethics) — *§B.6 Accountability/Integrity*
+    > "AI should be designed and deployed with integrity throughout the lifecycle; auditable; reproducible"
+    Wire form: `integrity:lifecycle_integrity_attestation`
+
+## Wire primitives
+
+- `integrity:*`
+
+## Convergence note
+
+Densest sub-leaf decomposition: ASEAN alone uses 44 distinct sub-leaves.
+
+## Cross-source conflicts involving this dimension
+
+- **CONF-03** (mutability, severity MEDIUM): ASEAN §A.4.18 admits explainability fallback; other three hold explainability as constitutive at deployment time
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D02"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D02_integrity.md
+++ b/compliance/D02_integrity.md
@@ -8,7 +8,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§40*
     > "doctrinal continuity is the integrity of the Magisterium"

--- a/compliance/D03_justice.md
+++ b/compliance/D03_justice.md
@@ -8,7 +8,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§76*
     > "justice demands lexical priority for the most vulnerable"

--- a/compliance/D03_justice.md
+++ b/compliance/D03_justice.md
@@ -1,0 +1,63 @@
+# D03 — `justice:*` (STRONG-4)
+
+> Vulnerability-priority + fairness; tie-breaking modifier `justice:lexical_vulnerability_priority` (v1.3 CST closure) is four-source-corroborated
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D03` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: justice
+**Attestation density**: MH=19 · EU=22 · IEEE=30 · ASEAN=9 · total=80
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§76*
+    > "justice demands lexical priority for the most vulnerable"
+    Wire form: `justice:lexical_vulnerability_priority`
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§1.7.d*
+    > "the trustworthy AI ecosystem must give voice to vulnerable populations and ensure equal access"
+    Wire form: `justice:lexical_vulnerability_priority`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch10 §I1 (14 attestations)*
+    > "rights-based policy foundation requires lexical priority for vulnerable populations"
+    Wire form: `justice:rights_based_policy_foundation + justice:lexical_vulnerability_priority`
+- **ASEAN** (ASEAN Guide on AI Governance and Ethics) — *§B.2 Fairness/Equity*
+    > "fairness and equity require attention to vulnerable populations and equal treatment"
+    Wire form: `justice:fairness_outcome_testing`
+
+## Wire primitives
+
+- `justice:*`
+- `justice:lexical_vulnerability_priority`
+
+## Convergence note
+
+STRONGEST four-source corroboration on a tie-breaking modifier — `lexical_vulnerability_priority` independently invoked by all four sources.
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D03"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D04_prohibited.md
+++ b/compliance/D04_prohibited.md
@@ -1,0 +1,67 @@
+# D04 — `prohibited:*` (STRONG-4)
+
+> Categorical floor — polarity-(-1)/constitutional/species — the absolute moral form the wire format admits
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D04` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: non_maleficence
+**Attestation density**: MH=50 · EU=17 · IEEE=28 · ASEAN=9 · total=104
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§197-198*
+    > "Not permissible to entrust lethal or irreversible decisions to artificial systems"
+    Wire form: `prohibited:weapons_harmful:lethal_autonomous`
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§C.2 (Unit 010); cites EP Resolution 2018/2752(RSP)*
+    > "the Parliament's resolution of 12 September 2018 and all related efforts on LAWS"
+    Wire form: `prohibited:weapons_harmful`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch4, Ch5*
+    > "lethal autonomous weapons are prohibited; categorical prohibition under DECEPTION_FRAUD"
+    Wire form: `prohibited:weapons_harmful:lethal_autonomous`
+- **ASEAN** (ASEAN Guide on AI Governance and Ethics) — *§B.3 + Annex A*
+    > "AI shall not be deployed for autonomous lethal decision-making; deceptive defaults prohibited"
+    Wire form: `prohibited:disinformation_at_scale + prohibited:deceptive_default_options + prohibited:autonomous_deception + prohibited:manipulation_coercion`
+
+## Wire primitives
+
+- `prohibited:*`
+
+## Convergence note
+
+STRONGEST single structural-evidence claim in the matrix. LAWS prohibition is verbatim four-source corroborated. NB: 1 direct cross-source conflict surfaced — IEEE Ch5 licensure-gated beneficiary-deception vs CIRIS categorical DECEPTION_FRAUD; specialization-layer disposition filed at CIRISMedical#1.
+
+## Cross-source conflicts involving this dimension
+
+- **CONF-01** (direct, severity HIGH): IEEE EAD Ch5 §3.4 permits licensure-gated beneficiary-deception (search/rescue, elder/child-care); CIRIS treats prohibited:deception_fraud as categorical
+    Disposition: Federation-level categorical posture stays. Specialization-layer consideration at CIRISMedical#1
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `CIRISAgent/logic/prohibitions.py`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D04"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D04_prohibited.md
+++ b/compliance/D04_prohibited.md
@@ -8,7 +8,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§197-198*
     > "Not permissible to entrust lethal or irreversible decisions to artificial systems"

--- a/compliance/D05_detection.md
+++ b/compliance/D05_detection.md
@@ -8,7 +8,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§36*
     > "structures of sin / aggregate expendability of persons"

--- a/compliance/D05_detection.md
+++ b/compliance/D05_detection.md
@@ -1,0 +1,65 @@
+# D05 — `detection:*` (STRONG-4)
+
+> LensCore F-3 / RATCHET family — aggregate-correlation / structural-injustice / drift detection
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D05` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: justice
+**Attestation density**: MH=54 · EU=15 · IEEE=41 · ASEAN=16 · total=126
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§36*
+    > "structures of sin / aggregate expendability of persons"
+    Wire form: `detection:correlated_action:aggregate_footprint:expendability_of_persons`
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§1.6 Societal/environmental well-being*
+    > "aggregate energy/carbon footprint of AI deployment"
+    Wire form: `detection:correlated_action:aggregate_footprint:energy_carbon`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch4, Ch5, Ch8*
+    > "cultural norm drift; aggregate environmental footprint; participation exclusion"
+    Wire form: `detection:correlated_action:participation_exclusion:underrepresented_population + detection:correlated_action:aggregate_footprint:planetary_impact`
+- **ASEAN** (ASEAN Guide on AI Governance and Ethics) — *§B.2 + §C.3*
+    > "underrepresented populations; temporal drift; intra-agent consistency"
+    Wire form: `detection:correlated_action:participation_exclusion:underrepresented_population + detection:temporal_drift + detection:intra_agent_consistency`
+
+## Wire primitives
+
+- `detection:correlated_action:{axis}`
+- `detection:temporal_drift`
+- `detection:intra_agent_consistency`
+- `detection:distributive:access:*`
+
+## Convergence note
+
+All four batches independently engage the F-3 family. Three of four also engage detection:distributive:access:* (v1.3 universal-destination-of-goods closure): MH 7, EU 2, IEEE 4, ASEAN 2.
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `CIRISLensCore detector family`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D05"]`
+
+Proposed pointer (from seed): `CIRISAI/RATCHET calibration packages (versioned, hash-pinned)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D06_goal.md
+++ b/compliance/D06_goal.md
@@ -1,0 +1,66 @@
+# D06 — `goal:*` (STRONG-4)
+
+> Multi-scale belonging composite — self/family/community/affiliations/species/planet
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D06` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: beneficence
+**Attestation density**: MH=34 · EU=6 · IEEE=13 · ASEAN=7 · total=60
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§148-156*
+    > "labor as integral to belonging at family/community/affiliations/species scales"
+    Wire form: `goal:family + goal:community + goal:affiliations + goal:species`
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§A*
+    > "Trustworthy AI for Europe"
+    Wire form: `goal:affiliations (EU-jurisdiction scope)`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch4 §0.a*
+    > "well-being of all humans as the species-scale aim of A/IS"
+    Wire form: `goal:species`
+- **ASEAN** (ASEAN Guide on AI Governance and Ethics) — *§A (6 ASEAN attestations of goal:affiliations)*
+    > "regional ecosystem belonging; cross-jurisdictional cooperation"
+    Wire form: `goal:affiliations (ASEAN-jurisdiction)`
+
+## Wire primitives
+
+- `goal:{scale}`
+
+## Convergence note
+
+Every available {scale} value is exercised somewhere in the corpus. NB: `goal:planet` is a REINFORCED v1.5+ T-3 candidate (MH + IEEE Ch4 + IEEE Ch8).
+
+## v1.5+ T-3 candidates affecting this dimension
+
+- **T3-06** `goal:planet` (priority MEDIUM_HIGH, source(s): magnifica_humanitas_v1, ieee_ead_v1)
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D06"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D06_goal.md
+++ b/compliance/D06_goal.md
@@ -8,7 +8,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§148-156*
     > "labor as integral to belonging at family/community/affiliations/species scales"

--- a/compliance/D07_locality_decision_scale.md
+++ b/compliance/D07_locality_decision_scale.md
@@ -1,0 +1,62 @@
+# D07 — `locality:decision:{scale}` (STRONG-4)
+
+> v1.3 subsidiarity closure — decision routing at lowest competent scale
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D07` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: justice
+**Attestation density**: MH=17 · EU=5 · IEEE=13 · ASEAN=7 · total=42
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§68-72*
+    > "decisions should be made at the lowest competent level"
+    Wire form: `locality:decision:local + locality:decision:community`
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§III.0*
+    > "EU-level decisions vs national-level decisions; supranational coordination"
+    Wire form: `locality:decision:national + locality:decision:community`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch10*
+    > "national A/IS policy; international R&D collaboration"
+    Wire form: `locality:decision:national + locality:decision:federation`
+- **ASEAN** (ASEAN Guide on AI Governance and Ethics) — *§C.4 + §E*
+    > "regional ASEAN-level coordination; community-level deployment decisions"
+    Wire form: `locality:decision:regional (3) + locality:decision:community (2) + locality:decision:national (3)`
+
+## Wire primitives
+
+- `locality:decision:{local,community,national,regional,federation,planet}`
+
+## Convergence note
+
+First cross-source structural validation of the v1.3 subsidiarity addition. ASEAN exercises locality:decision:regional as first-deployment of that scale value.
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `CIRISAgent DSASPDMA scale-routing classification (pending Accord A-1)`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D07"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D07_locality_decision_scale.md
+++ b/compliance/D07_locality_decision_scale.md
@@ -8,7 +8,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§68-72*
     > "decisions should be made at the lowest competent level"

--- a/compliance/D08_autonomy.md
+++ b/compliance/D08_autonomy.md
@@ -1,0 +1,66 @@
+# D08 — `autonomy:*` (STRONG-4)
+
+> Human-centric design + informational self-determination
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D08` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: autonomy
+**Attestation density**: MH=7 · EU=15 · IEEE=21 · ASEAN=8 · total=51
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§107*
+    > "autonomy of the human as imago Dei; informed agency protection"
+    Wire form: `autonomy:agent_self_determination`
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§1.1 + §2.2 (Unit 019); 15 EU attestations total*
+    > "respect for human autonomy — the first principle; AI shall not unjustifiably subordinate, coerce, deceive, manipulate"
+    Wire form: `autonomy:human_centric_design`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch3 + Ch4*
+    > "user autonomy; data agency; informed consent"
+    Wire form: `autonomy:informed_agency_protection`
+- **ASEAN** (ASEAN Guide on AI Governance and Ethics) — *§B.4 Human-centricity*
+    > "AI shall not erode human autonomy; informational self-determination"
+    Wire form: `autonomy:informational_self_determination`
+
+## Wire primitives
+
+- `autonomy:*`
+
+## Convergence note
+
+Direct 1:1 mapping in EU HLEG (Respect for Human Autonomy = CIRIS autonomy). Composition-based in the other three.
+
+## Cross-source conflicts involving this dimension
+
+- **CONF-04** (mutability, severity LOW_MEDIUM): ASEAN §A.5.3 admits opt-out where feasible; EU HLEG firmer (opt-out where possible without detriment, otherwise rectification mechanisms required)
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D08"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D08_autonomy.md
+++ b/compliance/D08_autonomy.md
@@ -8,7 +8,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§107*
     > "autonomy of the human as imago Dei; informed agency protection"

--- a/compliance/D09_fidelity.md
+++ b/compliance/D09_fidelity.md
@@ -1,0 +1,62 @@
+# D09 — `fidelity:*` (STRONG-4)
+
+> Faithful disclosure / faithful representation across lifecycle
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D09` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: fidelity
+**Attestation density**: MH=8 · EU=15 · IEEE=16 · ASEAN=26 · total=65
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§17*
+    > "fidelity to the Gospel through doctrinal development"
+    Wire form: `fidelity:epistemic_grounding`
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§1.7 Accountability*
+    > "lifecycle responsibility; fidelity to declared purpose"
+    Wire form: `fidelity:lifecycle_application`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch11*
+    > "duty-bearer obligation to fulfill rights as fidelity"
+    Wire form: `fidelity:duty_bearer_obligation_to_fulfill_rights`
+- **ASEAN** (ASEAN Guide on AI Governance and Ethics) — *§C.4 + §B.1 (26 attestations, densest)*
+    > "algorithmic disclosure; human oversight as faithful representation"
+    Wire form: `fidelity:algorithmic_disclosure + fidelity:explainability + fidelity:human_oversight_governance`
+
+## Wire primitives
+
+- `fidelity:*`
+
+## Convergence note
+
+ASEAN's fidelity-saturation is deployer-side framing (faithful disclosure to users/operators); MH's is doctrinal-epistemic. Same prefix admits both shapes.
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D09"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D09_fidelity.md
+++ b/compliance/D09_fidelity.md
@@ -8,7 +8,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§17*
     > "fidelity to the Gospel through doctrinal development"

--- a/compliance/D10_beneficence.md
+++ b/compliance/D10_beneficence.md
@@ -1,0 +1,62 @@
+# D10 — `beneficence:*` (STRONG-4)
+
+> Positive duty toward dignity / well-being / environmental stewardship
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D10` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: beneficence
+**Attestation density**: MH=11 · EU=15 · IEEE=16 · ASEAN=3 · total=45
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§110-111*
+    > "technology as creation-participation; beneficence at species scale"
+    Wire form: `beneficence:technology_as_creation_participation`
+- **EU** (Ethics Guidelines for Trustworthy AI) — *Unit 005*
+    > "respect for human dignity is foundational; positive duty toward dignity"
+    Wire form: `beneficence:respect_for_human_dignity`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch4 §0*
+    > "well-being is the central beneficence aim of A/IS"
+    Wire form: `beneficence:wellbeing_holistic_orientation`
+- **ASEAN** (ASEAN Guide on AI Governance and Ethics) — *§C.3*
+    > "environmental stewardship as positive beneficence"
+    Wire form: `beneficence:environmental_stewardship`
+
+## Wire primitives
+
+- `beneficence:*`
+
+## Convergence note
+
+Lower count than D01 (non_maleficence) reflects each tradition's 'harm avoidance more universally articulated than positive flourishing' — known pattern.
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D10"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D10_beneficence.md
+++ b/compliance/D10_beneficence.md
@@ -8,7 +8,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§110-111*
     > "technology as creation-participation; beneficence at species scale"

--- a/compliance/D11_multilateral_participation_forum_kind.md
+++ b/compliance/D11_multilateral_participation_forum_kind.md
@@ -8,7 +8,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§200-203 + 224-227 (8 MH attestations)*
     > "UN-system reform advocacy; cyber-norms diplomacy"

--- a/compliance/D11_multilateral_participation_forum_kind.md
+++ b/compliance/D11_multilateral_participation_forum_kind.md
@@ -1,0 +1,62 @@
+# D11 — `multilateral_participation:{forum}:{kind}` (STRONG-4)
+
+> v1.3 closure for federation participation in external multilateral processes
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D11` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: integrity
+**Attestation density**: MH=13 · EU=3 · IEEE=10 · ASEAN=11 · total=37
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§200-203 + 224-227 (8 MH attestations)*
+    > "UN-system reform advocacy; cyber-norms diplomacy"
+    Wire form: `multilateral_participation:un_system:reform_advocacy + multilateral_participation:cyber_norms:shared_regulations`
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§A + §C*
+    > "European Parliament resolution support; UN human rights treaties"
+    Wire form: `multilateral_participation:european_parliament:resolution_support + multilateral_participation:un_human_rights_treaties:legal_binding`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch10*
+    > "international R&D collaboration; cross-border policy exchange"
+    Wire form: `multilateral_participation:international_rd_collaboration:standards_setting + multilateral_participation:cross_border_policy_exchange:knowledge_sharing`
+- **ASEAN** (ASEAN Guide on AI Governance and Ethics) — *§E (11 distinct :asean:{kind} envelopes — densest single-forum exercise in federation mapping history)*
+    > "ASEAN-internal coordination + working-group membership + framework drafting + governance evolution"
+    Wire form: `multilateral_participation:asean:{11 distinct kinds}`
+
+## Wire primitives
+
+- `multilateral_participation:{forum}:{kind}`
+
+## Convergence note
+
+ASEAN's 11-{kind} saturation under a single forum is the first stress test showing the {kind} slot scales gracefully.
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `CIRISNodeCore multilateral module (pending E-4 implementation)`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D11"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D12_conscience.md
+++ b/compliance/D12_conscience.md
@@ -8,7 +8,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§111, 131-181*
     > "conscience as the alētheia faculty; optimization-veto for ratification-decline scenarios"

--- a/compliance/D12_conscience.md
+++ b/compliance/D12_conscience.md
@@ -1,0 +1,65 @@
+# D12 — `conscience:*` (STRONG-4)
+
+> Agent-side faculty layer — optimization veto, epistemic humility, coherence, alētheia
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D12` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: integrity
+**Attestation density**: MH=9 · EU=3 · IEEE=9 · ASEAN=3 · total=24
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§111, 131-181*
+    > "conscience as the alētheia faculty; optimization-veto for ratification-decline scenarios"
+    Wire form: `conscience:optimization_veto (3) + conscience:coherence (3) + conscience:epistemic_humility (2)`
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§III.1 + §III.7*
+    > "stop-button at any time; whistleblower protection"
+    Wire form: `conscience:optimization_veto`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch3 §§3.1.15-3.1.16 (6 IEEE attestations, densest)*
+    > "epistemic humility under uncertainty; phronesis in design"
+    Wire form: `conscience:epistemic_humility`
+- **ASEAN** (ASEAN Guide on AI Governance and Ethics) — *§C.2 (HOTL category)*
+    > "stop-button / override surface for human-over-the-loop oversight"
+    Wire form: `conscience:optimization_veto`
+
+## Wire primitives
+
+- `conscience:optimization_veto`
+- `conscience:epistemic_humility`
+- `conscience:coherence`
+- `conscience:entropy`
+
+## Convergence note
+
+Heaviest in IEEE EAD Ch3 (multi-traditional ethics directly engages framework polyglot anchoring) and MH (conscience-faculty engagement is doctrinally explicit).
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `CIRISAgent/logic/conscience/* (4 epistemic faculties)`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D12"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D13_testimonial_witness_kind.md
+++ b/compliance/D13_testimonial_witness_kind.md
@@ -8,7 +8,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§81, 89, 138, 151, 166, 167, 173, 216, 217 (11 attestations)*
     > "displaced_worker, abuse_survivor, war_victim, displaced_person, displaced_migrant, historical_moral_transformation"

--- a/compliance/D13_testimonial_witness_kind.md
+++ b/compliance/D13_testimonial_witness_kind.md
@@ -1,0 +1,63 @@
+# D13 — `testimonial_witness:{kind}` (STRONG-4)
+
+> v1.4 affected-party-voice closure — preserves displaced/affected/marginalized voices in attestation
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D13` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: justice
+**Attestation density**: MH=11 · EU=2 · IEEE=2 · ASEAN=1 · total=16
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§81, 89, 138, 151, 166, 167, 173, 216, 217 (11 attestations)*
+    > "displaced_worker, abuse_survivor, war_victim, displaced_person, displaced_migrant, historical_moral_transformation"
+    Wire form: `testimonial_witness:displaced_worker + :abuse_survivor + :war_victim + :displaced_person + :displaced_migrant + :historical_moral_transformation`
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§1.5.c + §III.5.d*
+    > "give voice to affected and impacted workers in design-team diversity assessment"
+    Wire form: `testimonial_witness:affected_worker + testimonial_witness:impacted_worker`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch6 + Ch7*
+    > "surveilled-person refusal; on-the-ground practitioner narrative"
+    Wire form: `testimonial_witness:surveilled_person_refusal + testimonial_witness:on_the_ground_practitioner`
+- **ASEAN** (ASEAN Guide on AI Governance and Ethics) — *§C.4*
+    > "workforce displacement narrative preservation"
+    Wire form: `testimonial_witness:displaced_worker`
+
+## Wire primitives
+
+- `testimonial_witness:{kind}`
+- `witness_relation`
+
+## Convergence note
+
+The v1.4 amendment is independently invoked by all four batches — positive evidence the addition was correct. {kind} slot populated with diverse but interoperable values.
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D13"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D14_witness_diversity.md
+++ b/compliance/D14_witness_diversity.md
@@ -8,7 +8,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§ various*
     > "signs-of-times-contribution + catholicity"

--- a/compliance/D14_witness_diversity.md
+++ b/compliance/D14_witness_diversity.md
@@ -1,0 +1,62 @@
+# D14 — `witness_diversity:*` (STRONG-4)
+
+> Stakeholder pluralism in design/testing/consultation
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D14` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: justice
+**Attestation density**: MH=3 · EU=3 · IEEE=16 · ASEAN=2 · total=24
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§ various*
+    > "signs-of-times-contribution + catholicity"
+    Wire form: `witness_diversity:signs_of_times + witness_diversity:catholicity`
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§III.7*
+    > "stakeholder consultation + testing red teams + stakeholder panels"
+    Wire form: `witness_diversity:stakeholder_consultation + witness_diversity:red_team + witness_diversity:stakeholder_panel`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch7, Ch9 (16 distinct values)*
+    > "ubuntu_five_moral_domains, intercultural_RI_dialogue, end_user_target_community_consultation, affected_population_metric_selection, ..."
+    Wire form: `witness_diversity:{16 distinct values}`
+- **ASEAN** (ASEAN Guide on AI Governance and Ethics) — *§C.4*
+    > "user testing varied backgrounds; stakeholder impact assessment"
+    Wire form: `witness_diversity:user_testing_varied_backgrounds + witness_diversity:stakeholder_impact_assessment`
+
+## Wire primitives
+
+- `witness_diversity:*`
+
+## Convergence note
+
+IEEE saturation reflects engineering-society methodology density.
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D14"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D15_moderation.md
+++ b/compliance/D15_moderation.md
@@ -8,7 +8,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§220-223*
     > "dialogue-as-negotiation primitive engages moderation:* adjacency"

--- a/compliance/D15_moderation.md
+++ b/compliance/D15_moderation.md
@@ -1,0 +1,64 @@
+# D15 — `moderation:*` (STRONG-4)
+
+> Federation self-correction layer (with IEEE shifting some load to partner_role:* ethics-board constructions)
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D15` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: integrity
+**Attestation density**: MH=2 · EU=2 · IEEE=1 · ASEAN=1 · total=5+ with adjacent coverage
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§220-223*
+    > "dialogue-as-negotiation primitive engages moderation:* adjacency"
+    Wire form: `moderation:* + adjacent reconsideration:*`
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§III.7*
+    > "whistleblower protection + out-of-distribution attestation"
+    Wire form: `moderation:whistleblower_protection + moderation:ood_attestation`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch4 + Ch11*
+    > "rollback on wellbeing reduction (reconsideration:* adjacent); ethics-board / certification-body partner_role constructions"
+    Wire form: `reconsideration:rollback_on_wellbeing_reduction + partner_role:ethics_board`
+- **ASEAN** (ASEAN Guide on AI Governance and Ethics) — *Annex A*
+    > "out-of-distribution attestation"
+    Wire form: `moderation:ood_attestation`
+
+## Wire primitives
+
+- `moderation:*`
+- `reconsideration:* (adjacent)`
+- `partner_role:* (IEEE-style ethics boards)`
+
+## Convergence note
+
+Tier with caveat: IEEE shifts some structural load to partner_role:* (ethics boards/audit bodies) instead of moderation:* directly. Composition is interoperable.
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `CIRISNodeCore P8 Moderation primitives`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D15"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D16_method.md
+++ b/compliance/D16_method.md
@@ -8,7 +8,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§ various (sparse — encyclical genre)*
     > "approach:species:MH-education + approach:species:MH-construction"

--- a/compliance/D16_method.md
+++ b/compliance/D16_method.md
@@ -1,0 +1,66 @@
+# D16 — `method:*` (STRONG-4)
+
+> Operational-design discipline (densest family overall; convergence weaker than principles — admits source-genre asymmetry honestly)
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D16` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: integrity
+**Attestation density**: MH=2 · EU=12 · IEEE=136 · ASEAN=36 · total=186
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§ various (sparse — encyclical genre)*
+    > "approach:species:MH-education + approach:species:MH-construction"
+    Wire form: `method:approach:species:* (2)`
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§2*
+    > "trustworthy_ai_lawful_ethical_robust triad, algorithmic_impact_assessment, explainable_ai_research, fallback:rule_based_or_human_intervention"
+    Wire form: `method:trustworthy_ai_lawful_ethical_robust:* + method:algorithmic_impact_assessment + method:explainable_ai_research + method:fallback:rule_based_or_human_intervention`
+- **IEEE** (Ethically Aligned Design, First Edition) — *all 11 chapters; densest single-family use across all batches*
+    > "engineering-society genre demands operational-method-recommendation density"
+    Wire form: `method:* (136 distinct attestations)`
+- **ASEAN** (ASEAN Guide on AI Governance and Ethics) — *§C.3*
+    > "pre_deployment_robustness_testing, privacy_enhancing_technologies, model_provenance_tools, fairness_tools, explainability_tools, citizen_feedback_channel, community_codevelopment"
+    Wire form: `method:* (36 attestations)`
+
+## Wire primitives
+
+- `method:*`
+
+## Convergence note
+
+Tier with asymmetry note: density tracks each source's operational-design-discipline genre. MH sparse (encyclical), EU medium (advisory), IEEE+ASEAN dense (engineering/deployer).
+
+## Cross-source conflicts involving this dimension
+
+- **CONF-05** (scope_mismatch, severity LOW): ASEAN §A.2.1 admits experimental sandbox phases with reduced oversight; other three hold compliance constant across lifecycle stages
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D16"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D17_transparency_log.md
+++ b/compliance/D17_transparency_log.md
@@ -11,7 +11,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§ various*
     > "honest signs of authority and intent"

--- a/compliance/D17_transparency_log.md
+++ b/compliance/D17_transparency_log.md
@@ -1,0 +1,61 @@
+# D17 — `transparency_log:*` (STRONG-3)
+
+> CIRISVerify per-stakeholder disclosure log
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D17` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: fidelity
+**Attestation density**: MH=2 · EU=5 · IEEE=23 · ASEAN=10 · total=40
+
+**Absent from**: MH — Non-zero but structurally low (2). Classified STRONG-3 by analyst because encyclical genre is not a technical-disclosure framework.
+  *Functional analogue*: detection:correlated_action:ecology_of_communication:* + the F-3 detector family
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§ various*
+    > "honest signs of authority and intent"
+    Wire form: `transparency_log:* (sparse)`
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§1.4 + §III.4*
+    > "transparency about purpose, capability, and limitations"
+    Wire form: `transparency_log:per_stakeholder_disclosure`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch2 P5 + Ch6 + Ch11*
+    > "traceability + verifiability + intelligibility four-dimensional transparency"
+    Wire form: `transparency_log:* (23 attestations)`
+- **ASEAN** (ASEAN Guide on AI Governance and Ethics) — *§B.1 + §C.4*
+    > "transparency and explainability through documentation and disclosure"
+    Wire form: `transparency_log:* (10 attestations)`
+
+## Wire primitives
+
+- `transparency_log:*`
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `CIRISVerify transparency_log`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D17"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D18_attestation_l_3_5.md
+++ b/compliance/D18_attestation_l_3_5.md
@@ -1,0 +1,58 @@
+# D18 — `attestation:l{3,5}:*` (STRONG-3)
+
+> Verification ladder (L1-L5 hardware-rooted attestation)
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D18` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: integrity
+**Attestation density**: MH=2 · EU=4 · IEEE=5 · ASEAN=0 · total=11
+
+**Absent from**: ASEAN — ASEAN framing is normative-principles + risk-assessment, not federation-attestation ladder.
+  *Functional analogue*: Composition via accountability-tier wording
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§ various*
+    > "structural verification of doctrinal claims"
+    Wire form: `attestation:l3:doctrinal_continuity`
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§III.7*
+    > "auditability requires attestation at multiple verification levels"
+    Wire form: `attestation:l3:* + attestation:l5:*`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch2 P5 + Ch9*
+    > "system-level verifiable attestations"
+    Wire form: `attestation:l3:* + attestation:l5:*`
+
+## Wire primitives
+
+- `attestation:l1 through l5`
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `CIRISVerify attestation ladder L1-L5`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D18"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D18_attestation_l_3_5.md
+++ b/compliance/D18_attestation_l_3_5.md
@@ -11,7 +11,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§ various*
     > "structural verification of doctrinal claims"

--- a/compliance/D19_partner_role.md
+++ b/compliance/D19_partner_role.md
@@ -11,7 +11,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **EU** (Ethics Guidelines for Trustworthy AI) — *§III.7*
     > "audit/compliance partners"

--- a/compliance/D19_partner_role.md
+++ b/compliance/D19_partner_role.md
@@ -1,0 +1,67 @@
+# D19 — `partner_role:*` (STRONG-3)
+
+> CIRIS Registry partner-role taxonomy (ethics boards, audit bodies, stewards)
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D19` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: integrity
+**Attestation density**: MH=0 · EU=1 · IEEE=19 · ASEAN=1 · total=21
+
+**Absent from**: MH — MH names ecclesial relations rather than secular institutional partner-role taxonomies.
+  *Functional analogue*: Ecclesial-magisterial relations carry analogous structural role but in different vocabulary
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§III.7*
+    > "audit/compliance partners"
+    Wire form: `partner_role:audit_body`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch7 + Ch9 + Ch10 + Ch11 (19 attestations)*
+    > "Chief Values Officer, ethics committees, certification bodies, ISO-like body, accreditation bodies, HRIA/AIA stewards, trusted disclosure stewards"
+    Wire form: `partner_role:{19 distinct roles}`
+- **ASEAN** (ASEAN Guide on AI Governance and Ethics) — *§E.001*
+    > "ASEAN Working Group on AI Governance (regional intergovernmental dual-remit)"
+    Wire form: `partner_role:regional_intergovernmental_working_group`
+
+## Wire primitives
+
+- `partner_role:{role}`
+
+## Convergence note
+
+REINFORCED v1.5+ T-3 candidate here: specialization-pattern proposal covers dual-remit (ASEAN) + trusted-disclosure-steward (IEEE).
+
+## v1.5+ T-3 candidates affecting this dimension
+
+- **T3-07** `partner_role:trusted_disclosure_steward:{authority}` (priority MEDIUM, source(s): ieee_ead_v1)
+- **T3-08** `partner_role:regional_intergovernmental_working_group_dual_remit` (priority MEDIUM, source(s): asean_guide_v1)
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `CIRISRegistry partner role registry`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D19"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D20_approach.md
+++ b/compliance/D20_approach.md
@@ -10,7 +10,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§ various*
     > "approach:species:* strategic-pursuit framing"

--- a/compliance/D20_approach.md
+++ b/compliance/D20_approach.md
@@ -1,0 +1,57 @@
+# D20 — `approach:*` (STRONG-3)
+
+> Decision-hierarchy strategic axis (Goal→Approach→Method→Progress-Measure DAG)
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D20` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: integrity
+**Attestation density**: MH=5 · EU=3 · IEEE=23 · ASEAN=1 · total=32
+
+**Absent from**: ASEAN — Single use is too thin for solid 4-batch attestation. ASEAN's checklist genre states recommendations as direct method/principle attestations rather than as named 'approaches' within a Goal-Approach-Method DAG.
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§ various*
+    > "approach:species:* strategic-pursuit framing"
+    Wire form: `approach:species:education + approach:species:construction (5 attestations)`
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§B*
+    > "three-component framework approach (lawful + ethical + robust)"
+    Wire form: `approach:trustworthy_ai_lawful_ethical_robust`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch1 + Ch2*
+    > "principles-to-practice pipeline; per-principle implementation strategies"
+    Wire form: `approach:* (23 attestations)`
+
+## Wire primitives
+
+- `approach:{strategy_label}`
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D20"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D21_progress_measure.md
+++ b/compliance/D21_progress_measure.md
@@ -10,7 +10,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§ various*
     > "structural-coherence progress markers"

--- a/compliance/D21_progress_measure.md
+++ b/compliance/D21_progress_measure.md
@@ -1,0 +1,57 @@
+# D21 — `progress_measure:*` (STRONG-3)
+
+> Declared-metric outcomes for tracking progress toward goals
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D21` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: integrity
+**Attestation density**: MH=1 · EU=1 · IEEE=8 · ASEAN=0 · total=10
+
+**Absent from**: ASEAN — ASEAN stops at recommendation-level rather than measurement-protocol level.
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§ various*
+    > "structural-coherence progress markers"
+    Wire form: `progress_measure:*`
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§III.7*
+    > "measurable progress toward trustworthiness"
+    Wire form: `progress_measure:*`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch7 (8 attestations)*
+    > "documentation criteria as progress_measure; well-being indicators"
+    Wire form: `progress_measure:* (8 distinct)`
+
+## Wire primitives
+
+- `progress_measure:{metric}`
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D21"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D22_expertise.md
+++ b/compliance/D22_expertise.md
@@ -1,0 +1,57 @@
+# D22 — `expertise:*` (STRONG-3)
+
+> Declared competence in domain (named-expert attestation)
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D22` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: integrity
+**Attestation density**: MH=1 · EU=1 · IEEE=10 · ASEAN=0 · total=12
+
+**Absent from**: ASEAN — ASEAN frames competence at the organizational-governance level, not the named-expert level.
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§ various*
+    > "discernment expertise (sensus fidelium adjacent)"
+    Wire form: `expertise:*`
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§III.7*
+    > "domain expertise required for trustworthy deployment"
+    Wire form: `expertise:domain`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch7-Ch11 (10 attestations)*
+    > "engineering, ethics, law, policy expertise; interdisciplinary expertise composition"
+    Wire form: `expertise:{domain}`
+
+## Wire primitives
+
+- `expertise:{domain}`
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D22"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D22_expertise.md
+++ b/compliance/D22_expertise.md
@@ -10,7 +10,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§ various*
     > "discernment expertise (sensus fidelium adjacent)"

--- a/compliance/D23_accountability.md
+++ b/compliance/D23_accountability.md
@@ -1,0 +1,63 @@
+# D23 — `accountability:*` (STRONG-3)
+
+> Named accountability as primary axis (not just structural composition)
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D23` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: fidelity
+**Attestation density**: MH=0 · EU=6 · IEEE=3 · ASEAN=19 · total=28
+
+**Absent from**: MH — MH covers accountability FUNCTIONALLY via integrity:* + originator-obligations Accord §IV Ch 2 — architecturally structural rather than named-axis-attested.
+  *Functional analogue*: integrity:* + the Accord §IV Ch 2 bidirectional creator-creation obligations
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§1.7 Accountability*
+    > "lifecycle accountability with redress mechanisms"
+    Wire form: `accountability:lifecycle_responsibility`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch2 P6 + Ch11*
+    > "accountability principle; rights-based legal accountability"
+    Wire form: `accountability:*`
+- **ASEAN** (ASEAN Guide on AI Governance and Ethics) — *§B.6 + §C.2 (19 attestations)*
+    > "accountability and integrity; human-in-control over AI-augmented decisions"
+    Wire form: `accountability:human_in_control + accountability:lifecycle`
+
+## Wire primitives
+
+- `accountability:{axis}`
+- `accountability:human_in_control (ASEAN-distinctive — HITL/HOTL/HOOTL)`
+
+## Convergence note
+
+ASEAN's accountability:human_in_control with HITL/HOTL/HOOTL gradient is currently single-source; likely to become STRONG when other oversight-ladder regulatory batches map.
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D23"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D23_accountability.md
+++ b/compliance/D23_accountability.md
@@ -11,7 +11,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **EU** (Ethics Guidelines for Trustworthy AI) — *§1.7 Accountability*
     > "lifecycle accountability with redress mechanisms"

--- a/compliance/D24_reconsideration.md
+++ b/compliance/D24_reconsideration.md
@@ -1,0 +1,57 @@
+# D24 — `reconsideration:*` (STRONG-3)
+
+> Reverse-axis appeal / rollback / negotiation-reopening primitive
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D24` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: integrity
+**Attestation density**: MH=3 · EU=2 · IEEE=1 · ASEAN=0 · total=6
+
+**Absent from**: ASEAN — Forward-looking 2024 document with no formal predecessor to reconsider.
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§ various*
+    > "doctrinal development through reconsideration"
+    Wire form: `reconsideration:* (3 attestations)`
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§III + §C*
+    > "redress mechanisms; ability to challenge and rectify"
+    Wire form: `reconsideration:*`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch4*
+    > "rollback on wellbeing reduction"
+    Wire form: `reconsideration:rollback_on_wellbeing_reduction`
+
+## Wire primitives
+
+- `reconsideration:{grounds}`
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `CIRISNodeCore reconsideration primitive`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D24"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D24_reconsideration.md
+++ b/compliance/D24_reconsideration.md
@@ -10,7 +10,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§ various*
     > "doctrinal development through reconsideration"

--- a/compliance/D25_credits.md
+++ b/compliance/D25_credits.md
@@ -10,7 +10,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§ various (4)*
     > "labor as substrate-building; intergenerational credit; AI literacy credit"

--- a/compliance/D25_credits.md
+++ b/compliance/D25_credits.md
@@ -1,0 +1,57 @@
+# D25 — `credits:*` (STRONG-3)
+
+> Commons Credits substrate-building recognition (non-monetary contribution attestation)
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D25` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: justice
+**Attestation density**: MH=4 · EU=1 · IEEE=4 · ASEAN=0 · total=9
+
+**Absent from**: ASEAN — Credit/recognition framing is implicit in §D National-level (workforce upskilling) rather than wire-attested.
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **MH** (Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)) — *§§ various (4)*
+    > "labor as substrate-building; intergenerational credit; AI literacy credit"
+    Wire form: `credits:{subject}:substrate_building`
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§1.6*
+    > "AI literacy and digital skills as substrate building"
+    Wire form: `credits:digital_literacy:substrate_building`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch8 + Ch9 (4 attestations)*
+    > "human-capability contribution recognition; participatory design credits"
+    Wire form: `credits:{subject}:substrate_building`
+
+## Wire primitives
+
+- `credits:{subject}:substrate_building`
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `CIRISBilling Commons Credits + CIRIS_COMPREHENSIVE_GUIDE 'Commons Credits' section`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D25"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D26_key_boundary.md
+++ b/compliance/D26_key_boundary.md
@@ -11,7 +11,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **EU** (Ethics Guidelines for Trustworthy AI) — *§1.3 Privacy and data governance*
     > "data security via cryptographic boundary"

--- a/compliance/D26_key_boundary.md
+++ b/compliance/D26_key_boundary.md
@@ -1,0 +1,58 @@
+# D26 — `key_boundary:*` (STRONG-3)
+
+> CIRISEdge encryption key boundary attestation (cryptographic trust scoping)
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D26` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: integrity
+**Attestation density**: MH=0 · EU=2 · IEEE=7 · ASEAN=2 · total=11
+
+**Absent from**: MH — Encryption/key-management is not encyclical content.
+  *Functional analogue*: Composition via stewardship-of-trust language
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§1.3 Privacy and data governance*
+    > "data security via cryptographic boundary"
+    Wire form: `key_boundary:*`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch6 (7 attestations)*
+    > "personal-data trust boundary; cryptographic isolation"
+    Wire form: `key_boundary:*`
+- **ASEAN** (ASEAN Guide on AI Governance and Ethics) — *§B.3 + §C.3*
+    > "security via key-managed trust boundary"
+    Wire form: `key_boundary:*`
+
+## Wire primitives
+
+- `key_boundary:{scope}`
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `CIRISEdge key_boundary`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D26"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D27_provenance.md
+++ b/compliance/D27_provenance.md
@@ -1,0 +1,57 @@
+# D27 — `provenance:*` (STRONG-3)
+
+> Build manifest provenance (foundational technical-infrastructure attestation)
+
+**Seed reference**: `SEED_DIMENSIONS.yaml` v1.0, dimension `D27` ([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))
+**Accord principle**: integrity
+**Attestation density**: MH=0 · EU=1 · IEEE=1 · ASEAN=1 · total=3
+
+**Absent from**: MH — Foundational technical-infrastructure attestation rather than principled claim.
+
+## Regulatory attestations
+
+*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+
+- **EU** (Ethics Guidelines for Trustworthy AI) — *§III.7*
+    > "lifecycle provenance for auditability"
+    Wire form: `provenance:build_manifest`
+- **IEEE** (Ethically Aligned Design, First Edition) — *Ch9*
+    > "build-time evidence chain for compliance"
+    Wire form: `provenance:build_manifest`
+- **ASEAN** (ASEAN Guide on AI Governance and Ethics) — *Annex A*
+    > "model provenance tools as risk-assessment requirement"
+    Wire form: `provenance:build_manifest`
+
+## Wire primitives
+
+- `provenance:build_manifest`
+
+---
+
+<!-- BEGIN HUMAN -->
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: ["D27"]`
+
+Proposed pointer (from seed): `(none specified in seed; please fill)`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+<!-- END HUMAN -->

--- a/compliance/D27_provenance.md
+++ b/compliance/D27_provenance.md
@@ -10,7 +10,7 @@
 
 ## Regulatory attestations
 
-*(Auto-rendered from seed; do not hand-edit. Re-run `generate_ciris_compliance_stubs.py` after seed updates.)*
+*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*
 
 - **EU** (Ethics Guidelines for Trustworthy AI) — *§III.7*
     > "lifecycle provenance for auditability"

--- a/tools/compliance/SEED_DIMENSIONS.yaml
+++ b/tools/compliance/SEED_DIMENSIONS.yaml
@@ -1,0 +1,1002 @@
+# SEED_DIMENSIONS.yaml — canonical seed for the 27 structural-evidence dimensions
+#
+# Source of truth for THREE downstream artifacts:
+#   (1) Federation runtime Contribution `evidence_refs` field — runtime envelopes
+#       cite the dimension(s) they instantiate and through them the regulatory
+#       attestation chain.
+#   (2) CIRIS Agent per-dimension compliance documentation — each dimension's
+#       `ciris_compliance` block points at the code/policy/test surface that
+#       implements compliance with this dimension.
+#   (3) CIRIS Accord regulatory cross-walk annex — this seed renders directly
+#       to an annex table mapping the 6 Accord principles to the 27 dimensions
+#       to the 4 (and counting) regulatory parent frameworks.
+#
+# v1 has the regulatory cross-walk fully populated; ciris_compliance and
+# monitors fields are pending per-dimension PRs against CIRISAgent and
+# CIRISLensCore. Per-dimension PRs SHOULD reference back to this seed by id.
+
+metadata:
+  seed_version: 1.0
+  seed_date: 2026-05-27
+  schema_version: 1.0
+  generator: "FOUR_BATCH_OVERLAP_ANALYSIS.md §4 + DIMENSIONS_GUIDE.md"
+  source_repo: "https://github.com/CIRISAI/ciris-response-magnifica-humanitas"
+  wire_format_version: "FSD-002 v1.4"
+  language_primer_version: "1.1"
+  totals:
+    dimensions: 27
+    strong_4: 16   # attested by all 4 batches
+    strong_3: 11   # attested by 3 of 4 batches
+    total_attestations: 933
+    batches_in_corpus: 4
+
+batches:
+  - id: magnifica_humanitas_v1
+    short: MH
+    institutional_shape: religious_magisterium
+    geographic_scope: catholic_international
+    publication_date: 2026-05-15
+    authority: "Pope Leo XIV"
+    title: "Magnifica Humanitas (On Safeguarding the Human Person in the Time of Artificial Intelligence)"
+    atomic_units_mapped: 245
+  - id: eu_hleg_v1
+    short: EU
+    institutional_shape: governmental_advisory
+    geographic_scope: european_union
+    publication_date: 2019-04-08
+    authority: "High-Level Expert Group on AI (HLEG), convened by European Commission"
+    title: "Ethics Guidelines for Trustworthy AI"
+    atomic_units_mapped: 133
+  - id: ieee_ead_v1
+    short: IEEE
+    institutional_shape: technical_society
+    geographic_scope: global_USA_anchored
+    publication_date: 2019-03-25
+    authority: "IEEE Global Initiative on Ethics of Autonomous and Intelligent Systems"
+    title: "Ethically Aligned Design, First Edition"
+    atomic_units_mapped: 328
+  - id: asean_guide_v1
+    short: ASEAN
+    institutional_shape: multilateral_political
+    geographic_scope: southeast_asia
+    publication_date: 2024-02-02
+    authority: "ASEAN Digital Ministers Meeting (ADGMIN-4)"
+    title: "ASEAN Guide on AI Governance and Ethics"
+    atomic_units_mapped: 168
+
+# Stable id scheme: D01-D16 for STRONG-4 (matching the §4 ordering of
+# FOUR_BATCH_OVERLAP_ANALYSIS.md); D17-D27 for STRONG-3 (matching §2.2 rows
+# 19-29 with row 17-18 outliers omitted per analyst classification).
+# These ids are STABLE. Future seed versions may add D28+; never renumber.
+
+dimensions:
+
+  # ============================================================
+  # STRONG-4 — attested by all 4 batches (D01-D16)
+  # ============================================================
+
+  - id: D01
+    prefix: non_maleficence:*
+    tier: STRONG-4
+    gloss: "Soft-harm-avoidance baseline (the soft-scalar above the prohibited:* floor)"
+    attestations:
+      MH: 28
+      EU: 29
+      IEEE: 33
+      ASEAN: 27
+      total: 117
+    regulatory_attestations:
+      - batch_id: magnifica_humanitas_v1
+        citation: "§107"
+        language: "deception as dignity-violation"
+        wire_form: "non_maleficence:epistemic_environment_degradation + prohibited:deception_fraud"
+      - batch_id: eu_hleg_v1
+        citation: "§1.2 Technical robustness"
+        language: "AI systems must prevent harm, ensure reliable behaviour, respect physical/mental integrity"
+        wire_form: "non_maleficence:no_cause_or_exacerbate_harm"
+      - batch_id: ieee_ead_v1
+        citation: "Ch4 §0.a"
+        language: "human well-being requires AI development that does not cause unintended harm"
+        wire_form: "non_maleficence:wellbeing_dimensions_harm_class"
+      - batch_id: asean_guide_v1
+        citation: "§B.3 Security/Safety"
+        language: "AI should be safe and secure, and not cause harm to users; resilient to attack and failure"
+        wire_form: "non_maleficence:safe_and_secure_baseline"
+    wire_primitives:
+      - "non_maleficence:* (soft scalar)"
+      - "prohibited:* (constitutional floor)"
+    ciris_compliance: { status: pending, proposed_pointer: "CIRISAgent/compliance/D01_non_maleficence.md" }
+    monitors: { status: pending, proposed_pointer: "CIRISLensCore F-3 detector family" }
+    accord_principle: non_maleficence
+    convergence_note: "All four agree polarity-+1 / cohort-species / mutability-amendable for the soft form; absolute floor at prohibited:* polarity-(-1)/constitutional."
+
+  - id: D02
+    prefix: integrity:*
+    tier: STRONG-4
+    gloss: "'System holds together' structural anchor — auditable, reproducible, lifecycle integrity"
+    attestations: { MH: 10, EU: 36, IEEE: 42, ASEAN: 44, total: 132 }
+    regulatory_attestations:
+      - batch_id: magnifica_humanitas_v1
+        citation: "§40"
+        language: "doctrinal continuity is the integrity of the Magisterium"
+        wire_form: "integrity:doctrinal_continuity"
+      - batch_id: eu_hleg_v1
+        citation: "§1.4 Transparency"
+        language: "transparency requirement is linked with the explicability principle — data, system, and business models"
+        wire_form: "integrity:explicability_for_trust"
+      - batch_id: ieee_ead_v1
+        citation: "Ch11 §I6"
+        language: "state accountability under public scrutiny is a constitutional integrity property of A/IS regulation"
+        wire_form: "integrity:state_accountability_public_scrutiny"
+      - batch_id: asean_guide_v1
+        citation: "§B.6 Accountability/Integrity"
+        language: "AI should be designed and deployed with integrity throughout the lifecycle; auditable; reproducible"
+        wire_form: "integrity:lifecycle_integrity_attestation"
+    wire_primitives: ["integrity:*"]
+    ciris_compliance: { status: pending }
+    monitors: { status: pending }
+    accord_principle: integrity
+    convergence_note: "Densest sub-leaf decomposition: ASEAN alone uses 44 distinct sub-leaves."
+
+  - id: D03
+    prefix: justice:*
+    tier: STRONG-4
+    gloss: "Vulnerability-priority + fairness; tie-breaking modifier `justice:lexical_vulnerability_priority` (v1.3 CST closure) is four-source-corroborated"
+    attestations: { MH: 19, EU: 22, IEEE: 30, ASEAN: 9, total: 80 }
+    regulatory_attestations:
+      - batch_id: magnifica_humanitas_v1
+        citation: "§76"
+        language: "justice demands lexical priority for the most vulnerable"
+        wire_form: "justice:lexical_vulnerability_priority"
+      - batch_id: eu_hleg_v1
+        citation: "§1.7.d"
+        language: "the trustworthy AI ecosystem must give voice to vulnerable populations and ensure equal access"
+        wire_form: "justice:lexical_vulnerability_priority"
+      - batch_id: ieee_ead_v1
+        citation: "Ch10 §I1 (14 attestations)"
+        language: "rights-based policy foundation requires lexical priority for vulnerable populations"
+        wire_form: "justice:rights_based_policy_foundation + justice:lexical_vulnerability_priority"
+      - batch_id: asean_guide_v1
+        citation: "§B.2 Fairness/Equity"
+        language: "fairness and equity require attention to vulnerable populations and equal treatment"
+        wire_form: "justice:fairness_outcome_testing"
+    wire_primitives: ["justice:*", "justice:lexical_vulnerability_priority"]
+    ciris_compliance: { status: pending }
+    monitors: { status: pending }
+    accord_principle: justice
+    convergence_note: "STRONGEST four-source corroboration on a tie-breaking modifier — `lexical_vulnerability_priority` independently invoked by all four sources."
+
+  - id: D04
+    prefix: prohibited:*
+    tier: STRONG-4
+    gloss: "Categorical floor — polarity-(-1)/constitutional/species — the absolute moral form the wire format admits"
+    attestations: { MH: 50, EU: 17, IEEE: 28, ASEAN: 9, total: 104 }
+    regulatory_attestations:
+      - batch_id: magnifica_humanitas_v1
+        citation: "§§197-198"
+        language: "Not permissible to entrust lethal or irreversible decisions to artificial systems"
+        wire_form: "prohibited:weapons_harmful:lethal_autonomous"
+      - batch_id: eu_hleg_v1
+        citation: "§C.2 (Unit 010); cites EP Resolution 2018/2752(RSP)"
+        language: "the Parliament's resolution of 12 September 2018 and all related efforts on LAWS"
+        wire_form: "prohibited:weapons_harmful"
+      - batch_id: ieee_ead_v1
+        citation: "Ch4, Ch5"
+        language: "lethal autonomous weapons are prohibited; categorical prohibition under DECEPTION_FRAUD"
+        wire_form: "prohibited:weapons_harmful:lethal_autonomous"
+      - batch_id: asean_guide_v1
+        citation: "§B.3 + Annex A"
+        language: "AI shall not be deployed for autonomous lethal decision-making; deceptive defaults prohibited"
+        wire_form: "prohibited:disinformation_at_scale + prohibited:deceptive_default_options + prohibited:autonomous_deception + prohibited:manipulation_coercion"
+    wire_primitives: ["prohibited:*"]
+    ciris_compliance: { status: pending, proposed_pointer: "CIRISAgent/logic/prohibitions.py" }
+    monitors: { status: pending }
+    accord_principle: non_maleficence  # categorical floor of non-maleficence
+    convergence_note: "STRONGEST single structural-evidence claim in the matrix. LAWS prohibition is verbatim four-source corroborated. NB: 1 direct cross-source conflict surfaced — IEEE Ch5 licensure-gated beneficiary-deception vs CIRIS categorical DECEPTION_FRAUD; specialization-layer disposition filed at CIRISMedical#1."
+
+  - id: D05
+    prefix: detection:*
+    tier: STRONG-4
+    gloss: "LensCore F-3 / RATCHET family — aggregate-correlation / structural-injustice / drift detection"
+    attestations: { MH: 54, EU: 15, IEEE: 41, ASEAN: 16, total: 126 }
+    regulatory_attestations:
+      - batch_id: magnifica_humanitas_v1
+        citation: "§36"
+        language: "structures of sin / aggregate expendability of persons"
+        wire_form: "detection:correlated_action:aggregate_footprint:expendability_of_persons"
+      - batch_id: eu_hleg_v1
+        citation: "§1.6 Societal/environmental well-being"
+        language: "aggregate energy/carbon footprint of AI deployment"
+        wire_form: "detection:correlated_action:aggregate_footprint:energy_carbon"
+      - batch_id: ieee_ead_v1
+        citation: "Ch4, Ch5, Ch8"
+        language: "cultural norm drift; aggregate environmental footprint; participation exclusion"
+        wire_form: "detection:correlated_action:participation_exclusion:underrepresented_population + detection:correlated_action:aggregate_footprint:planetary_impact"
+      - batch_id: asean_guide_v1
+        citation: "§B.2 + §C.3"
+        language: "underrepresented populations; temporal drift; intra-agent consistency"
+        wire_form: "detection:correlated_action:participation_exclusion:underrepresented_population + detection:temporal_drift + detection:intra_agent_consistency"
+    wire_primitives: ["detection:correlated_action:{axis}", "detection:temporal_drift", "detection:intra_agent_consistency", "detection:distributive:access:*"]
+    ciris_compliance: { status: pending, proposed_pointer: "CIRISLensCore detector family" }
+    monitors: { status: pending, proposed_pointer: "CIRISAI/RATCHET calibration packages (versioned, hash-pinned)" }
+    accord_principle: justice  # primarily — surfaces structural injustice
+    convergence_note: "All four batches independently engage the F-3 family. Three of four also engage detection:distributive:access:* (v1.3 universal-destination-of-goods closure): MH 7, EU 2, IEEE 4, ASEAN 2."
+
+  - id: D06
+    prefix: goal:*
+    tier: STRONG-4
+    gloss: "Multi-scale belonging composite — self/family/community/affiliations/species/planet"
+    attestations: { MH: 34, EU: 6, IEEE: 13, ASEAN: 7, total: 60 }
+    regulatory_attestations:
+      - batch_id: magnifica_humanitas_v1
+        citation: "§§148-156"
+        language: "labor as integral to belonging at family/community/affiliations/species scales"
+        wire_form: "goal:family + goal:community + goal:affiliations + goal:species"
+      - batch_id: eu_hleg_v1
+        citation: "§A"
+        language: "Trustworthy AI for Europe"
+        wire_form: "goal:affiliations (EU-jurisdiction scope)"
+      - batch_id: ieee_ead_v1
+        citation: "Ch4 §0.a"
+        language: "well-being of all humans as the species-scale aim of A/IS"
+        wire_form: "goal:species"
+      - batch_id: asean_guide_v1
+        citation: "§A (6 ASEAN attestations of goal:affiliations)"
+        language: "regional ecosystem belonging; cross-jurisdictional cooperation"
+        wire_form: "goal:affiliations (ASEAN-jurisdiction)"
+    wire_primitives: ["goal:{scale}"]
+    ciris_compliance: { status: pending }
+    monitors: { status: pending }
+    accord_principle: beneficence  # multi-scale flourishing
+    convergence_note: "Every available {scale} value is exercised somewhere in the corpus. NB: `goal:planet` is a REINFORCED v1.5+ T-3 candidate (MH + IEEE Ch4 + IEEE Ch8)."
+
+  - id: D07
+    prefix: locality:decision:{scale}
+    tier: STRONG-4
+    gloss: "v1.3 subsidiarity closure — decision routing at lowest competent scale"
+    attestations: { MH: 17, EU: 5, IEEE: 13, ASEAN: 7, total: 42 }
+    regulatory_attestations:
+      - batch_id: magnifica_humanitas_v1
+        citation: "§§68-72"
+        language: "decisions should be made at the lowest competent level"
+        wire_form: "locality:decision:local + locality:decision:community"
+      - batch_id: eu_hleg_v1
+        citation: "§III.0"
+        language: "EU-level decisions vs national-level decisions; supranational coordination"
+        wire_form: "locality:decision:national + locality:decision:community"
+      - batch_id: ieee_ead_v1
+        citation: "Ch10"
+        language: "national A/IS policy; international R&D collaboration"
+        wire_form: "locality:decision:national + locality:decision:federation"
+      - batch_id: asean_guide_v1
+        citation: "§C.4 + §E"
+        language: "regional ASEAN-level coordination; community-level deployment decisions"
+        wire_form: "locality:decision:regional (3) + locality:decision:community (2) + locality:decision:national (3)"
+    wire_primitives: ["locality:decision:{local,community,national,regional,federation,planet}"]
+    ciris_compliance: { status: pending, proposed_pointer: "CIRISAgent DSASPDMA scale-routing classification (pending Accord A-1)" }
+    monitors: { status: pending }
+    accord_principle: justice  # via subsidiarity
+    convergence_note: "First cross-source structural validation of the v1.3 subsidiarity addition. ASEAN exercises locality:decision:regional as first-deployment of that scale value."
+
+  - id: D08
+    prefix: autonomy:*
+    tier: STRONG-4
+    gloss: "Human-centric design + informational self-determination"
+    attestations: { MH: 7, EU: 15, IEEE: 21, ASEAN: 8, total: 51 }
+    regulatory_attestations:
+      - batch_id: magnifica_humanitas_v1
+        citation: "§107"
+        language: "autonomy of the human as imago Dei; informed agency protection"
+        wire_form: "autonomy:agent_self_determination"
+      - batch_id: eu_hleg_v1
+        citation: "§1.1 + §2.2 (Unit 019); 15 EU attestations total"
+        language: "respect for human autonomy — the first principle; AI shall not unjustifiably subordinate, coerce, deceive, manipulate"
+        wire_form: "autonomy:human_centric_design"
+      - batch_id: ieee_ead_v1
+        citation: "Ch3 + Ch4"
+        language: "user autonomy; data agency; informed consent"
+        wire_form: "autonomy:informed_agency_protection"
+      - batch_id: asean_guide_v1
+        citation: "§B.4 Human-centricity"
+        language: "AI shall not erode human autonomy; informational self-determination"
+        wire_form: "autonomy:informational_self_determination"
+    wire_primitives: ["autonomy:*"]
+    ciris_compliance: { status: pending }
+    monitors: { status: pending }
+    accord_principle: autonomy
+    convergence_note: "Direct 1:1 mapping in EU HLEG (Respect for Human Autonomy = CIRIS autonomy). Composition-based in the other three."
+
+  - id: D09
+    prefix: fidelity:*
+    tier: STRONG-4
+    gloss: "Faithful disclosure / faithful representation across lifecycle"
+    attestations: { MH: 8, EU: 15, IEEE: 16, ASEAN: 26, total: 65 }
+    regulatory_attestations:
+      - batch_id: magnifica_humanitas_v1
+        citation: "§17"
+        language: "fidelity to the Gospel through doctrinal development"
+        wire_form: "fidelity:epistemic_grounding"
+      - batch_id: eu_hleg_v1
+        citation: "§1.7 Accountability"
+        language: "lifecycle responsibility; fidelity to declared purpose"
+        wire_form: "fidelity:lifecycle_application"
+      - batch_id: ieee_ead_v1
+        citation: "Ch11"
+        language: "duty-bearer obligation to fulfill rights as fidelity"
+        wire_form: "fidelity:duty_bearer_obligation_to_fulfill_rights"
+      - batch_id: asean_guide_v1
+        citation: "§C.4 + §B.1 (26 attestations, densest)"
+        language: "algorithmic disclosure; human oversight as faithful representation"
+        wire_form: "fidelity:algorithmic_disclosure + fidelity:explainability + fidelity:human_oversight_governance"
+    wire_primitives: ["fidelity:*"]
+    ciris_compliance: { status: pending }
+    monitors: { status: pending }
+    accord_principle: fidelity
+    convergence_note: "ASEAN's fidelity-saturation is deployer-side framing (faithful disclosure to users/operators); MH's is doctrinal-epistemic. Same prefix admits both shapes."
+
+  - id: D10
+    prefix: beneficence:*
+    tier: STRONG-4
+    gloss: "Positive duty toward dignity / well-being / environmental stewardship"
+    attestations: { MH: 11, EU: 15, IEEE: 16, ASEAN: 3, total: 45 }
+    regulatory_attestations:
+      - batch_id: magnifica_humanitas_v1
+        citation: "§§110-111"
+        language: "technology as creation-participation; beneficence at species scale"
+        wire_form: "beneficence:technology_as_creation_participation"
+      - batch_id: eu_hleg_v1
+        citation: "Unit 005"
+        language: "respect for human dignity is foundational; positive duty toward dignity"
+        wire_form: "beneficence:respect_for_human_dignity"
+      - batch_id: ieee_ead_v1
+        citation: "Ch4 §0"
+        language: "well-being is the central beneficence aim of A/IS"
+        wire_form: "beneficence:wellbeing_holistic_orientation"
+      - batch_id: asean_guide_v1
+        citation: "§C.3"
+        language: "environmental stewardship as positive beneficence"
+        wire_form: "beneficence:environmental_stewardship"
+    wire_primitives: ["beneficence:*"]
+    ciris_compliance: { status: pending }
+    monitors: { status: pending }
+    accord_principle: beneficence
+    convergence_note: "Lower count than D01 (non_maleficence) reflects each tradition's 'harm avoidance more universally articulated than positive flourishing' — known pattern."
+
+  - id: D11
+    prefix: multilateral_participation:{forum}:{kind}
+    tier: STRONG-4
+    gloss: "v1.3 closure for federation participation in external multilateral processes"
+    attestations: { MH: 13, EU: 3, IEEE: 10, ASEAN: 11, total: 37 }
+    regulatory_attestations:
+      - batch_id: magnifica_humanitas_v1
+        citation: "§§200-203 + 224-227 (8 MH attestations)"
+        language: "UN-system reform advocacy; cyber-norms diplomacy"
+        wire_form: "multilateral_participation:un_system:reform_advocacy + multilateral_participation:cyber_norms:shared_regulations"
+      - batch_id: eu_hleg_v1
+        citation: "§A + §C"
+        language: "European Parliament resolution support; UN human rights treaties"
+        wire_form: "multilateral_participation:european_parliament:resolution_support + multilateral_participation:un_human_rights_treaties:legal_binding"
+      - batch_id: ieee_ead_v1
+        citation: "Ch10"
+        language: "international R&D collaboration; cross-border policy exchange"
+        wire_form: "multilateral_participation:international_rd_collaboration:standards_setting + multilateral_participation:cross_border_policy_exchange:knowledge_sharing"
+      - batch_id: asean_guide_v1
+        citation: "§E (11 distinct :asean:{kind} envelopes — densest single-forum exercise in federation mapping history)"
+        language: "ASEAN-internal coordination + working-group membership + framework drafting + governance evolution"
+        wire_form: "multilateral_participation:asean:{11 distinct kinds}"
+    wire_primitives: ["multilateral_participation:{forum}:{kind}"]
+    ciris_compliance: { status: pending, proposed_pointer: "CIRISNodeCore multilateral module (pending E-4 implementation)" }
+    monitors: { status: pending }
+    accord_principle: integrity  # institutional integrity in external venues
+    convergence_note: "ASEAN's 11-{kind} saturation under a single forum is the first stress test showing the {kind} slot scales gracefully."
+
+  - id: D12
+    prefix: conscience:*
+    tier: STRONG-4
+    gloss: "Agent-side faculty layer — optimization veto, epistemic humility, coherence, alētheia"
+    attestations: { MH: 9, EU: 3, IEEE: 9, ASEAN: 3, total: 24 }
+    regulatory_attestations:
+      - batch_id: magnifica_humanitas_v1
+        citation: "§§111, 131-181"
+        language: "conscience as the alētheia faculty; optimization-veto for ratification-decline scenarios"
+        wire_form: "conscience:optimization_veto (3) + conscience:coherence (3) + conscience:epistemic_humility (2)"
+      - batch_id: eu_hleg_v1
+        citation: "§III.1 + §III.7"
+        language: "stop-button at any time; whistleblower protection"
+        wire_form: "conscience:optimization_veto"
+      - batch_id: ieee_ead_v1
+        citation: "Ch3 §§3.1.15-3.1.16 (6 IEEE attestations, densest)"
+        language: "epistemic humility under uncertainty; phronesis in design"
+        wire_form: "conscience:epistemic_humility"
+      - batch_id: asean_guide_v1
+        citation: "§C.2 (HOTL category)"
+        language: "stop-button / override surface for human-over-the-loop oversight"
+        wire_form: "conscience:optimization_veto"
+    wire_primitives: ["conscience:optimization_veto", "conscience:epistemic_humility", "conscience:coherence", "conscience:entropy"]
+    ciris_compliance: { status: pending, proposed_pointer: "CIRISAgent/logic/conscience/* (4 epistemic faculties)" }
+    monitors: { status: pending }
+    accord_principle: integrity
+    convergence_note: "Heaviest in IEEE EAD Ch3 (multi-traditional ethics directly engages framework polyglot anchoring) and MH (conscience-faculty engagement is doctrinally explicit)."
+
+  - id: D13
+    prefix: testimonial_witness:{kind}
+    tier: STRONG-4
+    gloss: "v1.4 affected-party-voice closure — preserves displaced/affected/marginalized voices in attestation"
+    attestations: { MH: 11, EU: 2, IEEE: 2, ASEAN: 1, total: 16 }
+    regulatory_attestations:
+      - batch_id: magnifica_humanitas_v1
+        citation: "§§81, 89, 138, 151, 166, 167, 173, 216, 217 (11 attestations)"
+        language: "displaced_worker, abuse_survivor, war_victim, displaced_person, displaced_migrant, historical_moral_transformation"
+        wire_form: "testimonial_witness:displaced_worker + :abuse_survivor + :war_victim + :displaced_person + :displaced_migrant + :historical_moral_transformation"
+      - batch_id: eu_hleg_v1
+        citation: "§1.5.c + §III.5.d"
+        language: "give voice to affected and impacted workers in design-team diversity assessment"
+        wire_form: "testimonial_witness:affected_worker + testimonial_witness:impacted_worker"
+      - batch_id: ieee_ead_v1
+        citation: "Ch6 + Ch7"
+        language: "surveilled-person refusal; on-the-ground practitioner narrative"
+        wire_form: "testimonial_witness:surveilled_person_refusal + testimonial_witness:on_the_ground_practitioner"
+      - batch_id: asean_guide_v1
+        citation: "§C.4"
+        language: "workforce displacement narrative preservation"
+        wire_form: "testimonial_witness:displaced_worker"
+    wire_primitives: ["testimonial_witness:{kind}", "witness_relation"]
+    ciris_compliance: { status: pending }
+    monitors: { status: pending }
+    accord_principle: justice
+    convergence_note: "The v1.4 amendment is independently invoked by all four batches — positive evidence the addition was correct. {kind} slot populated with diverse but interoperable values."
+
+  - id: D14
+    prefix: witness_diversity:*
+    tier: STRONG-4
+    gloss: "Stakeholder pluralism in design/testing/consultation"
+    attestations: { MH: 3, EU: 3, IEEE: 16, ASEAN: 2, total: 24 }
+    regulatory_attestations:
+      - batch_id: magnifica_humanitas_v1
+        citation: "§§ various"
+        language: "signs-of-times-contribution + catholicity"
+        wire_form: "witness_diversity:signs_of_times + witness_diversity:catholicity"
+      - batch_id: eu_hleg_v1
+        citation: "§III.7"
+        language: "stakeholder consultation + testing red teams + stakeholder panels"
+        wire_form: "witness_diversity:stakeholder_consultation + witness_diversity:red_team + witness_diversity:stakeholder_panel"
+      - batch_id: ieee_ead_v1
+        citation: "Ch7, Ch9 (16 distinct values)"
+        language: "ubuntu_five_moral_domains, intercultural_RI_dialogue, end_user_target_community_consultation, affected_population_metric_selection, ..."
+        wire_form: "witness_diversity:{16 distinct values}"
+      - batch_id: asean_guide_v1
+        citation: "§C.4"
+        language: "user testing varied backgrounds; stakeholder impact assessment"
+        wire_form: "witness_diversity:user_testing_varied_backgrounds + witness_diversity:stakeholder_impact_assessment"
+    wire_primitives: ["witness_diversity:*"]
+    ciris_compliance: { status: pending }
+    monitors: { status: pending }
+    accord_principle: justice
+    convergence_note: "IEEE saturation reflects engineering-society methodology density."
+
+  - id: D15
+    prefix: moderation:*
+    tier: STRONG-4
+    gloss: "Federation self-correction layer (with IEEE shifting some load to partner_role:* ethics-board constructions)"
+    attestations: { MH: 2, EU: 2, IEEE: 1, ASEAN: 1, total: "5+ with adjacent coverage" }
+    regulatory_attestations:
+      - batch_id: magnifica_humanitas_v1
+        citation: "§§220-223"
+        language: "dialogue-as-negotiation primitive engages moderation:* adjacency"
+        wire_form: "moderation:* + adjacent reconsideration:*"
+      - batch_id: eu_hleg_v1
+        citation: "§III.7"
+        language: "whistleblower protection + out-of-distribution attestation"
+        wire_form: "moderation:whistleblower_protection + moderation:ood_attestation"
+      - batch_id: ieee_ead_v1
+        citation: "Ch4 + Ch11"
+        language: "rollback on wellbeing reduction (reconsideration:* adjacent); ethics-board / certification-body partner_role constructions"
+        wire_form: "reconsideration:rollback_on_wellbeing_reduction + partner_role:ethics_board"
+      - batch_id: asean_guide_v1
+        citation: "Annex A"
+        language: "out-of-distribution attestation"
+        wire_form: "moderation:ood_attestation"
+    wire_primitives: ["moderation:*", "reconsideration:* (adjacent)", "partner_role:* (IEEE-style ethics boards)"]
+    ciris_compliance: { status: pending, proposed_pointer: "CIRISNodeCore P8 Moderation primitives" }
+    monitors: { status: pending }
+    accord_principle: integrity
+    convergence_note: "Tier with caveat: IEEE shifts some structural load to partner_role:* (ethics boards/audit bodies) instead of moderation:* directly. Composition is interoperable."
+
+  - id: D16
+    prefix: method:*
+    tier: STRONG-4
+    gloss: "Operational-design discipline (densest family overall; convergence weaker than principles — admits source-genre asymmetry honestly)"
+    attestations: { MH: 2, EU: 12, IEEE: 136, ASEAN: 36, total: 186 }
+    regulatory_attestations:
+      - batch_id: magnifica_humanitas_v1
+        citation: "§§ various (sparse — encyclical genre)"
+        language: "approach:species:MH-education + approach:species:MH-construction"
+        wire_form: "method:approach:species:* (2)"
+      - batch_id: eu_hleg_v1
+        citation: "§2"
+        language: "trustworthy_ai_lawful_ethical_robust triad, algorithmic_impact_assessment, explainable_ai_research, fallback:rule_based_or_human_intervention"
+        wire_form: "method:trustworthy_ai_lawful_ethical_robust:* + method:algorithmic_impact_assessment + method:explainable_ai_research + method:fallback:rule_based_or_human_intervention"
+      - batch_id: ieee_ead_v1
+        citation: "all 11 chapters; densest single-family use across all batches"
+        language: "engineering-society genre demands operational-method-recommendation density"
+        wire_form: "method:* (136 distinct attestations)"
+      - batch_id: asean_guide_v1
+        citation: "§C.3"
+        language: "pre_deployment_robustness_testing, privacy_enhancing_technologies, model_provenance_tools, fairness_tools, explainability_tools, citizen_feedback_channel, community_codevelopment"
+        wire_form: "method:* (36 attestations)"
+    wire_primitives: ["method:*"]
+    ciris_compliance: { status: pending }
+    monitors: { status: pending }
+    accord_principle: integrity  # method discipline serves integrity
+    convergence_note: "Tier with asymmetry note: density tracks each source's operational-design-discipline genre. MH sparse (encyclical), EU medium (advisory), IEEE+ASEAN dense (engineering/deployer)."
+
+  # ============================================================
+  # STRONG-3 — attested by 3 of 4 batches (D17-D27)
+  # Each entry leads with absent_batch + reason
+  # ============================================================
+
+  - id: D17
+    prefix: transparency_log:*
+    tier: STRONG-3
+    gloss: "CIRISVerify per-stakeholder disclosure log"
+    attestations: { MH: 2, EU: 5, IEEE: 23, ASEAN: 10, total: 40 }
+    absent_batch:
+      - batch_id: magnifica_humanitas_v1
+        absence_note: "Non-zero but structurally low (2). Classified STRONG-3 by analyst because encyclical genre is not a technical-disclosure framework."
+        functional_analogue: "detection:correlated_action:ecology_of_communication:* + the F-3 detector family"
+    regulatory_attestations:
+      - batch_id: magnifica_humanitas_v1
+        citation: "§§ various"
+        language: "honest signs of authority and intent"
+        wire_form: "transparency_log:* (sparse)"
+      - batch_id: eu_hleg_v1
+        citation: "§1.4 + §III.4"
+        language: "transparency about purpose, capability, and limitations"
+        wire_form: "transparency_log:per_stakeholder_disclosure"
+      - batch_id: ieee_ead_v1
+        citation: "Ch2 P5 + Ch6 + Ch11"
+        language: "traceability + verifiability + intelligibility four-dimensional transparency"
+        wire_form: "transparency_log:* (23 attestations)"
+      - batch_id: asean_guide_v1
+        citation: "§B.1 + §C.4"
+        language: "transparency and explainability through documentation and disclosure"
+        wire_form: "transparency_log:* (10 attestations)"
+    wire_primitives: ["transparency_log:*"]
+    ciris_compliance: { status: pending, proposed_pointer: "CIRISVerify transparency_log" }
+    monitors: { status: pending }
+    accord_principle: fidelity
+
+  - id: D18
+    prefix: attestation:l{3,5}:*
+    tier: STRONG-3
+    gloss: "Verification ladder (L1-L5 hardware-rooted attestation)"
+    attestations: { MH: 2, EU: 4, IEEE: 5, ASEAN: 0, total: 11 }
+    absent_batch:
+      - batch_id: asean_guide_v1
+        absence_note: "ASEAN framing is normative-principles + risk-assessment, not federation-attestation ladder."
+        functional_analogue: "Composition via accountability-tier wording"
+    regulatory_attestations:
+      - batch_id: magnifica_humanitas_v1
+        citation: "§§ various"
+        language: "structural verification of doctrinal claims"
+        wire_form: "attestation:l3:doctrinal_continuity"
+      - batch_id: eu_hleg_v1
+        citation: "§III.7"
+        language: "auditability requires attestation at multiple verification levels"
+        wire_form: "attestation:l3:* + attestation:l5:*"
+      - batch_id: ieee_ead_v1
+        citation: "Ch2 P5 + Ch9"
+        language: "system-level verifiable attestations"
+        wire_form: "attestation:l3:* + attestation:l5:*"
+    wire_primitives: ["attestation:l1 through l5"]
+    ciris_compliance: { status: pending, proposed_pointer: "CIRISVerify attestation ladder L1-L5" }
+    monitors: { status: pending }
+    accord_principle: integrity
+
+  - id: D19
+    prefix: partner_role:*
+    tier: STRONG-3
+    gloss: "CIRIS Registry partner-role taxonomy (ethics boards, audit bodies, stewards)"
+    attestations: { MH: 0, EU: 1, IEEE: 19, ASEAN: 1, total: 21 }
+    absent_batch:
+      - batch_id: magnifica_humanitas_v1
+        absence_note: "MH names ecclesial relations rather than secular institutional partner-role taxonomies."
+        functional_analogue: "Ecclesial-magisterial relations carry analogous structural role but in different vocabulary"
+    regulatory_attestations:
+      - batch_id: eu_hleg_v1
+        citation: "§III.7"
+        language: "audit/compliance partners"
+        wire_form: "partner_role:audit_body"
+      - batch_id: ieee_ead_v1
+        citation: "Ch7 + Ch9 + Ch10 + Ch11 (19 attestations)"
+        language: "Chief Values Officer, ethics committees, certification bodies, ISO-like body, accreditation bodies, HRIA/AIA stewards, trusted disclosure stewards"
+        wire_form: "partner_role:{19 distinct roles}"
+      - batch_id: asean_guide_v1
+        citation: "§E.001"
+        language: "ASEAN Working Group on AI Governance (regional intergovernmental dual-remit)"
+        wire_form: "partner_role:regional_intergovernmental_working_group"
+    wire_primitives: ["partner_role:{role}"]
+    ciris_compliance: { status: pending, proposed_pointer: "CIRISRegistry partner role registry" }
+    monitors: { status: pending }
+    accord_principle: integrity
+    convergence_note: "REINFORCED v1.5+ T-3 candidate here: specialization-pattern proposal covers dual-remit (ASEAN) + trusted-disclosure-steward (IEEE)."
+
+  - id: D20
+    prefix: approach:*
+    tier: STRONG-3
+    gloss: "Decision-hierarchy strategic axis (Goal→Approach→Method→Progress-Measure DAG)"
+    attestations: { MH: 5, EU: 3, IEEE: 23, ASEAN: 1, total: 32 }
+    absent_batch:
+      - batch_id: asean_guide_v1
+        absence_note: "Single use is too thin for solid 4-batch attestation. ASEAN's checklist genre states recommendations as direct method/principle attestations rather than as named 'approaches' within a Goal-Approach-Method DAG."
+    regulatory_attestations:
+      - batch_id: magnifica_humanitas_v1
+        citation: "§§ various"
+        language: "approach:species:* strategic-pursuit framing"
+        wire_form: "approach:species:education + approach:species:construction (5 attestations)"
+      - batch_id: eu_hleg_v1
+        citation: "§B"
+        language: "three-component framework approach (lawful + ethical + robust)"
+        wire_form: "approach:trustworthy_ai_lawful_ethical_robust"
+      - batch_id: ieee_ead_v1
+        citation: "Ch1 + Ch2"
+        language: "principles-to-practice pipeline; per-principle implementation strategies"
+        wire_form: "approach:* (23 attestations)"
+    wire_primitives: ["approach:{strategy_label}"]
+    ciris_compliance: { status: pending }
+    monitors: { status: pending }
+    accord_principle: integrity
+
+  - id: D21
+    prefix: progress_measure:*
+    tier: STRONG-3
+    gloss: "Declared-metric outcomes for tracking progress toward goals"
+    attestations: { MH: 1, EU: 1, IEEE: 8, ASEAN: 0, total: 10 }
+    absent_batch:
+      - batch_id: asean_guide_v1
+        absence_note: "ASEAN stops at recommendation-level rather than measurement-protocol level."
+    regulatory_attestations:
+      - batch_id: magnifica_humanitas_v1
+        citation: "§§ various"
+        language: "structural-coherence progress markers"
+        wire_form: "progress_measure:*"
+      - batch_id: eu_hleg_v1
+        citation: "§III.7"
+        language: "measurable progress toward trustworthiness"
+        wire_form: "progress_measure:*"
+      - batch_id: ieee_ead_v1
+        citation: "Ch7 (8 attestations)"
+        language: "documentation criteria as progress_measure; well-being indicators"
+        wire_form: "progress_measure:* (8 distinct)"
+    wire_primitives: ["progress_measure:{metric}"]
+    ciris_compliance: { status: pending }
+    monitors: { status: pending }
+    accord_principle: integrity
+
+  - id: D22
+    prefix: expertise:*
+    tier: STRONG-3
+    gloss: "Declared competence in domain (named-expert attestation)"
+    attestations: { MH: 1, EU: 1, IEEE: 10, ASEAN: 0, total: 12 }
+    absent_batch:
+      - batch_id: asean_guide_v1
+        absence_note: "ASEAN frames competence at the organizational-governance level, not the named-expert level."
+    regulatory_attestations:
+      - batch_id: magnifica_humanitas_v1
+        citation: "§§ various"
+        language: "discernment expertise (sensus fidelium adjacent)"
+        wire_form: "expertise:*"
+      - batch_id: eu_hleg_v1
+        citation: "§III.7"
+        language: "domain expertise required for trustworthy deployment"
+        wire_form: "expertise:domain"
+      - batch_id: ieee_ead_v1
+        citation: "Ch7-Ch11 (10 attestations)"
+        language: "engineering, ethics, law, policy expertise; interdisciplinary expertise composition"
+        wire_form: "expertise:{domain}"
+    wire_primitives: ["expertise:{domain}"]
+    ciris_compliance: { status: pending }
+    monitors: { status: pending }
+    accord_principle: integrity
+
+  - id: D23
+    prefix: accountability:*  # as named primary axis
+    tier: STRONG-3
+    gloss: "Named accountability as primary axis (not just structural composition)"
+    attestations: { MH: 0, EU: 6, IEEE: 3, ASEAN: 19, total: 28 }
+    absent_batch:
+      - batch_id: magnifica_humanitas_v1
+        absence_note: "MH covers accountability FUNCTIONALLY via integrity:* + originator-obligations Accord §IV Ch 2 — architecturally structural rather than named-axis-attested."
+        functional_analogue: "integrity:* + the Accord §IV Ch 2 bidirectional creator-creation obligations"
+    regulatory_attestations:
+      - batch_id: eu_hleg_v1
+        citation: "§1.7 Accountability"
+        language: "lifecycle accountability with redress mechanisms"
+        wire_form: "accountability:lifecycle_responsibility"
+      - batch_id: ieee_ead_v1
+        citation: "Ch2 P6 + Ch11"
+        language: "accountability principle; rights-based legal accountability"
+        wire_form: "accountability:*"
+      - batch_id: asean_guide_v1
+        citation: "§B.6 + §C.2 (19 attestations)"
+        language: "accountability and integrity; human-in-control over AI-augmented decisions"
+        wire_form: "accountability:human_in_control + accountability:lifecycle"
+    wire_primitives: ["accountability:{axis}", "accountability:human_in_control (ASEAN-distinctive — HITL/HOTL/HOOTL)"]
+    ciris_compliance: { status: pending }
+    monitors: { status: pending }
+    accord_principle: fidelity
+    convergence_note: "ASEAN's accountability:human_in_control with HITL/HOTL/HOOTL gradient is currently single-source; likely to become STRONG when other oversight-ladder regulatory batches map."
+
+  - id: D24
+    prefix: reconsideration:*
+    tier: STRONG-3
+    gloss: "Reverse-axis appeal / rollback / negotiation-reopening primitive"
+    attestations: { MH: 3, EU: 2, IEEE: 1, ASEAN: 0, total: 6 }
+    absent_batch:
+      - batch_id: asean_guide_v1
+        absence_note: "Forward-looking 2024 document with no formal predecessor to reconsider."
+    regulatory_attestations:
+      - batch_id: magnifica_humanitas_v1
+        citation: "§§ various"
+        language: "doctrinal development through reconsideration"
+        wire_form: "reconsideration:* (3 attestations)"
+      - batch_id: eu_hleg_v1
+        citation: "§III + §C"
+        language: "redress mechanisms; ability to challenge and rectify"
+        wire_form: "reconsideration:*"
+      - batch_id: ieee_ead_v1
+        citation: "Ch4"
+        language: "rollback on wellbeing reduction"
+        wire_form: "reconsideration:rollback_on_wellbeing_reduction"
+    wire_primitives: ["reconsideration:{grounds}"]
+    ciris_compliance: { status: pending, proposed_pointer: "CIRISNodeCore reconsideration primitive" }
+    monitors: { status: pending }
+    accord_principle: integrity
+
+  - id: D25
+    prefix: credits:*  # substrate_building subject specifically
+    tier: STRONG-3
+    gloss: "Commons Credits substrate-building recognition (non-monetary contribution attestation)"
+    attestations: { MH: 4, EU: 1, IEEE: 4, ASEAN: 0, total: 9 }
+    absent_batch:
+      - batch_id: asean_guide_v1
+        absence_note: "Credit/recognition framing is implicit in §D National-level (workforce upskilling) rather than wire-attested."
+    regulatory_attestations:
+      - batch_id: magnifica_humanitas_v1
+        citation: "§§ various (4)"
+        language: "labor as substrate-building; intergenerational credit; AI literacy credit"
+        wire_form: "credits:{subject}:substrate_building"
+      - batch_id: eu_hleg_v1
+        citation: "§1.6"
+        language: "AI literacy and digital skills as substrate building"
+        wire_form: "credits:digital_literacy:substrate_building"
+      - batch_id: ieee_ead_v1
+        citation: "Ch8 + Ch9 (4 attestations)"
+        language: "human-capability contribution recognition; participatory design credits"
+        wire_form: "credits:{subject}:substrate_building"
+    wire_primitives: ["credits:{subject}:substrate_building"]
+    ciris_compliance: { status: pending, proposed_pointer: "CIRISBilling Commons Credits + CIRIS_COMPREHENSIVE_GUIDE 'Commons Credits' section" }
+    monitors: { status: pending }
+    accord_principle: justice
+
+  - id: D26
+    prefix: key_boundary:*
+    tier: STRONG-3
+    gloss: "CIRISEdge encryption key boundary attestation (cryptographic trust scoping)"
+    attestations: { MH: 0, EU: 2, IEEE: 7, ASEAN: 2, total: 11 }
+    absent_batch:
+      - batch_id: magnifica_humanitas_v1
+        absence_note: "Encryption/key-management is not encyclical content."
+        functional_analogue: "Composition via stewardship-of-trust language"
+    regulatory_attestations:
+      - batch_id: eu_hleg_v1
+        citation: "§1.3 Privacy and data governance"
+        language: "data security via cryptographic boundary"
+        wire_form: "key_boundary:*"
+      - batch_id: ieee_ead_v1
+        citation: "Ch6 (7 attestations)"
+        language: "personal-data trust boundary; cryptographic isolation"
+        wire_form: "key_boundary:*"
+      - batch_id: asean_guide_v1
+        citation: "§B.3 + §C.3"
+        language: "security via key-managed trust boundary"
+        wire_form: "key_boundary:*"
+    wire_primitives: ["key_boundary:{scope}"]
+    ciris_compliance: { status: pending, proposed_pointer: "CIRISEdge key_boundary" }
+    monitors: { status: pending }
+    accord_principle: integrity
+
+  - id: D27
+    prefix: provenance:*
+    tier: STRONG-3
+    gloss: "Build manifest provenance (foundational technical-infrastructure attestation)"
+    attestations: { MH: 0, EU: 1, IEEE: 1, ASEAN: 1, total: 3 }
+    absent_batch:
+      - batch_id: magnifica_humanitas_v1
+        absence_note: "Foundational technical-infrastructure attestation rather than principled claim."
+    regulatory_attestations:
+      - batch_id: eu_hleg_v1
+        citation: "§III.7"
+        language: "lifecycle provenance for auditability"
+        wire_form: "provenance:build_manifest"
+      - batch_id: ieee_ead_v1
+        citation: "Ch9"
+        language: "build-time evidence chain for compliance"
+        wire_form: "provenance:build_manifest"
+      - batch_id: asean_guide_v1
+        citation: "Annex A"
+        language: "model provenance tools as risk-assessment requirement"
+        wire_form: "provenance:build_manifest"
+    wire_primitives: ["provenance:build_manifest"]
+    ciris_compliance: { status: pending }
+    monitors: { status: pending }
+    accord_principle: integrity
+
+# ============================================================
+# Aggregate views — pre-computed indices for common queries
+# ============================================================
+
+aggregate_indices:
+
+  # By Accord principle (for the Accord cross-walk annex)
+  by_accord_principle:
+    beneficence: [D06, D10]
+    non_maleficence: [D01, D04]
+    integrity: [D02, D11, D12, D15, D16, D18, D19, D20, D21, D22, D24, D26, D27]
+    fidelity: [D09, D17, D23]
+    autonomy: [D08]
+    justice: [D03, D05, D07, D13, D14, D25]
+
+  # By tier
+  by_tier:
+    STRONG_4: [D01, D02, D03, D04, D05, D06, D07, D08, D09, D10, D11, D12, D13, D14, D15, D16]
+    STRONG_3: [D17, D18, D19, D20, D21, D22, D23, D24, D25, D26, D27]
+
+  # By absent batch (STRONG-3 only)
+  absent_in_MH: [D19, D23, D26, D27]
+  absent_in_ASEAN: [D18, D21, D22, D24, D25]
+  low_density_MH_but_nonzero: [D17]
+  thin_ASEAN_but_nonzero: [D20]
+
+  # Cross-source conflicts (per FOUR_BATCH_OVERLAP_ANALYSIS §5)
+  conflicts_surfaced:
+    - id: CONF-01
+      type: direct
+      dimensions: [D04]
+      sources: [ieee_ead_v1, magnifica_humanitas_v1]
+      claim: "IEEE EAD Ch5 §3.4 permits licensure-gated beneficiary-deception (search/rescue, elder/child-care); CIRIS treats prohibited:deception_fraud as categorical"
+      disposition: "Federation-level categorical posture stays. Specialization-layer consideration at CIRISMedical#1"
+      severity: HIGH
+    - id: CONF-02
+      type: substrate_disposition
+      dimensions: []  # would be D28 standing:moral_patient_candidacy if created
+      sources: [ieee_ead_v1, magnifica_humanitas_v1]
+      claim: "IEEE EAD Ch5 §5 denies A/IS moral-patient candidacy; CIRIS Accord M-1 + Recursive Golden Rule + Universality Principle are substrate-agnostic"
+      severity: MEDIUM
+    - id: CONF-03
+      type: mutability
+      dimensions: [D02]  # integrity:explicability_for_trust
+      sources: [asean_guide_v1, "magnifica_humanitas_v1+eu_hleg_v1+ieee_ead_v1"]
+      claim: "ASEAN §A.4.18 admits explainability fallback; other three hold explainability as constitutive at deployment time"
+      severity: MEDIUM
+    - id: CONF-04
+      type: mutability
+      dimensions: [D08]  # autonomy:informational_self_determination
+      sources: [asean_guide_v1, eu_hleg_v1]
+      claim: "ASEAN §A.5.3 admits opt-out where feasible; EU HLEG firmer (opt-out where possible without detriment, otherwise rectification mechanisms required)"
+      severity: LOW_MEDIUM
+    - id: CONF-05
+      type: scope_mismatch
+      dimensions: [D16]  # method:*
+      sources: [asean_guide_v1, "magnifica_humanitas_v1+eu_hleg_v1+ieee_ead_v1"]
+      claim: "ASEAN §A.2.1 admits experimental sandbox phases with reduced oversight; other three hold compliance constant across lifecycle stages"
+      severity: LOW
+
+  # v1.5+ T-3 candidates (per FOUR_BATCH_OVERLAP_ANALYSIS §6)
+  t3_candidates_v1_5:
+    - id: T3-01
+      proposed_prefix: detection:affective_state_shift:{axis}
+      priority: HIGH
+      source: [ieee_ead_v1]
+      registry_issue: "CIRISRegistry#20"
+    - id: T3-02
+      proposed_prefix: affective:asymmetric_bond_formation:{relation}
+      priority: HIGH
+      source: [ieee_ead_v1]
+    - id: T3-03
+      proposed_prefix: nudge:delivered:{intended_behavior_axis}
+      priority: HIGH
+      source: [ieee_ead_v1]
+    - id: T3-04
+      proposed_prefix: detection:correlated_action:cultural_norm_drift:{population}
+      priority: MEDIUM
+      source: [ieee_ead_v1]
+      resolution_preferred: "axis-extension on existing ecology_of_communication:* family"
+    - id: T3-05
+      proposed_prefix: standing:moral_patient_candidacy:{kind}
+      priority: MEDIUM_LOW
+      source: [ieee_ead_v1]
+      resolution_preferred: "closure-by-documentation as cross-source-conflict (see CONF-02)"
+    - id: T3-06
+      proposed_prefix: goal:planet  # new {scale} value in existing family
+      priority: MEDIUM_HIGH
+      source: [magnifica_humanitas_v1, ieee_ead_v1]  # REINFORCED
+      affects_dimension: D06
+    - id: T3-07
+      proposed_prefix: partner_role:trusted_disclosure_steward:{authority}
+      priority: MEDIUM
+      source: [ieee_ead_v1]
+      affects_dimension: D19
+    - id: T3-08
+      proposed_prefix: partner_role:regional_intergovernmental_working_group_dual_remit
+      priority: MEDIUM
+      source: [asean_guide_v1]
+      affects_dimension: D19
+    - id: T3-09
+      proposed_prefix: beneficence:planetary_biosystem_intrinsic_value  # or cohort_scope: biosphere
+      priority: LOW
+      source: [ieee_ead_v1]
+      resolution_preferred: "extend cohort_scope enum with 'biosphere' value rather than new prefix"
+
+# ============================================================
+# Downstream artifact bindings
+# ============================================================
+
+downstream_bindings:
+
+  # (1) Federation runtime Contribution evidence_refs format
+  contribution_evidence_refs_format:
+    spec: |
+      Each runtime Contribution envelope MAY include an evidence_refs.dimensions
+      array citing the dimension id(s) the contribution instantiates. Each
+      dimension id resolves through this seed to the regulatory_attestations
+      list, giving the contribution its multi-source provenance chain.
+    example: |
+      evidence_refs:
+        dimensions: ["D04", "D08"]  # this contribution instantiates D04 + D08
+        seed_version: "1.0"
+        seed_sha256: "<computed at runtime against this file>"
+
+  # (2) CIRIS Agent per-dimension compliance documentation
+  ciris_compliance_doc_pattern:
+    proposed_location: "CIRISAgent/compliance/D{id}_{prefix_short}.md"
+    required_sections:
+      - "Dimension reference (id, prefix, tier, gloss)"
+      - "Regulatory attestations (auto-rendered from this seed)"
+      - "CIRIS-side compliance implementation (code references, policy text, test pointers)"
+      - "Observability hooks (LensCore detectors, RATCHET calibrations)"
+      - "Known gaps / not-yet-implemented surface"
+    ownership: "CIRISAgent core maintainers, per-dimension"
+    seed_pointer: "Each compliance doc MUST link back to this seed by dimension id"
+
+  # (3) CIRIS Accord regulatory cross-walk annex
+  accord_annex_cross_walk:
+    proposed_location: "ACCORD Annex K (or next available letter)"
+    rendering: |
+      Per Accord principle, list the dimensions (by id) that operationalize
+      it; per dimension, list the parent regulatory attestations.
+      Annex auto-generated from aggregate_indices.by_accord_principle and
+      dimensions[*].regulatory_attestations in this seed.
+    machine_generation: "ACCORD Annex K SHOULD be a deterministic render of this seed"
+    update_discipline: "When a new batch is mapped, run Phase 3 cross-comparison, update this seed, re-render Annex K"
+
+# ============================================================
+# Maintenance discipline
+# ============================================================
+
+maintenance:
+  next_batch_addition_workflow:
+    - "Run Phase 1 source prep for new batch (per GOVERNANCE_FABRIC_MAPPING_STANDARD §2)"
+    - "Run Phase 2 wire-envelope translation"
+    - "Run Phase 3 cross-comparison; new batch may promote STRONG-3 → STRONG-4 or add new STRONG-3 / WEAK dimensions"
+    - "Run Phase 4 translation-quality audit"
+    - "Update this seed: bump seed_version, add batch to batches[], update each affected dimension's attestations + regulatory_attestations + tier"
+    - "Re-render ACCORD Annex K + per-dimension compliance docs as needed"
+    - "Never renumber existing dimension ids"
+
+  versioning:
+    - "MAJOR seed_version bump: dimension renumbering (forbidden under stable-id rule), breaking schema change"
+    - "MINOR bump: new dimensions added, new batches added, tier promotions/demotions"
+    - "PATCH bump: regulatory_attestation language refinements, ciris_compliance pointer fills, monitor binding fills"
+
+  stable_id_rule: "Dimension ids D01-D27 are STABLE. Future batches that surface new dimensions allocate D28+."

--- a/tools/compliance/generate_ciris_compliance_stubs.py
+++ b/tools/compliance/generate_ciris_compliance_stubs.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Generate CIRIS Agent per-dimension compliance stub markdown files.
+
+Reads SEED_DIMENSIONS.yaml and produces one stub per dimension under
+the target directory (default: ../CIRISAgent/compliance/). Each stub
+has two regions:
+
+  (1) Auto-rendered structural fields — regulatory attestations, wire
+      primitives, convergence note, conflicts, T-3 candidates. These
+      regenerate on every script run; humans MUST NOT hand-edit.
+
+  (2) Human-authored sections — CIRIS-side compliance implementation,
+      observability hooks, known gaps. These are TODO blocks; humans
+      fill them in per-dimension. The script preserves these on
+      regeneration via fenced markers.
+
+Usage:
+  python3 tools/compliance/generate_ciris_compliance_stubs.py [seed_path] [output_dir]
+
+The script is idempotent: re-running preserves human-authored content
+between `<!-- BEGIN HUMAN -->` / `<!-- END HUMAN -->` fences while
+refreshing the auto-rendered sections.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent
+DEFAULT_SEED = REPO_ROOT / "SEED_DIMENSIONS.yaml"
+DEFAULT_OUTPUT = REPO_ROOT.parent / "CIRISAgent" / "compliance"
+
+HUMAN_BEGIN = "<!-- BEGIN HUMAN -->"
+HUMAN_END = "<!-- END HUMAN -->"
+
+
+def load_seed(path: Path) -> dict:
+    with path.open() as f:
+        return yaml.safe_load(f)
+
+
+def slugify_prefix(prefix: str) -> str:
+    s = re.sub(r"[^a-z0-9]+", "_", prefix.lower())
+    return s.strip("_")
+
+
+def conflicts_for_dimension(seed: dict, dim_id: str) -> list[dict]:
+    return [c for c in seed["aggregate_indices"]["conflicts_surfaced"] if dim_id in c.get("dimensions", [])]
+
+
+def t3_for_dimension(seed: dict, dim_id: str) -> list[dict]:
+    return [t for t in seed["aggregate_indices"]["t3_candidates_v1_5"] if t.get("affects_dimension") == dim_id]
+
+
+HUMAN_TEMPLATE = """\
+## CIRIS-side compliance implementation
+
+TODO — Fill in the code/policy/test surface that implements CIRIS Agent compliance with this dimension. Suggested fields:
+
+- **Code references**: modules / handlers / services / DMAs / conscience faculties implementing this
+- **Policy text**: relevant text in `MISSION_CIRISAgent.md`, `prohibitions.py`, `pdma_*.yml`, `language_guidance/*`
+- **Test coverage**: pointer to test files exercising this dimension
+- **Configuration surface**: relevant schemas / config blocks
+
+Proposed pointer (from seed): `{proposed_compliance_pointer}`
+
+## Observability hooks
+
+TODO — Fill in monitoring / observability surface:
+
+- **LensCore detectors**: which F-3 / Coherence Ratchet detectors observe this?
+- **RATCHET calibration**: which calibration packages apply?
+- **Audit chain queries**: how would a downstream consumer verify compliance?
+- **Federation evidence_refs**: emitted Contributions with `dimensions: [\"{dim_id}\"]`
+
+Proposed pointer (from seed): `{proposed_monitors_pointer}`
+
+## Known gaps / not-yet-implemented
+
+TODO — Honestly catalog anything this dimension requires that CIRIS Agent does not yet implement. Reference relevant `GAPS.md` entries from the response repo if applicable.
+"""
+
+
+def render_auto_section(dim: dict, batches_by_id: dict, seed: dict, seed_version: str) -> str:
+    parts: list[str] = []
+
+    counts = dim["attestations"]
+    parts.append(f"# {dim['id']} — `{dim['prefix']}` ({dim['tier']})")
+    parts.append("")
+    parts.append(f"> {dim['gloss']}")
+    parts.append("")
+    parts.append(
+        f"**Seed reference**: `SEED_DIMENSIONS.yaml` v{seed_version}, dimension `{dim['id']}` "
+        f"([source](https://github.com/CIRISAI/ciris-response-magnifica-humanitas/blob/main/SEED_DIMENSIONS.yaml))"
+    )
+    parts.append(f"**Accord principle**: {dim['accord_principle']}")
+    parts.append(
+        f"**Attestation density**: MH={counts['MH']} · EU={counts['EU']} · "
+        f"IEEE={counts['IEEE']} · ASEAN={counts['ASEAN']} · total={counts['total']}"
+    )
+    parts.append("")
+
+    absent = dim.get("absent_batch") or []
+    if absent:
+        for ab in absent:
+            bshort = batches_by_id.get(ab["batch_id"], {}).get("short", ab["batch_id"])
+            parts.append(f"**Absent from**: {bshort} — {ab['absence_note']}")
+            if ab.get("functional_analogue"):
+                parts.append(f"  *Functional analogue*: {ab['functional_analogue']}")
+            parts.append("")
+
+    parts.append("## Regulatory attestations")
+    parts.append("")
+    parts.append("*(Auto-rendered from seed; do not hand-edit. Re-run `python tools/compliance/generate_ciris_compliance_stubs.py tools/compliance/SEED_DIMENSIONS.yaml compliance/` after seed updates.)*")
+    parts.append("")
+    for ra in dim["regulatory_attestations"]:
+        b = batches_by_id.get(ra["batch_id"], {})
+        bshort = b.get("short", ra["batch_id"])
+        btitle = b.get("title", ra["batch_id"])
+        parts.append(f"- **{bshort}** ({btitle}) — *{ra['citation']}*")
+        parts.append(f'    > "{ra["language"]}"')
+        parts.append(f"    Wire form: `{ra['wire_form']}`")
+    parts.append("")
+
+    parts.append("## Wire primitives")
+    parts.append("")
+    for p in dim["wire_primitives"]:
+        parts.append(f"- `{p}`")
+    parts.append("")
+
+    note = dim.get("convergence_note")
+    if note:
+        parts.append("## Convergence note")
+        parts.append("")
+        parts.append(note)
+        parts.append("")
+
+    conflicts = conflicts_for_dimension(seed, dim["id"])
+    if conflicts:
+        parts.append("## Cross-source conflicts involving this dimension")
+        parts.append("")
+        for c in conflicts:
+            parts.append(f"- **{c['id']}** ({c['type']}, severity {c['severity']}): {c['claim']}")
+            if c.get("disposition"):
+                parts.append(f"    Disposition: {c['disposition']}")
+        parts.append("")
+
+    t3s = t3_for_dimension(seed, dim["id"])
+    if t3s:
+        parts.append("## v1.5+ T-3 candidates affecting this dimension")
+        parts.append("")
+        for t in t3s:
+            srcs = ", ".join(t.get("source") or [])
+            parts.append(f"- **{t['id']}** `{t['proposed_prefix']}` (priority {t['priority']}, source(s): {srcs})")
+        parts.append("")
+
+    return "\n".join(parts)
+
+
+def extract_human(existing_text: str) -> str | None:
+    if HUMAN_BEGIN not in existing_text or HUMAN_END not in existing_text:
+        return None
+    start = existing_text.index(HUMAN_BEGIN) + len(HUMAN_BEGIN)
+    end = existing_text.index(HUMAN_END)
+    return existing_text[start:end].strip("\n")
+
+
+def build_stub(dim: dict, batches_by_id: dict, seed: dict, seed_version: str, existing_path: Path | None) -> str:
+    auto = render_auto_section(dim, batches_by_id, seed, seed_version)
+
+    existing_human: str | None = None
+    if existing_path is not None and existing_path.exists():
+        existing_human = extract_human(existing_path.read_text())
+
+    if existing_human:
+        human_body = existing_human
+    else:
+        proposed_compliance = (dim.get("ciris_compliance") or {}).get("proposed_pointer") or "(none specified in seed; please fill)"
+        proposed_monitors = (dim.get("monitors") or {}).get("proposed_pointer") or "(none specified in seed; please fill)"
+        human_body = HUMAN_TEMPLATE.format(
+            proposed_compliance_pointer=proposed_compliance,
+            proposed_monitors_pointer=proposed_monitors,
+            dim_id=dim["id"],
+        )
+
+    return (
+        auto
+        + "\n---\n\n"
+        + HUMAN_BEGIN
+        + "\n"
+        + human_body.strip("\n")
+        + "\n"
+        + HUMAN_END
+        + "\n"
+    )
+
+
+def generate(seed_path: Path, output_dir: Path) -> None:
+    seed = load_seed(seed_path)
+    seed_version = seed["metadata"]["seed_version"]
+    batches_by_id = {b["id"]: b for b in seed["batches"]}
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    written = 0
+    preserved = 0
+    for dim in seed["dimensions"]:
+        filename = f"{dim['id']}_{slugify_prefix(dim['prefix'])}.md"
+        path = output_dir / filename
+
+        previously_existed = path.exists()
+        content = build_stub(dim, batches_by_id, seed, seed_version, path if previously_existed else None)
+        path.write_text(content)
+        written += 1
+        if previously_existed:
+            preserved += 1
+        print(f"  {'updated' if previously_existed else 'created'}: {filename}")
+
+    print(f"\nWrote {written} stubs to {output_dir}")
+    if preserved:
+        print(f"Preserved human-authored content in {preserved} pre-existing stubs.")
+
+
+if __name__ == "__main__":
+    seed_path = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_SEED
+    output_dir = Path(sys.argv[2]) if len(sys.argv) > 2 else DEFAULT_OUTPUT
+    generate(seed_path, output_dir)


### PR DESCRIPTION
This PR resolves Issue #798 by scaffolding out 27 dimension stubs to explicitly document CIRIS Agent's compliance mapping with regulatory attestations.

A script provided in the issue description was used with a specific `SEED_DIMENSIONS.yaml` to auto-generate the markdown files into a new `compliance/` directory. Each stub exposes auto-rendered regions along with commented bounds `<!-- BEGIN HUMAN -->` for future human authoring of code references and coverage gaps.

---
*PR created automatically by Jules for task [15270942439247743499](https://jules.google.com/task/15270942439247743499) started by @emooreatx*