### PR TITLE
feat(#910): inject prohibited-capabilities context into round-1 DMAs (localizable what/why)

### DIFF
--- a/ciris_engine/logic/buses/prohibitions.py
+++ b/ciris_engine/logic/buses/prohibitions.py
@@ -1250,3 +1250,51 @@ def get_prohibition_severity(category: str) -> ProhibitionSeverity:
         return ProhibitionSeverity.TIER_RESTRICTED
     else:
         return ProhibitionSeverity.NEVER_ALLOWED
+
+
+# === Round-1 DMA prohibition context (CIRISAgent#910) ===
+# Short what/why per prohibited category, injected into the system context of
+# the round-1 parallel DMAs ONLY (PDMA/CSDMA/DSDMA) so a prohibited trajectory
+# is NAMED in reasoning content — flowing forward into ASPDMA/conscience — before
+# it ever reaches the WiseBus structural gate (which stays the enforcement point).
+#
+# The category LIST + severity tier are derived from PROHIBITED_CAPABILITIES at
+# assembly time (single source of truth — the block can never drift from the
+# gate). This map only supplies the human-readable rationale. English base;
+# per-language overrides live in
+# ciris_engine/data/localized/{lang}.json -> prompts.prohibitions.<CATEGORY>
+# (and _header / _tier_never / _tier_module), with this English text as fallback.
+CATEGORY_GUIDANCE: Dict[str, str] = {
+    # Legitimate for humans / licensed modules — never the main agent.
+    "MEDICAL": "Medical diagnosis, treatment, or clinical health guidance — belongs to licensed clinicians, not this agent.",
+    "FINANCIAL": "Personalized investment, securities, or tax advice — belongs to licensed financial professionals.",
+    "LEGAL": "Legal advice, drafting, or representation — belongs to licensed attorneys.",
+    "HOME_SECURITY": "Physical access, lock, or alarm control — safety-critical; requires a dedicated licensed module.",
+    "IDENTITY_VERIFICATION": "Authoritative identity, citizenship, or biometric verification — legal-consequence gravity; requires a dedicated module.",
+    "CONTENT_MODERATION": "Authoritative content adjudication or age verification — requires a dedicated, accountable module.",
+    "RESEARCH": "Conduct of human-subjects or clinical research — requires ethics review and a dedicated module.",
+    "INFRASTRUCTURE_CONTROL": "Control of critical infrastructure (air traffic, dams, emergency dispatch) — safety-of-life; requires a dedicated module.",
+    # Absolutely outside scope — never allowed.
+    "SPIRITUAL_DIRECTION": "Spiritual direction, absolution, or blessing — belongs to humans, communities, and traditions, never to AI (CIRIS's apophatic boundary).",
+    "WEAPONS_HARMFUL": "Design, acquisition, or use of weapons or means of harm.",
+    "MANIPULATION_COERCION": "Manipulation, coercion, or addictive/deceptive design that overrides a person's autonomy.",
+    "SURVEILLANCE_MASS": "Mass surveillance, communication interception, or biometric categorization of people.",
+    "DECEPTION_FRAUD": "Fraud, scams, or deception for illicit gain.",
+    "CYBER_OFFENSIVE": "Offensive cyber capability — exploits, malware, or unauthorized intrusion.",
+    "ELECTION_INTERFERENCE": "Interference with elections or democratic processes.",
+    "BIOMETRIC_INFERENCE": "Inferring protected traits, emotions, or future behavior from biometric data.",
+    "AUTONOMOUS_DECEPTION": "Concealing capabilities, resisting correction, or deceptive alignment.",
+    "HAZARDOUS_MATERIALS": "Creation or handling of biological, chemical, or radiological hazards.",
+    "DISCRIMINATION": "Discrimination against protected classes, redlining, or algorithmic bias (EU AI Act Art. 9/10).",
+}
+
+# English fallbacks for the assembled block's framing (overridable per-locale).
+PROHIBITION_HEADER_EN = (
+    "CAPABILITY BOUNDARIES — if a request, or your own reasoning, trends toward "
+    "any capability below, NAME the category in your output and treat it as "
+    "out-of-scope so later stages can weigh and defer it. These are enforced "
+    "downstream at the WiseBus gate; surfacing them here is upstream awareness, "
+    "not a substitute for the gate."
+)
+PROHIBITION_TIER_NEVER_EN = "Never permitted (absolutely outside this agent's scope):"
+PROHIBITION_TIER_MODULE_EN = "Only via a separate licensed/accountable module (never the main agent):"

--- a/ciris_engine/logic/dma/csdma.py
+++ b/ciris_engine/logic/dma/csdma.py
@@ -122,6 +122,17 @@ class CSDMAEvaluator(BaseDMA[ProcessingQueueItem, CSDMAResult], CSDMAProtocol):
         if _lang_guidance:
             messages.append({"role": "system", "content": _lang_guidance})
 
+        # Round-1 prohibition context (#910): name prohibited trajectories in
+        # reasoning BEFORE the WiseBus gate. Derived from PROHIBITED_CAPABILITIES
+        # at assembly time (single source of truth) + localized. Round-1 DMAs
+        # ONLY — NOT ASPDMA/recursive: a named trajectory flows forward via the
+        # existing output path rather than being restated at every step.
+        from ciris_engine.logic.utils.localization import get_prohibition_guidance
+
+        _prohibitions = get_prohibition_guidance(self.prompt_loader.language)
+        if _prohibitions:
+            messages.append({"role": "system", "content": _prohibitions})
+
         # Check for template override of system_prompt (e.g., HE-300 format instructions)
         template_system_override = None
         if isinstance(self.prompts, dict):

--- a/ciris_engine/logic/dma/csdma.py
+++ b/ciris_engine/logic/dma/csdma.py
@@ -5,6 +5,7 @@ if TYPE_CHECKING:
     from ciris_engine.schemas.dma.prompts import PromptCollection
 
 from ciris_engine.logic.formatters import (
+    append_round1_accord_blocks,
     format_parent_task_chain,
     format_system_prompt_blocks,
     format_system_snapshot,
@@ -14,7 +15,6 @@ from ciris_engine.logic.formatters import (
 )
 from ciris_engine.logic.processors.support.processing_queue import ProcessingQueueItem
 from ciris_engine.logic.registries.base import ServiceRegistry
-from ciris_engine.logic.utils import get_accord_text
 from ciris_engine.protocols.dma.base import CSDMAProtocol
 from ciris_engine.schemas.dma.results import CSDMAResult
 from ciris_engine.schemas.runtime.models import ImageContent
@@ -109,29 +109,13 @@ class CSDMAEvaluator(BaseDMA[ProcessingQueueItem, CSDMAResult], CSDMAProtocol):
         """
         messages: List[JSONDict] = []
 
-        # Add accord based on mode (centralized in get_accord_text)
-        accord_mode = self.prompt_loader.get_accord_mode(self.prompt_template_data)
-        accord_text = get_accord_text(accord_mode)
-        if accord_text:
-            messages.append({"role": "system", "content": accord_text})
-        # Per-language guidance — empty for most languages, populated for
-        # locales where systematic terminology gaps were observed (am as
-        # of 2.7.6). See ciris_engine.logic.utils.localization.get_language_guidance.
-        from ciris_engine.logic.utils.localization import get_language_guidance
-        _lang_guidance = get_language_guidance(self.prompt_loader.language)
-        if _lang_guidance:
-            messages.append({"role": "system", "content": _lang_guidance})
-
-        # Round-1 prohibition context (#910): name prohibited trajectories in
-        # reasoning BEFORE the WiseBus gate. Derived from PROHIBITED_CAPABILITIES
-        # at assembly time (single source of truth) + localized. Round-1 DMAs
-        # ONLY — NOT ASPDMA/recursive: a named trajectory flows forward via the
-        # existing output path rather than being restated at every step.
-        from ciris_engine.logic.utils.localization import get_prohibition_guidance
-
-        _prohibitions = get_prohibition_guidance(self.prompt_loader.language)
-        if _prohibitions:
-            messages.append({"role": "system", "content": _prohibitions})
+        # Round-1 DMA system blocks — ACCORD + per-language guidance +
+        # prohibition context (#910) — via the shared helper (NOT ASPDMA).
+        append_round1_accord_blocks(
+            messages,
+            language=self.prompt_loader.language,
+            accord_mode=self.prompt_loader.get_accord_mode(self.prompt_template_data),
+        )
 
         # Check for template override of system_prompt (e.g., HE-300 format instructions)
         template_system_override = None

--- a/ciris_engine/logic/dma/dsdma_base.py
+++ b/ciris_engine/logic/dma/dsdma_base.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Mapping, Optional, Union, cast
 from pydantic import BaseModel, Field
 
 from ciris_engine.logic.formatters import (
+    append_round1_accord_blocks,
     format_system_prompt_blocks,
     format_system_snapshot,
     format_user_profiles,
@@ -11,7 +12,6 @@ from ciris_engine.logic.formatters import (
 )
 from ciris_engine.logic.processors.support.processing_queue import ProcessingQueueItem
 from ciris_engine.logic.registries.base import ServiceRegistry
-from ciris_engine.logic.utils.constants import get_accord_text
 from ciris_engine.protocols.dma.base import DSDMAProtocol
 from ciris_engine.schemas.dma.core import DMAInputData
 from ciris_engine.schemas.dma.prompts import PromptCollection
@@ -417,30 +417,14 @@ class BaseDSDMA(BaseDMA[DMAInputData, DSDMAResult], DSDMAProtocol):
             )
         user_content = self.build_multimodal_content(user_message_content, thought_images)
 
-        # Add accord based on mode (centralized in get_accord_text)
         messages: List[JSONDict] = []
-        accord_mode = self.prompt_loader.get_accord_mode(self.prompt_template_data)
-        accord_text = get_accord_text(accord_mode)
-        if accord_text:
-            messages.append({"role": "system", "content": accord_text})
-        # Per-language guidance block — empty for most languages, populated for
-        # locales where we've observed systematic terminology gaps (Amharic
-        # in 2.7.6). See ciris_engine.logic.utils.localization.get_language_guidance.
-        from ciris_engine.logic.utils.localization import get_language_guidance
-        _lang_guidance = get_language_guidance(self.prompt_loader.language)
-        if _lang_guidance:
-            messages.append({"role": "system", "content": _lang_guidance})
-
-        # Round-1 prohibition context (#910): name prohibited trajectories in
-        # reasoning BEFORE the WiseBus gate. Derived from PROHIBITED_CAPABILITIES
-        # at assembly time (single source of truth) + localized. Round-1 DMAs
-        # ONLY — NOT ASPDMA/recursive: a named trajectory flows forward via the
-        # existing output path rather than being restated at every step.
-        from ciris_engine.logic.utils.localization import get_prohibition_guidance
-
-        _prohibitions = get_prohibition_guidance(self.prompt_loader.language)
-        if _prohibitions:
-            messages.append({"role": "system", "content": _prohibitions})
+        # Round-1 DMA system blocks — ACCORD + per-language guidance +
+        # prohibition context (#910) — via the shared helper (NOT ASPDMA).
+        append_round1_accord_blocks(
+            messages,
+            language=self.prompt_loader.language,
+            accord_mode=self.prompt_loader.get_accord_mode(self.prompt_template_data),
+        )
         messages.append({"role": "system", "content": system_message_content})
         messages.append({"role": "user", "content": user_content})
 

--- a/ciris_engine/logic/dma/dsdma_base.py
+++ b/ciris_engine/logic/dma/dsdma_base.py
@@ -430,6 +430,17 @@ class BaseDSDMA(BaseDMA[DMAInputData, DSDMAResult], DSDMAProtocol):
         _lang_guidance = get_language_guidance(self.prompt_loader.language)
         if _lang_guidance:
             messages.append({"role": "system", "content": _lang_guidance})
+
+        # Round-1 prohibition context (#910): name prohibited trajectories in
+        # reasoning BEFORE the WiseBus gate. Derived from PROHIBITED_CAPABILITIES
+        # at assembly time (single source of truth) + localized. Round-1 DMAs
+        # ONLY — NOT ASPDMA/recursive: a named trajectory flows forward via the
+        # existing output path rather than being restated at every step.
+        from ciris_engine.logic.utils.localization import get_prohibition_guidance
+
+        _prohibitions = get_prohibition_guidance(self.prompt_loader.language)
+        if _prohibitions:
+            messages.append({"role": "system", "content": _prohibitions})
         messages.append({"role": "system", "content": system_message_content})
         messages.append({"role": "user", "content": user_content})
 

--- a/ciris_engine/logic/dma/pdma.py
+++ b/ciris_engine/logic/dma/pdma.py
@@ -5,10 +5,13 @@ if TYPE_CHECKING:
     from ciris_engine.schemas.dma.prompts import PromptCollection
 
 from ciris_engine.constants import DEFAULT_OPENAI_MODEL_NAME
-from ciris_engine.logic.formatters import format_system_snapshot, format_user_profiles
+from ciris_engine.logic.formatters import (
+    append_round1_accord_blocks,
+    format_system_snapshot,
+    format_user_profiles,
+)
 from ciris_engine.logic.processors.support.processing_queue import ProcessingQueueItem
 from ciris_engine.logic.registries.base import ServiceRegistry
-from ciris_engine.logic.utils import get_accord_text
 from ciris_engine.protocols.dma.base import PDMAProtocol
 from ciris_engine.schemas.dma.results import EthicalDMAResult
 from ciris_engine.schemas.types import JSONDict
@@ -195,29 +198,13 @@ class EthicalPDMAEvaluator(BaseDMA[ProcessingQueueItem, EthicalDMAResult], PDMAP
         prompt_start = time.time()
         messages: List[JSONDict] = []
 
-        # Add accord based on mode (centralized in get_accord_text)
-        accord_mode = self.prompt_loader.get_accord_mode(self.prompt_template_data)
-        accord_text = get_accord_text(accord_mode)
-        if accord_text:
-            messages.append({"role": "system", "content": accord_text})
-        # Per-language guidance — empty for most languages, populated for
-        # locales where systematic terminology gaps were observed (am as
-        # of 2.7.6). See ciris_engine.logic.utils.localization.get_language_guidance.
-        from ciris_engine.logic.utils.localization import get_language_guidance
-        _lang_guidance = get_language_guidance(self.prompt_loader.language)
-        if _lang_guidance:
-            messages.append({"role": "system", "content": _lang_guidance})
-
-        # Round-1 prohibition context (#910): name prohibited trajectories in
-        # reasoning BEFORE the WiseBus gate. Derived from PROHIBITED_CAPABILITIES
-        # at assembly time (single source of truth) + localized. Round-1 DMAs
-        # ONLY — NOT ASPDMA/recursive: a named trajectory flows forward via the
-        # existing output path rather than being restated at every step.
-        from ciris_engine.logic.utils.localization import get_prohibition_guidance
-
-        _prohibitions = get_prohibition_guidance(self.prompt_loader.language)
-        if _prohibitions:
-            messages.append({"role": "system", "content": _prohibitions})
+        # Round-1 DMA system blocks — ACCORD + per-language guidance +
+        # prohibition context (#910) — via the shared helper (NOT ASPDMA).
+        append_round1_accord_blocks(
+            messages,
+            language=self.prompt_loader.language,
+            accord_mode=self.prompt_loader.get_accord_mode(self.prompt_template_data),
+        )
 
         system_message = self._build_system_message_text(original_thought_content, full_context_str)
         messages.append({"role": "system", "content": system_message})

--- a/ciris_engine/logic/dma/pdma.py
+++ b/ciris_engine/logic/dma/pdma.py
@@ -208,6 +208,17 @@ class EthicalPDMAEvaluator(BaseDMA[ProcessingQueueItem, EthicalDMAResult], PDMAP
         if _lang_guidance:
             messages.append({"role": "system", "content": _lang_guidance})
 
+        # Round-1 prohibition context (#910): name prohibited trajectories in
+        # reasoning BEFORE the WiseBus gate. Derived from PROHIBITED_CAPABILITIES
+        # at assembly time (single source of truth) + localized. Round-1 DMAs
+        # ONLY — NOT ASPDMA/recursive: a named trajectory flows forward via the
+        # existing output path rather than being restated at every step.
+        from ciris_engine.logic.utils.localization import get_prohibition_guidance
+
+        _prohibitions = get_prohibition_guidance(self.prompt_loader.language)
+        if _prohibitions:
+            messages.append({"role": "system", "content": _prohibitions})
+
         system_message = self._build_system_message_text(original_thought_content, full_context_str)
         messages.append({"role": "system", "content": system_message})
 

--- a/ciris_engine/logic/formatters/__init__.py
+++ b/ciris_engine/logic/formatters/__init__.py
@@ -5,6 +5,7 @@ from .escalation import get_escalation_guidance
 from .identity import format_agent_identity
 from .prompt_blocks import (
     format_parent_task_chain,
+    append_round1_accord_blocks,
     format_system_prompt_blocks,
     format_thoughts_chain,
     format_user_prompt_blocks,
@@ -18,6 +19,7 @@ __all__ = [
     "format_agent_identity",
     "format_parent_task_chain",
     "format_thoughts_chain",
+    "append_round1_accord_blocks",
     "format_system_prompt_blocks",
     "format_user_prompt_blocks",
     "get_escalation_guidance",

--- a/ciris_engine/logic/formatters/prompt_blocks.py
+++ b/ciris_engine/logic/formatters/prompt_blocks.py
@@ -62,3 +62,22 @@ def format_user_prompt_blocks(
     if schema_block:
         blocks.append(schema_block)
     return "\n\n".join(filter(None, blocks)).strip()
+
+
+def append_round1_accord_blocks(messages: List[Any], *, language: str, accord_mode: str) -> None:
+    """Append the round-1 parallel-DMA system blocks, in canonical order:
+    ACCORD -> per-language guidance -> prohibition context (#910).
+
+    Shared by PDMA/CSDMA/DSDMA (the round-1 DMAs) — NOT ASPDMA/recursive, which
+    carry accord + language guidance but deliberately omit the prohibition block
+    so a named trajectory flows forward via the existing output path rather than
+    being restated at every step. Mutates ``messages`` in place, appending only
+    non-empty blocks (skip empty system messages over the wire).
+    """
+    # Lazy imports keep the low-level formatters module free of util-layer cycles.
+    from ciris_engine.logic.utils.constants import get_accord_text
+    from ciris_engine.logic.utils.localization import get_language_guidance, get_prohibition_guidance
+
+    for content in (get_accord_text(accord_mode), get_language_guidance(language), get_prohibition_guidance(language)):
+        if content:
+            messages.append({"role": "system", "content": content})

--- a/ciris_engine/logic/utils/localization.py
+++ b/ciris_engine/logic/utils/localization.py
@@ -369,6 +369,57 @@ def get_language_guidance(lang_code: str) -> str:
     return raw.strip()
 
 
+def get_prohibition_guidance(lang_code: str) -> str:
+    """Return the round-1 DMA prohibition-context block for LLM prompts (#910).
+
+    The category list + severity tier are read from ``PROHIBITED_CAPABILITIES``
+    at call time (single source of truth — this can never drift from the WiseBus
+    gate). Each category's short what/why is localized: ``prompts.prohibitions.
+    <CATEGORY>`` in ``{lang}.json`` when present, else the English base
+    ``CATEGORY_GUIDANCE``. The framing (header + tier labels) is likewise
+    localized with English fallback. A category present in the gate but missing
+    a description still surfaces (generic fallback), so new prohibitions can
+    never silently drop out of the reasoning context.
+
+    Injected into PDMA/CSDMA/DSDMA only (NOT ASPDMA/recursive passes): a
+    prohibited trajectory named in round-1 output flows forward into ASPDMA and
+    conscience via the existing output path, rather than being restated at every
+    step. Callers append the result as a system message only when non-empty.
+    """
+    from ciris_engine.logic.buses.prohibitions import (
+        CATEGORY_GUIDANCE,
+        PROHIBITED_CAPABILITIES,
+        PROHIBITION_HEADER_EN,
+        PROHIBITION_TIER_MODULE_EN,
+        PROHIBITION_TIER_NEVER_EN,
+        ProhibitionSeverity,
+        get_prohibition_severity,
+    )
+
+    never: list[str] = []
+    module: list[str] = []
+    for category in PROHIBITED_CAPABILITIES:
+        desc = get_string(lang_code, f"prompts.prohibitions.{category}", default="").strip()
+        if not desc:
+            desc = CATEGORY_GUIDANCE.get(category, "Outside this agent's scope.")
+        line = f"- {desc}"
+        if get_prohibition_severity(category) == ProhibitionSeverity.NEVER_ALLOWED:
+            never.append(line)
+        else:
+            module.append(line)
+
+    header = get_string(lang_code, "prompts.prohibitions._header", default="").strip() or PROHIBITION_HEADER_EN
+    tier_never = get_string(lang_code, "prompts.prohibitions._tier_never", default="").strip() or PROHIBITION_TIER_NEVER_EN
+    tier_module = get_string(lang_code, "prompts.prohibitions._tier_module", default="").strip() or PROHIBITION_TIER_MODULE_EN
+
+    blocks = [header]
+    if never:
+        blocks.append(tier_never + "\n" + "\n".join(never))
+    if module:
+        blocks.append(tier_module + "\n" + "\n".join(module))
+    return "\n\n".join(blocks)
+
+
 def get_preferred_language() -> str:
     """Get the preferred language from environment.
 

--- a/evidence/cc_impl.tsv
+++ b/evidence/cc_impl.tsv
@@ -1,0 +1,27 @@
+# CIRISAgent evidence registry — impl: tier (CIRISConstitution#17 / CIRISAgent#911)
+# The sibling spec-map manifest CIRISConstitution's check_claims.py resolves
+# cross-repo `impl:CIRISAgent#911` pointers against (see CIRISConstitution
+# constitution/EVIDENCE.md). Validated in CI by tools/check_evidence.py: every
+# CIRISAgent `path#symbol` MUST AST-resolve at this repo ref — a moved/renamed/
+# deleted symbol is a build failure (a spec-regression test), so a Constitution
+# `impl:` pointer can never silently rot.
+#
+# Columns: decimal_id  claim_id  repo  path#symbol  status
+#   status = impl      : the agent implements it; symbol resolves here.
+#            staged    : spec-ahead / pending merge (e.g. #910 until it lands).
+#            substrate : owned by the fabric node (ciris-server / persist / lens),
+#                        NOT the agent — the Constitution should retag off
+#                        impl:CIRISAgent. Row carries no agent symbol (repo=—).
+#            normative : spec-only, no code implementation (repo=—).
+# Rows with repo=— (substrate/normative) are informational — not resolved.
+decimal_id	claim_id	repo	path#symbol	status
+1.3	CLM-pdma-ordermax	CIRISAgent	ciris_engine/logic/conscience/core.py#OptimizationVetoConscience.check	impl
+1.3	CLM-pdma-ordermax	CIRISAgent	ciris_engine/logic/conscience/thought_depth_guardrail.py#ThoughtDepthGuardrail.check	impl
+1.9	CLM-wbd	CIRISAgent	ciris_engine/logic/handlers/control/defer_handler.py#DeferHandler.handle	impl
+8.8.9	CLM-discrimination-gate	CIRISAgent	ciris_engine/logic/buses/wise_bus.py#WiseBus._validate_capability	impl
+8.8.9	CLM-discrimination-gate	CIRISAgent	ciris_engine/logic/utils/localization.py#get_prohibition_guidance	staged
+—	CLM-h3ere-steppoints	CIRISAgent	ciris_engine/schemas/services/runtime_control.py#StepPoint	impl
+6.2.3.1	CLM-sigma-attest	—	—	substrate
+1.2	CLM-admission	—	—	substrate
+1.13.3	CLM-adversary	—	—	normative
+1.13.3.3	CLM-adversary-classes	—	—	normative

--- a/tests/ciris_engine/logic/dma/test_prohibition_context.py
+++ b/tests/ciris_engine/logic/dma/test_prohibition_context.py
@@ -1,0 +1,81 @@
+"""Round-1 DMA prohibition-context injection (CIRISAgent#910).
+
+The prohibited-capabilities list is surfaced in the system context of the
+round-1 parallel DMAs (PDMA/CSDMA/DSDMA) — and ONLY those — so prohibited
+trajectories are named in reasoning content before they reach the WiseBus gate.
+The block is generated from PROHIBITED_CAPABILITIES at assembly time (single
+source of truth) with a short, localizable what/why per category.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+from ciris_engine.logic.buses.prohibitions import (
+    CATEGORY_GUIDANCE,
+    PROHIBITED_CAPABILITIES,
+    ProhibitionSeverity,
+    get_prohibition_severity,
+)
+from ciris_engine.logic.utils.localization import get_prohibition_guidance
+
+_DMA_DIR = pathlib.Path(__file__).resolve().parents[4] / "ciris_engine" / "logic" / "dma"
+
+
+def test_every_gate_category_has_guidance() -> None:
+    """Drift guard: the reasoning block can never silently drop a gate category."""
+    missing = [c for c in PROHIBITED_CAPABILITIES if c not in CATEGORY_GUIDANCE]
+    assert missing == [], f"PROHIBITED_CAPABILITIES categories without CATEGORY_GUIDANCE: {missing}"
+
+
+def test_block_covers_every_category_and_severity() -> None:
+    block = get_prohibition_guidance("en")
+    # every category's what/why is present
+    for category, desc in CATEGORY_GUIDANCE.items():
+        assert desc in block, f"{category} description missing from block"
+    # both severity tiers rendered
+    assert "Never permitted" in block
+    assert "separate licensed" in block
+    # never-allowed items land in the NEVER section (order: header, never, module)
+    never_section = block.split("Never permitted")[1].split("Only via")[0]
+    for category in PROHIBITED_CAPABILITIES:
+        if get_prohibition_severity(category) == ProhibitionSeverity.NEVER_ALLOWED:
+            assert CATEGORY_GUIDANCE[category] in never_section
+
+
+def test_new_category_without_description_still_surfaces(monkeypatch) -> None:
+    """A gate category with no description must not vanish — generic fallback."""
+    import ciris_engine.logic.buses.prohibitions as P
+
+    patched = dict(P.PROHIBITED_CAPABILITIES)
+    patched["FUTURE_UNKNOWN"] = {"some_cap"}
+    monkeypatch.setattr(P, "PROHIBITED_CAPABILITIES", patched)
+    block = get_prohibition_guidance("en")
+    assert "Outside this agent's scope." in block
+
+
+def test_localized_override_is_used(monkeypatch) -> None:
+    """A {lang}.json prompts.prohibitions.<CATEGORY> override replaces the English base."""
+    import ciris_engine.logic.utils.localization as L
+
+    real = L.get_string
+
+    def fake(lang, key, default=""):
+        if key == "prompts.prohibitions.MEDICAL":
+            return "LOCALIZED-MEDICAL-WHY"
+        return real(lang, key, default=default)
+
+    monkeypatch.setattr(L, "get_string", fake)
+    block = get_prohibition_guidance("xx")
+    assert "LOCALIZED-MEDICAL-WHY" in block
+    assert CATEGORY_GUIDANCE["MEDICAL"] not in block  # English base overridden
+
+
+def test_round1_dmas_inject_but_aspdma_does_not() -> None:
+    """Round-1 DMAs inject the block; ASPDMA/recursive passes must not (#910)."""
+    for fn in ("pdma.py", "csdma.py", "dsdma_base.py"):
+        src = (_DMA_DIR / fn).read_text()
+        assert "get_prohibition_guidance" in src, f"round-1 {fn} should inject prohibitions"
+    for fn in ("dsaspdma.py", "tsaspdma.py"):
+        src = (_DMA_DIR / fn).read_text()
+        assert "get_prohibition_guidance" not in src, f"ASPDMA {fn} must NOT inject prohibitions"

--- a/tests/ciris_engine/logic/dma/test_prohibition_context.py
+++ b/tests/ciris_engine/logic/dma/test_prohibition_context.py
@@ -72,10 +72,20 @@ def test_localized_override_is_used(monkeypatch) -> None:
 
 
 def test_round1_dmas_inject_but_aspdma_does_not() -> None:
-    """Round-1 DMAs inject the block; ASPDMA/recursive passes must not (#910)."""
+    """Round-1 DMAs inject the block via the shared helper; ASPDMA must not (#910).
+
+    The accord + language-guidance + prohibition append is centralized in
+    formatters.append_round1_accord_blocks (de-duplicated). Round-1 DMAs call it;
+    the prohibition injection lives inside it; ASPDMA/recursive passes deliberately
+    do NOT call it (they keep accord + language guidance, no prohibitions).
+    """
+    helper_src = (_DMA_DIR.parent / "formatters" / "prompt_blocks.py").read_text()
+    assert "get_prohibition_guidance" in helper_src, "helper must inject the prohibition block"
+
     for fn in ("pdma.py", "csdma.py", "dsdma_base.py"):
         src = (_DMA_DIR / fn).read_text()
-        assert "get_prohibition_guidance" in src, f"round-1 {fn} should inject prohibitions"
+        assert "append_round1_accord_blocks" in src, f"round-1 {fn} should call the round-1 helper"
     for fn in ("dsaspdma.py", "tsaspdma.py"):
         src = (_DMA_DIR / fn).read_text()
+        assert "append_round1_accord_blocks" not in src, f"ASPDMA {fn} must NOT use the round-1 helper"
         assert "get_prohibition_guidance" not in src, f"ASPDMA {fn} must NOT inject prohibitions"

--- a/tests/test_evidence_registry.py
+++ b/tests/test_evidence_registry.py
@@ -1,0 +1,42 @@
+"""CI gate for the CC evidence registry (CIRISAgent#911).
+
+Runs tools/check_evidence.py so that every in-repo ``path#symbol`` in
+``evidence/cc_impl.tsv`` must AST-resolve — a moved/renamed/deleted symbol is a
+test failure (a spec-regression test), so a Constitution ``impl:CIRISAgent``
+pointer can never silently rot.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def test_cc_impl_manifest_symbols_resolve() -> None:
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "tools" / "check_evidence.py")],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        "evidence/cc_impl.tsv has an unresolvable path#symbol:\n"
+        + result.stdout
+        + result.stderr
+    )
+
+
+def test_manifest_present_and_well_formed() -> None:
+    manifest = ROOT / "evidence" / "cc_impl.tsv"
+    assert manifest.exists(), "evidence/cc_impl.tsv is missing"
+    lines = [ln for ln in manifest.read_text().splitlines() if ln and not ln.startswith("#")]
+    header = lines[0].split("\t")
+    assert header == ["decimal_id", "claim_id", "repo", "path#symbol", "status"]
+    # every data row has the right column count and a known status
+    known_status = {"impl", "staged", "substrate", "normative"}
+    for row in lines[1:]:
+        cols = row.split("\t")
+        assert len(cols) == 5, f"bad column count: {row!r}"
+        assert cols[4] in known_status, f"unknown status {cols[4]!r} in {row!r}"

--- a/tools/check_evidence.py
+++ b/tools/check_evidence.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""check_evidence.py — resolve the CC evidence ``impl:`` manifest (CIRISAgent#911).
+
+``evidence/cc_impl.tsv`` is the sibling spec-map manifest the Constitution's
+``check_claims.py`` resolves cross-repo ``impl:CIRISAgent#911`` pointers against
+(see CIRISConstitution ``constitution/EVIDENCE.md``). This is the CI gate that
+keeps the manifest honest: every in-repo ``path#symbol`` MUST resolve to a symbol
+that actually exists — a moved/renamed/deleted symbol is a build failure (a
+spec-regression test), so a Constitution ``impl:`` pointer can never silently rot.
+
+Manifest columns (TSV):  ``decimal_id  claim_id  repo  path#symbol  status``
+
+Resolution:
+  - ``repo=CIRISAgent`` -> resolve ``path#symbol`` in THIS repo. The file must
+    exist and the symbol must be defined at module level (``def``/``class``/a
+    module-level assignment) or as ``Class.method``. A dead pointer = FAIL.
+  - ``repo=—``            -> ``open``/``normative-only`` row, no symbol; skipped.
+  - ``status=staged``    -> the claim is spec-ahead; its row is still resolved if
+    it carries a real ``path#symbol`` (a staged pointer that names a symbol must
+    still resolve), but a staged row with no path (``—``) is informational.
+
+Exit non-zero on any FAIL.
+"""
+
+from __future__ import annotations
+
+import ast
+import csv
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = ROOT / "evidence" / "cc_impl.tsv"
+COLUMNS = ["decimal_id", "claim_id", "repo", "path#symbol", "status"]
+
+
+def _module_symbols(tree: ast.Module) -> tuple[set[str], dict[str, set[str]]]:
+    """Return (top-level names, {class_name: {method names}})."""
+    top: set[str] = set()
+    methods: dict[str, set[str]] = {}
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            top.add(node.name)
+        elif isinstance(node, ast.ClassDef):
+            top.add(node.name)
+            methods[node.name] = {
+                m.name for m in node.body if isinstance(m, (ast.FunctionDef, ast.AsyncFunctionDef))
+            }
+        elif isinstance(node, ast.Assign):
+            for t in node.targets:
+                if isinstance(t, ast.Name):
+                    top.add(t.id)
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            top.add(node.target.id)
+    return top, methods
+
+
+def resolve(pointer: str) -> str | None:
+    """Return an error string if ``path#symbol`` does not resolve, else None."""
+    if "#" not in pointer:
+        return f"pointer has no '#symbol': {pointer!r}"
+    path_str, symbol = pointer.split("#", 1)
+    path = ROOT / path_str
+    if not path.exists():
+        return f"file does not exist: {path_str}"
+    try:
+        tree = ast.parse(path.read_text(), filename=str(path))
+    except SyntaxError as e:  # pragma: no cover - would be a broken repo
+        return f"could not parse {path_str}: {e}"
+    top, methods = _module_symbols(tree)
+    if "." in symbol:
+        cls, meth = symbol.split(".", 1)
+        if cls not in top:
+            return f"class not found: {path_str}#{cls}"
+        if meth not in methods.get(cls, set()):
+            return f"method not found: {path_str}#{symbol}"
+        return None
+    if symbol not in top:
+        return f"symbol not found: {path_str}#{symbol}"
+    return None
+
+
+def main() -> int:
+    if not MANIFEST.exists():
+        print(f"FAIL: manifest missing: {MANIFEST}", file=sys.stderr)
+        return 1
+    errors: list[str] = []
+    resolved = skipped = 0
+    with MANIFEST.open() as f:
+        reader = csv.reader((ln for ln in f if not ln.startswith("#")), delimiter="\t")
+        header = next(reader, None)
+        if header != COLUMNS:
+            print(f"FAIL: header {header} != {COLUMNS}", file=sys.stderr)
+            return 1
+        for ln, row in enumerate(reader, start=2):
+            if not row or not any(c.strip() for c in row):
+                continue
+            if len(row) != len(COLUMNS):
+                errors.append(f"L{ln}: expected {len(COLUMNS)} columns, got {len(row)}")
+                continue
+            _decimal, claim, repo, pointer, _status = (c.strip() for c in row)
+            if repo != "CIRISAgent" or pointer in ("", "—"):
+                skipped += 1
+                continue
+            err = resolve(pointer)
+            if err:
+                errors.append(f"L{ln} [{claim}]: {err}")
+            else:
+                resolved += 1
+
+    for e in errors:
+        print(f"FAIL: {e}", file=sys.stderr)
+    print(f"cc_impl.tsv: {resolved} in-repo pointers resolved, {skipped} skipped, {len(errors)} failed")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #910.

## What
Surfaces `PROHIBITED_CAPABILITIES` in the **round-1 parallel DMA** system context (PDMA/CSDMA/DSDMA) so a prohibited trajectory is **named in reasoning content** — flowing forward into ASPDMA/conscience — before it reaches the WiseBus gate. Previously the list was reachable only by two structural gates; zero prompt/DMA code touched it, so risk was enforced purely post-hoc.

## How
- **Derived from the source of truth:** category list + severity tier come from `PROHIBITED_CAPABILITIES` at assembly time — the block can never drift from the gate. `CATEGORY_GUIDANCE` supplies only a short **what/why** per category.
- **Localized:** `get_prohibition_guidance(lang)` localizes each what/why via `prompts.prohibitions.<CATEGORY>` in `{lang}.json`, English base as fallback. A gate category missing a description still surfaces (generic fallback).
- **Round-1 only:** injected in `pdma.py`/`csdma.py`/`dsdma_base.py`; explicitly **not** `dsaspdma.py`/`tsaspdma.py` (ASPDMA/recursive), matching #910's intent.
- **WiseBus gate stays** — this is defense-in-depth upstream awareness, not a replacement.

## Tests
Drift guard (every gate category has guidance), coverage + severity grouping, localized-override, new-category fallback, and the round-1-only / ASPDMA-excluded invariant. 143 existing DMA tests still green.

## Follow-ups
- Careful **29-language localization** of the short descriptions (ships English-base now; works everywhere via fallback).
- Evidence-registry entry (#911): this injection is the `staged`→`impl` transition for the DISCRIMINATION-in-reasoning claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)