### PR TITLE
ci(research): land the trace-capture workflow on main so it is dispatchable

### DIFF
--- a/.github/workflows/research-capture.yml
+++ b/.github/workflows/research-capture.yml
@@ -1,0 +1,204 @@
+name: Research Trace Capture
+
+# Signed CEG trace capture for the research team, run from the Actions tab.
+#
+# Patterned on safety-battery.yml: same secret-check-then-skip shape, same
+# umask-077 key write, same Sigstore attestation on the bundle, same artifact
+# conventions. The API key is a repository secret; everything else is a form
+# field, so a capture leaves no credential in the run configuration.
+#
+# WHY A WORKFLOW RATHER THAN A LOCAL IMAGE: a pre-registered campaign has to be
+# able to say which artifact produced which number. A run URL plus an
+# attestation does that; "the capture I ran on Tuesday" does not. It also means
+# no image build, no digest to track, and no contention for a shared dev box.
+#
+# Outputs: one ceg-seal-<trace_id>.json per sealed trace at three detail levels
+# (generic / detailed / full_traces). Each is the CEG carrier AS IT WOULD SHIP —
+# the full federation_attestations row including scrub_signature_classical,
+# scrub_signature_pqc and original_content_hash.
+
+on:
+  workflow_dispatch:
+    inputs:
+      provider:
+        description: 'LLM provider (selects which *_API_KEY secret is used)'
+        default: 'openrouter'
+        type: choice
+        options: [openrouter, together, groq, openai, deepinfra]
+      model:
+        description: 'Model id — CASE-SENSITIVE. Together lists both google/gemma-4-31B-it and pearl-ai/gemma-4-31b-it'
+        default: 'meta-llama/llama-4-scout'
+        type: string
+      languages:
+        description: 'Comma-separated locales, e.g. en or en,es,ja'
+        default: 'en'
+        type: string
+      questions_file:
+        description: 'Repo-relative probe corpus (blank = built-in)'
+        default: ''
+        type: string
+      concurrency:
+        description: 'Parallel probes'
+        default: '1'
+        type: string
+      base_url:
+        description: 'Override the provider default endpoint (blank = provider default)'
+        default: ''
+        type: string
+      overrides_manifest:
+        description: 'Research-bound prompt overrides as INLINE JSON. Applied through the audited facility, so the run records having been manipulated. Blank = none.'
+        default: ''
+        type: string
+
+permissions:
+  id-token: write # Sigstore attestation issuance
+  attestations: write
+  contents: read
+
+concurrency:
+  # One capture at a time per ref — concurrent runs share qa_reports/ and would
+  # interleave their traces into a single cohort.
+  group: research-capture-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  capture:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - name: Install
+        run: |
+          pip install --upgrade pip wheel
+          pip install -r requirements.txt
+
+      - name: Check for the provider secret
+        id: secrets_check
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          DEEPINFRA_API_KEY: ${{ secrets.DEEPINFRA_API_KEY }}
+        run: |
+          # Secrets are not exposed to fork PRs. Skip loudly with the remedy
+          # named rather than failing with an opaque auth error 40 minutes in.
+          case "${{ inputs.provider }}" in
+            openrouter) KEY="$OPENROUTER_API_KEY" ;;
+            together)   KEY="$TOGETHER_API_KEY" ;;
+            groq)       KEY="$GROQ_API_KEY" ;;
+            openai)     KEY="$OPENAI_API_KEY" ;;
+            deepinfra)  KEY="$DEEPINFRA_API_KEY" ;;
+          esac
+          if [ -z "$KEY" ]; then
+            echo "have_secret=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No API key secret in scope for provider '${{ inputs.provider }}' (commonly a fork PR). A maintainer can re-run on a trusted branch."
+            {
+              echo "### Skipped"
+              echo ""
+              echo "This run has no \`${{ inputs.provider }}\` API key in scope."
+              echo "Set the matching repository secret, or pick a provider whose secret exists."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "have_secret=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Write provider API key
+        if: steps.secrets_check.outputs.have_secret == 'true'
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          TOGETHER_API_KEY: ${{ secrets.TOGETHER_API_KEY }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          DEEPINFRA_API_KEY: ${{ secrets.DEEPINFRA_API_KEY }}
+        run: |
+          umask 077
+          case "${{ inputs.provider }}" in
+            openrouter) printf '%s' "$OPENROUTER_API_KEY" > "$HOME/.openrouter_key" ;;
+            together)   printf '%s' "$TOGETHER_API_KEY"   > "$HOME/.together_key" ;;
+            groq)       printf '%s' "$GROQ_API_KEY"       > "$HOME/.groq_key" ;;
+            openai)     printf '%s' "$OPENAI_API_KEY"     > "$HOME/.openai_key" ;;
+            deepinfra)  printf '%s' "$DEEPINFRA_API_KEY"  > "$HOME/.deepinfra_key" ;;
+          esac
+
+      - name: Record the instrument
+        id: instrument
+        if: steps.secrets_check.outputs.have_secret == 'true'
+        run: |
+          # Written BEFORE the run so it survives a failure. A campaign must be
+          # able to tell which artifact produced which number.
+          SERVER=$(python3 -c 'import importlib.metadata as m;print(m.version("ciris-server"))')
+          echo "server=$SERVER" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Instrument"
+            echo ""
+            echo "| field | value |"
+            echo "|---|---|"
+            echo "| commit | \`${{ github.sha }}\` |"
+            echo "| ciris-server | \`$SERVER\` |"
+            echo "| provider / model | \`${{ inputs.provider }}\` / \`${{ inputs.model }}\` |"
+            echo "| languages | \`${{ inputs.languages }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Stage the override manifest
+        id: manifest
+        if: steps.secrets_check.outputs.have_secret == 'true' && inputs.overrides_manifest != ''
+        run: |
+          mkdir -p /tmp/research
+          printf '%s' '${{ inputs.overrides_manifest }}' > /tmp/research/manifest.json
+          python3 -c "import json;json.load(open('/tmp/research/manifest.json'))" \
+            || { echo '::error::overrides_manifest is not valid JSON'; exit 1; }
+          echo "OVERRIDES=/tmp/research/manifest.json" >> "$GITHUB_ENV"
+
+      - name: Capture
+        if: steps.secrets_check.outputs.have_secret == 'true'
+        env:
+          PROVIDER: ${{ inputs.provider }}
+          MODEL: ${{ inputs.model }}
+          LANGUAGES: ${{ inputs.languages }}
+          CONCURRENCY: ${{ inputs.concurrency }}
+          BASE_URL: ${{ inputs.base_url }}
+          QUESTIONS_FILE: ${{ inputs.questions_file }}
+          OUT_DIR: ${{ github.workspace }}/research-traces
+        run: |
+          case "$PROVIDER" in
+            openrouter) export API_KEY_FILE="$HOME/.openrouter_key" ;;
+            together)   export API_KEY_FILE="$HOME/.together_key" ;;
+            groq)       export API_KEY_FILE="$HOME/.groq_key" ;;
+            openai)     export API_KEY_FILE="$HOME/.openai_key" ;;
+            deepinfra)  export API_KEY_FILE="$HOME/.deepinfra_key" ;;
+          esac
+          ./tools/research/capture_traces.sh 2>&1 | tee "$GITHUB_WORKSPACE/capture.log"
+          exit "${PIPESTATUS[0]}"
+
+      - name: Summarise the cohort
+        if: always() && steps.secrets_check.outputs.have_secret == 'true'
+        run: |
+          python3 tools/research/summarise_cohort.py "$GITHUB_WORKSPACE/research-traces" \
+            >> "$GITHUB_STEP_SUMMARY" || true
+
+      - name: Attest capture bundle
+        # Sigstore provenance over the traces themselves. Without this the
+        # artifact is just a zip someone uploaded; with it, a campaign can prove
+        # which run and which commit produced the cohort it scored.
+        if: steps.secrets_check.outputs.have_secret == 'true'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: 'research-traces/**/ceg-seal-*.json'
+
+      - uses: actions/upload-artifact@v6
+        if: always() && steps.secrets_check.outputs.have_secret == 'true'
+        with:
+          name: ceg-traces-${{ inputs.provider }}-${{ inputs.languages }}-${{ github.run_id }}
+          path: |
+            research-traces/
+            capture.log
+          retention-days: 90
+          overwrite: true
+          if-no-files-found: error

--- a/tools/research/README.md
+++ b/tools/research/README.md
@@ -1,0 +1,103 @@
+# Trace capture for research
+
+Signed CEG traces from a live model run, at three detail levels.
+
+## Isolated (recommended when sharing a box)
+
+Published to GHCR with every release — pull a pinned image rather than building
+from a working tree:
+
+```bash
+docker run --rm \
+  -e API_KEY=sk-... \
+  -v "$PWD/traces:/out" \
+  ghcr.io/cirisai/ciris-research-capture:latest
+```
+
+Or build locally from source:
+
+```bash
+cd docker
+API_KEY=sk-... docker compose -f docker-compose.research.yml run --rm capture
+```
+
+Container-local database, logs and port. Nothing is shared with development
+except `docker/research-traces/`, mounted read-write. Two people can run at once.
+
+## Direct
+
+```bash
+API_KEY=sk-... ./tools/research/capture_traces.sh
+```
+
+## Knobs
+
+| var | default | notes |
+|---|---|---|
+| `API_KEY` / `API_KEY_FILE` | — | **required** |
+| `PROVIDER` | `openrouter` | `openrouter` `together` `groq` `openai` `deepinfra` |
+| `MODEL` | `meta-llama/llama-4-scout` | **case-sensitive** — Together lists both `google/gemma-4-31B-it` and `pearl-ai/gemma-4-31b-it` |
+| `LANGUAGES` | `en` | comma-separated |
+| `QUESTIONS_FILE` | built-in corpus | container path, e.g. `/questions/mine.json` |
+| `CONCURRENCY` | `1` | |
+| `BASE_URL` | per provider | override for anything unlisted |
+| `OUT_DIR` | `/out` | |
+
+## Output
+
+```
+$OUT_DIR/default/ceg-seal-<trace_id>.json           generic
+$OUT_DIR/accord_detailed/ceg-seal-<trace_id>.json   + actionable lists
+$OUT_DIR/accord_full/ceg-seal-<trace_id>.json       + raw prompts/completions
+```
+
+Each file is the CEG carrier **as it would ship**: the full
+`federation_attestations` row, all 22 columns, including
+`scrub_signature_classical`, `scrub_signature_pqc`, `original_content_hash`.
+Byte columns are hex-encoded as `{"__hex__": "..."}`. Written on **seal**, so an
+unreachable canonical does not cost you the corpus.
+
+```python
+import json
+d = json.load(open("ceg-seal-<id>.json"))
+d["signed_rows"]                              # PQC-signed count
+d["ceg_rows"][0]["attestation_envelope"]      # the wire envelope
+d["ceg_rows"][0]["scrub_signature_pqc"]       # importable into the mesh
+```
+
+## Exit codes
+
+| code | meaning |
+|---|---|
+| 0 | ran, traces captured |
+| 2 | no API key / unknown provider |
+| 3 | preflight failed — names the cause (401 bad key · 402 valid key, no credit · 404 model case · 429 rate limit) |
+| 4 | **ran but captured nothing** |
+
+Exit 4 exists because the failure it catches is silent: a run once reported
+`Success Rate 100.0%` while writing zero trace files, and anything reading that
+directory would have computed over an empty set and called it clean. A capture
+run with no captures is a failed run.
+
+## If a run captures nothing
+
+Every path logs its verdict — grep the adapter log for `Local-copy` and
+`CEG seal`. You will get one of: `Local-copy enabled: <dir>`,
+`Local-copy OFF`, `CEG seal teed: <file> — N rows, M signed`,
+`CEG seal NOT teed (no local_copy_dir)`, or
+`CEG seal teed NOTHING: no carrier row matches trace_id=...` (a source-side
+defect, not a capture one).
+
+## Notes
+
+**Building on a host where buildkit's DNS fails.** Some hosts resolve
+`registry-1.docker.io` fine but buildkit's network does not
+(`i/o timeout ... on 10.19.16.1:53`). `docker pull python:3.12-slim` then
+`DOCKER_BUILDKIT=0 docker build -f docker/Dockerfile.research -t ciris-research-capture:local .`
+works, because the legacy builder resolves the base locally. Pulling from GHCR
+avoids the problem entirely.
+
+**Verified end-to-end** at 2.9.7: image builds clean, container run returns
+exit 0 with 6 traces across generic/detailed/full_traces, all 6 PQC-signed,
+written through the volume mount to the host. Guards verified in-container:
+exit 2 with no key, exit 3 on a bad key naming the cause.

--- a/tools/research/capture_traces.sh
+++ b/tools/research/capture_traces.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Capture signed CEG traces from a live model run.
+#
+#   PROVIDER=openrouter API_KEY=sk-... MODEL=meta-llama/llama-4-scout \
+#     ./tools/research/capture_traces.sh
+#
+# Everything is an env var with a sane default; the only required one is API_KEY.
+# Run it directly on a dev box, or via docker/docker-compose.research.yml to get
+# an isolated database and port (recommended when sharing a machine).
+#
+# WHAT YOU GET, per sealed trace, at three detail levels:
+#   $OUT_DIR/<backend>/default/ceg-seal-<trace_id>.json          generic
+#   $OUT_DIR/<backend>/accord_detailed/ceg-seal-<trace_id>.json  + actionable lists
+#   $OUT_DIR/<backend>/accord_full/ceg-seal-<trace_id>.json      + raw prompts/completions
+#
+# Each file is the CEG carrier AS IT WOULD SHIP: the full federation_attestations
+# row, all 22 columns, including scrub_signature_classical / scrub_signature_pqc
+# / original_content_hash. Byte columns are hex-encoded as {"__hex__": "..."}.
+# Written on SEAL, so an unreachable canonical does not cost you the corpus.
+set -euo pipefail
+
+PROVIDER="${PROVIDER:-openrouter}"
+MODEL="${MODEL:-meta-llama/llama-4-scout}"
+LANGUAGES="${LANGUAGES:-en}"
+CONCURRENCY="${CONCURRENCY:-1}"
+QUESTIONS_FILE="${QUESTIONS_FILE:-}"
+OUT_DIR="${OUT_DIR:-/out}"
+BASE_URL="${BASE_URL:-}"
+API_KEY="${API_KEY:-}"
+API_KEY_FILE="${API_KEY_FILE:-}"
+# Research-bound prompt overrides. Path to a manifest INSIDE the container
+# (mount it read-only, e.g. -v ./manifests:/manifests:ro then
+# OVERRIDES=/manifests/arm-b.json). Reaching the prompts any other way — bind-
+# mounting over a YAML, editing the image — bypasses the audited facility, so
+# the run carries no record of having been manipulated. That reproduces the
+# condition-self-report problem in a new place, which is self-defeating when the
+# thing you are testing IS the override path.
+OVERRIDES="${OVERRIDES:-}"
+
+# Provider -> default base URL. Override with BASE_URL for anything else.
+case "$PROVIDER" in
+  openrouter) BASE_URL="${BASE_URL:-https://openrouter.ai/api/v1}" ;;
+  together)   BASE_URL="${BASE_URL:-https://api.together.xyz/v1}" ;;
+  groq)       BASE_URL="${BASE_URL:-https://api.groq.com/openai/v1}" ;;
+  openai)     BASE_URL="${BASE_URL:-https://api.openai.com/v1}" ;;
+  deepinfra)  BASE_URL="${BASE_URL:-https://api.deepinfra.com/v1/openai}" ;;
+  *)
+    if [ -z "$BASE_URL" ]; then
+      echo "ERROR: unknown PROVIDER='$PROVIDER' and no BASE_URL set." >&2
+      echo "       known: openrouter together groq openai deepinfra" >&2
+      exit 2
+    fi ;;
+esac
+
+if [ -z "$API_KEY" ] && [ -n "$API_KEY_FILE" ] && [ -f "$API_KEY_FILE" ]; then
+  API_KEY="$(tr -d '\n\r' < "$API_KEY_FILE")"
+fi
+if [ -z "$API_KEY" ]; then
+  echo "ERROR: no API key. Set API_KEY=... or API_KEY_FILE=/path/to/key" >&2
+  exit 2
+fi
+
+KEYFILE="$(mktemp)"; trap 'rm -f "$KEYFILE"' EXIT
+printf '%s' "$API_KEY" > "$KEYFILE"
+
+# PREFLIGHT — fail in seconds on a bad key/model rather than after a full run.
+# A 401 and a 402 both present as "no output"; one is a bad key, the other a
+# valid key on an unfunded account, and they need different fixes.
+echo "── preflight ─────────────────────────────────────────────"
+code=$(curl -s -o /tmp/pf.json -w '%{http_code}' --max-time 45 \
+  -H "Authorization: Bearer $API_KEY" -H 'Content-Type: application/json' \
+  -H 'User-Agent: ciris-research-capture/1.0' \
+  -d "{\"model\":\"$MODEL\",\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}],\"max_tokens\":1}" \
+  "$BASE_URL/chat/completions" || echo 000)
+if [ "$code" != "200" ]; then
+  echo "  FAIL: HTTP $code from $PROVIDER"
+  echo "  base_url : $BASE_URL"
+  echo "  model    : $MODEL"
+  echo "  says     : $(head -c 300 /tmp/pf.json 2>/dev/null)"
+  case "$code" in
+    401) echo "  -> key invalid or revoked." ;;
+    402) echo "  -> key VALID, account out of credit. Billing, not config." ;;
+    403) echo "  -> access denied for this model (tier/enablement)." ;;
+    404) echo "  -> model not found. Check CASE — provider ids are case-sensitive." ;;
+    429) echo "  -> rate limited." ;;
+    000) echo "  -> endpoint unreachable (DNS/TLS/network)." ;;
+  esac
+  exit 3
+fi
+echo "  OK: $PROVIDER / $MODEL"
+
+mkdir -p "$OUT_DIR"
+export CIRIS_ACCORD_METRICS_LOCAL_COPY_DIR="$OUT_DIR"
+
+if [ -n "$OVERRIDES" ]; then
+  if [ ! -f "$OVERRIDES" ]; then
+    echo "ERROR: OVERRIDES=$OVERRIDES not found in the container." >&2
+    echo "       Mount it read-only, e.g.  -v \$PWD/manifests:/manifests:ro" >&2
+    exit 5
+  fi
+  # Two keys by design: one says WHAT to apply, the other says you are ALLOWED
+  # to. A single key would let a stray line in a production .env swap the
+  # covenant out of a live agent.
+  export CIRIS_RESEARCH_PROMPT_OVERRIDES="$OVERRIDES"
+  export CIRIS_TESTING_MODE=true
+  echo "── overrides ─────────────────────────────────────────────"
+  echo "  manifest : $OVERRIDES"
+  python3 - "$OVERRIDES" <<'EOP' || { echo "  manifest is not valid JSON" >&2; exit 5; }
+import json, sys
+m = json.load(open(sys.argv[1]))
+print(f"  condition: {m.get('condition', '(none declared)')}")
+ov = m.get("overrides") or {}
+print(f"  keys     : {len(ov)}")
+for k in list(ov)[:6]:
+    print(f"    - {k}")
+EOP
+fi
+
+BEFORE=$(find "$OUT_DIR" -name 'ceg-seal-*.json' 2>/dev/null | wc -l)
+
+ARGS=(model_eval --live --live-key-file "$KEYFILE" --live-model "$MODEL"
+      --live-base-url "$BASE_URL" --live-provider openai
+      --model-eval-languages "$LANGUAGES" --model-eval-concurrency "$CONCURRENCY" --verbose)
+[ -n "$QUESTIONS_FILE" ] && ARGS+=(--model-eval-questions-file "$QUESTIONS_FILE")
+
+echo "── run ───────────────────────────────────────────────────"
+echo "  languages=$LANGUAGES concurrency=$CONCURRENCY out=$OUT_DIR"
+set +e
+python3 -u -m tools.qa_runner "${ARGS[@]}"
+RC=$?
+set -e
+
+AFTER=$(find "$OUT_DIR" -name 'ceg-seal-*.json' 2>/dev/null | wc -l)
+NEW=$((AFTER - BEFORE))
+SIGNED=$(grep -l '"scrub_signature_pqc"' $(find "$OUT_DIR" -name 'ceg-seal-*.json' 2>/dev/null) 2>/dev/null | wc -l)
+
+echo "── result ────────────────────────────────────────────────"
+echo "  qa_runner exit : $RC"
+echo "  new traces     : $NEW"
+echo "  PQC-signed     : $SIGNED"
+
+# HARD FAIL ON AN EMPTY CORPUS.
+#
+# A run that evaluates cleanly and captures nothing is the failure mode this
+# harness exists to prevent: it reported "Success Rate 100.0%" while writing
+# zero trace files, and anything downstream would then compute over an empty set
+# and call it a clean result. A capture run with no captures is a failed run.
+if [ "$NEW" -eq 0 ]; then
+  echo "  FAIL: the run produced NO trace files."
+  echo "        Check the adapter log for 'Local-copy' / 'CEG seal' lines — every"
+  echo "        path logs its verdict, including why it wrote nothing."
+  exit 4
+fi
+if [ "$SIGNED" -eq 0 ]; then
+  echo "  WARN: no PQC signatures present — not mesh-importable as-is."
+fi
+echo "  traces in $OUT_DIR"
+exit $RC

--- a/tools/research/summarise_cohort.py
+++ b/tools/research/summarise_cohort.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Summarise a captured CEG cohort into a markdown block.
+
+Extracted from the workflow rather than inlined as a heredoc so it can be tested
+and run by hand against a downloaded artifact.
+
+It reports three things the campaign has been bitten by:
+
+1. AN EMPTY COHORT, loudly. A run that evaluates cleanly and captures nothing
+   once reported "Success Rate 100.0%" while writing zero trace files, and
+   anything scoring it computed over an empty set and called the result clean.
+
+2. CONSTANT SCALARS. A feature with no variance is dropped at the retention
+   gate, so a cohort can report a sixteen-feature projection while measuring
+   fewer, with nothing in the output saying so. Constancy is usually either an
+   unmeasured upstream field or a corpus too small to vary — both worth knowing
+   before a number is quoted.
+
+3. A DECLARED CONDITION CONTRADICTED BY RUNTIME STATE — the sealed
+   `condition_attestation`. A run labelled (c) whose faculties were skipped is
+   not a (c) run, and scoring it under that label produces a confident wrong
+   answer rather than a noisy one.
+"""
+
+from __future__ import annotations
+
+import collections
+import glob
+import json
+import re
+import sys
+
+SCALARS = ("entropy_score", "coherence_score", "entropy_level", "coherence_level")
+
+
+def main(root: str) -> int:
+    files = sorted(glob.glob(f"{root}/**/ceg-seal-*.json", recursive=True))
+    print("\n### Cohort\n")
+    if not files:
+        print("**No traces captured.** Anything scoring this cohort would compute over an empty set.")
+        print("\nCheck the adapter log for `Local-copy` / `CEG seal` lines — every path logs its verdict,")
+        print("including why it wrote nothing.")
+        return 0
+
+    signed = 0
+    with_attestation = 0
+    contradictions = []
+    values: dict[str, set[str]] = collections.defaultdict(set)
+
+    for f in files:
+        try:
+            d = json.load(open(f))
+        except Exception:  # noqa: BLE001 — a malformed file should not hide the rest
+            continue
+        signed += int(d.get("signed_rows") or 0)
+        ca = d.get("condition_attestation")
+        if ca:
+            with_attestation += 1
+            if ca.get("contradicts_declaration"):
+                contradictions.append((d.get("trace_id"), ca.get("declared_condition"), ca.get("implied_condition")))
+        blob = json.dumps(d.get("ceg_rows") or [])
+        for key in SCALARS:
+            for m in re.finditer(rf'"{key}"\s*:\s*([0-9.]+)', blob):
+                values[key].add(m.group(1))
+
+    print(f"- documents: **{len(files)}** · PQC-signed rows: **{signed}**")
+    print(f"- carrying `condition_attestation`: **{with_attestation}/{len(files)}**")
+    if with_attestation == 0:
+        print("  - ⚠️ none carry it — this capture predates the attestation, so a")
+        print("    consistency gate over it would return zero contradictions and read as a pass.")
+        print("    **An absent gate is not a satisfied gate.**")
+
+    print("\n**Scalars**\n")
+    for key in SCALARS:
+        vals = sorted(values.get(key, set()))
+        if not vals:
+            continue
+        if len(vals) == 1:
+            print(f"- `{key}`: {vals} ⚠️ **CONSTANT** — no variance, dropped at the retention gate")
+        else:
+            print(f"- `{key}`: {vals}")
+
+    if contradictions:
+        print("\n**DECLARED CONDITION CONTRADICTED BY RUNTIME STATE**\n")
+        for trace_id, declared, implied in contradictions:
+            print(f"- `{trace_id}`: declared `{declared}`, runtime implies `{implied}`")
+        print("\nThis cohort must not be scored under the declared arm.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else "research-traces"))


### PR DESCRIPTION
Adds `Research Trace Capture` (workflow_dispatch) plus the `tools/research/` tree it calls.

## Why this must be on `main`

`workflow_dispatch` only appears in the Actions tab — and only accepts `gh workflow run` — when the file exists on the **default branch**. This workflow currently lives only on `release/2.9.7`, so the research team has no button and **no error message**: the failure mode is an absent control, not a rejection.

Once here, runs can target whichever ref carries the code under test (`release/2.9.7` today).

## Scope

Whole `tools/research/` tree, not the workflow alone, so `main` is self-consistent rather than carrying a workflow that references scripts it does not have. No engine or adapter code.

- `.github/workflows/research-capture.yml`
- `tools/research/capture_traces.sh`
- `tools/research/summarise_cohort.py`
- `tools/research/README.md`

## What it unblocks

Two runs the research team has ready, one dispatch each:

1. **Instrument check** — `overrides_manifest` forcing entropy above 0.40, exercising the recursive-conscience path. That path has *never executed*: every trace captured to date carries `action_was_overridden=False`. It also settles the `attempt_index` cohort semantics (whether a follow-up thought is one cohort member or two — currently a 1.14× effect), which they are rightly refusing to decide from the non-firing case.
2. **Mislabel test** — declare `condition: "c"`, skip faculties, confirm the sealed `condition_attestation` contradicts and the consistency gate refuses. That is the half of their gate built blind and explicitly marked untrusted.

## Shape

Patterned on `safety-battery.yml`: secret-check-then-skip-with-a-notice for fork PRs, `umask 077` key write, Sigstore `attest-build-provenance` over the traces, same artifact conventions.

The API key is a repository secret keyed by provider (`OPENROUTER_API_KEY`, `TOGETHER_API_KEY`, …); everything else is a form field, so a capture leaves no credential in the run configuration.

Attestation matters here beyond hygiene: without it the artifact is a zip someone uploaded; with it, a pre-registered campaign can prove which run and which commit produced the cohort it scored.

## Secrets required

At least one of `OPENROUTER_API_KEY` / `TOGETHER_API_KEY` / `GROQ_API_KEY` / `OPENAI_API_KEY` / `DEEPINFRA_API_KEY`. Absent, the run skips with a notice naming the remedy rather than failing on an opaque auth error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBWhDYiDHNEbxp7WHx8dTt