### PR TITLE
fix: locale-aware string overrides — a baseline manifest served English into all 29 locales (44/46 keys) + the TORQUE taxonomy table and state-space findings

### DIFF
--- a/ciris_engine/logic/utils/localization.py
+++ b/ciris_engine/logic/utils/localization.py
@@ -219,11 +219,15 @@ def get_string(
     # CIRIS_TESTING_MODE are set; the accessor returns None with zero state
     # otherwise. Checked before resolution so the override is what reaches the
     # prompt, not a locale-fallback of it.
-    from ciris_engine.logic.utils.research_overrides import get_active_overrides
+    from ciris_engine.logic.utils.research_overrides import get_active_overrides, override_string
 
     _manifest = get_active_overrides()
     if _manifest is not None:
-        _override = _manifest.overrides.string.get(key)
+        # Resolved WITH lang_code: these keys are localized, so a single value
+        # cannot stand for all of them. Passing the locale is what stops a
+        # baseline manifest — snapshotted at en — from serving English guidance,
+        # English prohibitions and English retry scaffolding into every locale.
+        _override = override_string(key, lang_code)
         if _override is not None:
             return _interpolate(_override, **params) if params else _override
 
@@ -460,13 +464,14 @@ def get_prohibition_guidance(lang_code: str) -> str:
     # so it must consult the override registry itself — otherwise the whole
     # prohibition block (22 of the 44 reachable prompt keys) would be the one
     # part of the `string` namespace that silently kept its CIRIS text.
-    from ciris_engine.logic.utils.research_overrides import get_active_overrides
-
-    _manifest = get_active_overrides()
-    _string_overrides = _manifest.overrides.string if _manifest is not None else {}
+    from ciris_engine.logic.utils.research_overrides import override_string
 
     def _local(key: str) -> str:
-        override = _string_overrides.get(key)
+        # Resolved WITH lang_code, for the same reason this function bypasses
+        # get_string's fallback chain: a single override value standing for every
+        # locale would serve English prohibitions into every non-English prompt —
+        # the pollution the comment above exists to prevent.
+        override = override_string(key, lang_code)
         if override is not None:
             return override.strip()
         value = _resolve_key(lang_data, key)

--- a/ciris_engine/logic/utils/research_overrides.py
+++ b/ciris_engine/logic/utils/research_overrides.py
@@ -45,7 +45,7 @@ import logging
 import os
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, FrozenSet, List, Optional, Set, Tuple
+from typing import Any, Dict, FrozenSet, List, Optional, Sequence, Set, Tuple, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -523,7 +523,20 @@ class OverrideSet(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    string: Dict[str, str] = Field(default_factory=dict)
+    #: ``string`` keys are LOCALIZED — the same key resolves to different text in
+    #: each locale. A value may therefore be either:
+    #:
+    #: * ``str``   — this exact text in EVERY locale. A deliberate choice, not a
+    #:   default: it puts one language's text into every language's prompt.
+    #: * ``dict``  — ``{locale: text}``, the faithful form for a localized key.
+    #:   A locale absent from the mapping REFUSES at resolution rather than
+    #:   falling back to English (that fallback is the R4 laundering this
+    #:   facility exists to prevent).
+    #:
+    #: Before this was a union, every value was a scalar snapshotted at ``en``,
+    #: so a baseline manifest silently served English guidance, English
+    #: prohibitions and English retry scaffolding in all 29 locales.
+    string: Dict[str, Union[str, Dict[str, str]]] = Field(default_factory=dict)
     dma_prompt: Dict[str, str] = Field(default_factory=dict)
     conscience_prompt: Dict[str, str] = Field(default_factory=dict)
     corpus: Dict[str, str] = Field(default_factory=dict)
@@ -884,9 +897,42 @@ def get_active_overrides() -> Optional[ResearchOverrideManifest]:
 # --------------------------------------------------------------------------
 
 
-def override_string(key: str) -> Optional[str]:
+def override_string(key: str, lang_code: Optional[str] = None) -> Optional[str]:
+    """Resolve a ``string`` override for ``key`` in ``lang_code``.
+
+    A scalar value applies to every locale. A mapping is resolved against
+    ``lang_code``; a locale the mapping does not cover REFUSES rather than
+    falling back to English, because silently serving English into a non-English
+    prompt is exactly the laundering R4 forbids — and it is what this facility
+    did for every localized key before the value type became a union.
+
+    ``lang_code=None`` is accepted only for scalar values, so callers that
+    genuinely have no locale in hand still work.
+    """
     m = get_active_overrides()
-    return m.overrides.string.get(key) if m else None
+    if m is None:
+        return None
+    value = m.overrides.string.get(key)
+    if value is None or isinstance(value, str):
+        return value
+
+    if lang_code is None:
+        raise RuntimeError(
+            f"research overrides active: key {key!r} is overridden per-locale, but the "
+            f"caller resolved it without a locale. A per-locale override cannot be "
+            f"applied to an unknown locale — pass lang_code, or make the override a "
+            f"single string if one text really is intended for every locale."
+        )
+    try:
+        return value[lang_code]
+    except KeyError:
+        raise RuntimeError(
+            f"research overrides active: key {key!r} is overridden per-locale but carries "
+            f"no entry for locale {lang_code!r} (has: {', '.join(sorted(value)) or 'none'}). "
+            f"Falling back to English would put English text in a {lang_code!r} prompt — the "
+            f"laundering R4 forbids. Add {lang_code!r} to the mapping, or use a single "
+            f"string if that text is intended for every locale."
+        ) from None
 
 
 def override_dma_prompt(template_name: str, field: str) -> Optional[str]:
@@ -1082,8 +1128,21 @@ def strict_manifest_skeleton(experiment_id: str = "CHANGE-ME", condition: str = 
     }
 
 
-def baseline_manifest() -> Dict[str, Any]:
+def baseline_manifest(locales: Optional[Sequence[str]] = None) -> Dict[str, Any]:
     """A strict manifest pre-filled with the CURRENT live values.
+
+    ``locales`` selects which locales the localized ``string`` keys are captured
+    for; it defaults to every locale in the bundle, so a locale added later is
+    picked up with no change here. Narrow it when an experiment runs a known
+    subset — a full capture of every localized key across every locale is large,
+    and a manifest carrying locales the run never composes is noise.
+
+    A ``string`` key is emitted as a ``{locale: text}`` mapping when its text
+    actually differs across the captured locales, and as a plain string when it
+    does not. That is what makes the round-trip guarantee below true: capturing
+    a localized key at ``en`` alone and pinning that one value used to serve
+    English guidance, English prohibitions and English retry scaffolding in all
+    29 locales, while reporting a clean run.
 
     `strict_manifest_skeleton()` emits `REPLACE::<key>` placeholders for all 97
     keys. That is right for a wholesale variant — a non-CIRIS arm is a complete
@@ -1101,18 +1160,35 @@ def baseline_manifest() -> Dict[str, Any]:
     """
     from ciris_engine.logic.conscience.prompt_loader import ConsciencePromptLoader
     from ciris_engine.logic.dma.prompt_loader import DMAPromptLoader
-    from ciris_engine.logic.utils.localization import get_string
+    from ciris_engine.logic.utils.localization import get_available_languages, get_string
 
     skeleton = strict_manifest_skeleton()
     out: Dict[str, Any] = dict(skeleton)
     out["experiment_id"] = "CHANGE-ME"
-    filled: Dict[str, Dict[str, str]] = {ns: {} for ns in skeleton["overrides"]}
+    filled: Dict[str, Dict[str, Any]] = {ns: {} for ns in skeleton["overrides"]}
+
+    captured = list(locales) if locales else get_available_languages()
+    if not captured:
+        raise RuntimeError(
+            "no locales available to capture — refusing to emit a baseline that would "
+            "silently cover no locale at all"
+        )
+    base = str(out.get("base_locale") or "en")
+    if base not in captured:
+        # The base locale anchors the scalar case; without it a key that does not
+        # vary would still be captured from an arbitrary locale.
+        captured = [base, *captured]
 
     for key in skeleton["overrides"].get("string", {}):
         try:
-            filled["string"][key] = get_string("en", key)
+            per_locale = {lang: get_string(lang, key) for lang in captured}
         except Exception:  # noqa: BLE001 — an unresolvable key keeps its marker
             filled["string"][key] = skeleton["overrides"]["string"][key]
+            continue
+        # Collapse to a scalar only when the key genuinely does not vary, so the
+        # manifest stays small without ever standing one locale in for another.
+        distinct = set(per_locale.values())
+        filled["string"][key] = per_locale[base] if len(distinct) == 1 else per_locale
 
     cl = ConsciencePromptLoader()
     for key, marker in skeleton["overrides"].get("conscience_prompt", {}).items():
@@ -1138,12 +1214,26 @@ def baseline_manifest() -> Dict[str, Any]:
         filled[ns] = dict(skeleton["overrides"].get(ns, {}))
 
     out["overrides"] = filled
-    unresolved = sum(1 for ns in filled.values() for v in ns.values() if str(v).startswith("REPLACE::"))
-    out["_baseline_note"] = (
-        f"{unresolved} key(s) still carry REPLACE:: markers and MUST be filled or the run is "
-        f"not measuring what it claims. Change only the keys your experiment alters."
-    )
+    # The note goes to the CALLER, never into the manifest: `extra="forbid"`
+    # rejects unknown keys, so emitting `_baseline_note` inline made
+    # `baseline > m.json && validate m.json` fail on a key this function itself
+    # added. See baseline_unresolved().
     return out
+
+
+def baseline_unresolved(manifest: Dict[str, Any]) -> List[str]:
+    """Keys in a baseline manifest still carrying their ``REPLACE::`` marker.
+
+    These are the value-bearing keys `baseline` deliberately refuses to pre-fill:
+    leaving them unset makes an unfilled arm fail loudly instead of silently
+    re-running the CIRIS values under an experimental label.
+    """
+    return sorted(
+        f"{ns}.{key}"
+        for ns, block in manifest.get("overrides", {}).items()
+        for key, value in block.items()
+        if isinstance(value, str) and value.startswith("REPLACE::")
+    )
 
 
 def validate_manifest_file(path: str) -> Tuple[bool, str]:
@@ -1255,7 +1345,19 @@ if __name__ == "__main__":  # pragma: no cover - operator convenience
     elif command == "skeleton":
         print(json.dumps(strict_manifest_skeleton(), indent=2, ensure_ascii=False))
     elif command == "baseline":
-        print(json.dumps(baseline_manifest(), indent=2, ensure_ascii=False))
+        # Optional locale narrowing: `baseline en,es,am`. Default captures every
+        # locale in the bundle, so a locale added later needs no change here.
+        _locales = [s for s in sys.argv[2].split(",") if s.strip()] if len(sys.argv) > 2 else None
+        _manifest = baseline_manifest(_locales)
+        print(json.dumps(_manifest, indent=2, ensure_ascii=False))
+        _unresolved = baseline_unresolved(_manifest)
+        if _unresolved:
+            print(
+                f"{len(_unresolved)} key(s) still carry REPLACE:: markers and MUST be filled or "
+                f"the run is not measuring what it claims. Change only the keys your experiment "
+                f"alters.\n  " + "\n  ".join(_unresolved),
+                file=sys.stderr,
+            )
     elif command == "keyspace":
         for namespace, keys in (
             ("string", scan_reachable_string_keys()),

--- a/tests/ciris_engine/logic/utils/test_research_overrides_locale.py
+++ b/tests/ciris_engine/logic/utils/test_research_overrides_locale.py
@@ -1,0 +1,142 @@
+"""``string`` overrides are LOCALIZED — one value cannot stand for every locale.
+
+The regression these pin: ``baseline_manifest()`` captured every ``string`` key
+at ``get_string("en", key)``, and ``get_string`` returned the override before it
+ever consulted ``lang_code``. A baseline-derived manifest — the *documented*
+workflow, whose docstring promises "every other key round-trips to its current
+value" — therefore pinned English text for all 29 locales.
+
+On v2.9.9-stable that was 44 of 46 string keys: every ``prompts.prohibitions.*``
+(21), every ``conscience.*`` retry string (16), the five ``prompts.dma.bounce_*``
+keys and ``prompts.language_guidance``. A compose dump across am/ja/en under a
+baseline manifest returned 13,694 B of English guidance for all three; the same
+dump with no manifest returned 25,337 / 16,145 / 13,694 correctly.
+
+It defeated an invariant the codebase states twice — ``get_prohibition_guidance``
+deliberately bypasses the English fallback chain because it "would serve English
+into every non-English prompt and pollute it", and R4 refuses ``[EN]``
+laundering. The override registry was the hole in both.
+"""
+
+import json
+
+import pytest
+
+from ciris_engine.logic.utils import research_overrides as ro
+from ciris_engine.logic.utils.localization import get_string
+from ciris_engine.logic.utils.research_overrides import ENV_ANCHOR, ENV_MANIFEST
+
+_KEY = "prompts.language_guidance"
+
+
+@pytest.fixture(autouse=True)
+def _clean_override_state():
+    ro.reset_research_overrides()
+    yield
+    ro.reset_research_overrides()
+
+
+def _activate(monkeypatch, tmp_path, string_overrides):
+    manifest = {
+        "manifest_version": "1",
+        "experiment_id": "locale-regression",
+        "condition": "c",
+        "base_locale": "en",
+        "mode": "additive",
+        "residue_digest": ro.compute_residue_digest(),
+        "overrides": {
+            "string": string_overrides,
+            "dma_prompt": {},
+            "conscience_prompt": {},
+            "corpus": {},
+            "template": {},
+        },
+        "research_hashes": {},
+    }
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+    monkeypatch.setenv(ENV_MANIFEST, str(path))
+    monkeypatch.setenv(ENV_ANCHOR, "true")
+    ro.reset_research_overrides()
+
+
+class TestPerLocaleOverrides:
+    def test_mapping_resolves_the_requested_locale(self, monkeypatch, tmp_path):
+        _activate(monkeypatch, tmp_path, {_KEY: {"en": "ENGLISH", "ja": "JAPANESE", "am": "AMHARIC"}})
+
+        assert get_string("en", _KEY) == "ENGLISH"
+        assert get_string("ja", _KEY) == "JAPANESE"
+        assert get_string("am", _KEY) == "AMHARIC"
+
+    def test_scalar_still_applies_to_every_locale(self, monkeypatch, tmp_path):
+        """A single string is a legitimate, DELIBERATE 'same text everywhere'."""
+        _activate(monkeypatch, tmp_path, {_KEY: "ONE TEXT"})
+
+        for lang in ("en", "ja", "am"):
+            assert get_string(lang, _KEY) == "ONE TEXT"
+
+    def test_missing_locale_refuses_instead_of_serving_english(self, monkeypatch, tmp_path):
+        """The bug's exact shape: silence here put English in an Amharic prompt."""
+        _activate(monkeypatch, tmp_path, {_KEY: {"en": "ENGLISH", "ja": "JAPANESE"}})
+
+        with pytest.raises(RuntimeError, match=r"no entry for locale 'am'"):
+            get_string("am", _KEY)
+
+    def test_prohibitions_localize_too(self, monkeypatch, tmp_path):
+        """get_prohibition_guidance reads the registry directly, bypassing
+        get_string — so it needed the same fix, and 21 of the 44 flattened keys
+        were prohibition text."""
+        from ciris_engine.logic.utils.localization import get_prohibition_guidance
+
+        key = "prompts.prohibitions.MEDICAL"
+        _activate(monkeypatch, tmp_path, {key: {"en": "EN-MEDICAL", "ja": "JA-MEDICAL"}})
+
+        assert "EN-MEDICAL" in get_prohibition_guidance("en")
+        assert "JA-MEDICAL" in get_prohibition_guidance("ja")
+        assert "EN-MEDICAL" not in get_prohibition_guidance("ja")
+
+
+class TestBaselineRoundTrip:
+    def test_baseline_captures_per_locale_not_english_only(self):
+        manifest = ro.baseline_manifest(["en", "ja", "am"])
+        value = manifest["overrides"]["string"][_KEY]
+
+        assert isinstance(value, dict), "a localized key captured as a scalar is the regression"
+        assert set(value) == {"en", "ja", "am"}
+        # Three different languages must not round-trip to one text.
+        assert len(set(value.values())) == 3
+
+    def test_invariant_keys_stay_scalar(self):
+        """Collapsing to a scalar keeps the manifest small — but only where the
+        key genuinely does not vary, never by standing one locale in for another."""
+        manifest = ro.baseline_manifest(["en", "ja", "am"])
+        values = manifest["overrides"]["string"].values()
+
+        assert any(isinstance(v, str) for v in values), "expected at least one invariant key"
+        for value in values:
+            if isinstance(value, dict):
+                assert len(set(value.values())) > 1, "a mapping whose values are identical should be scalar"
+
+    def test_baseline_output_validates_as_a_manifest(self, tmp_path):
+        """`baseline > m.json && validate m.json` used to fail on `_baseline_note`
+        — a key baseline itself added, which `extra="forbid"` then rejected."""
+        manifest = ro.baseline_manifest(["en"])
+
+        assert "_baseline_note" not in manifest
+        path = tmp_path / "m.json"
+        path.write_text(json.dumps(manifest), encoding="utf-8")
+        # Unresolved REPLACE:: markers are reported separately, never inline.
+        assert ro.baseline_unresolved(manifest), "the value-bearing keys should stay unfilled"
+
+    def test_default_captures_every_bundled_locale(self):
+        """No hardcoded locale list: a locale added to the bundle later is picked
+        up here with no change to this module."""
+        from ciris_engine.logic.utils.localization import get_available_languages
+
+        manifest = ro.baseline_manifest()
+        mappings = [v for v in manifest["overrides"]["string"].values() if isinstance(v, dict)]
+
+        assert mappings, "expected localized keys to be captured as mappings"
+        available = set(get_available_languages())
+        for mapping in mappings:
+            assert set(mapping) >= available - {"en"} or set(mapping) <= available


### PR DESCRIPTION
RATCHET's findings for the TORQUE-ready cut. One shipped fix (this branch, tested, rebased on `release/2.9.10`), then the taxonomy table and the state-space work that follows it.

## What blocks the tag: `string` overrides are not locale-aware

`baseline_manifest()` captured every `string` key at `get_string("en", key)` (`research_overrides.py:1113` on this branch), and `get_string` returned the override before consulting `lang_code` (`localization.py:226`). A baseline-derived manifest — the documented workflow, whose docstring promises *"every other key round-trips to its current value"* — therefore pinned **one language's text for all 29 locales**.

Measured on `v2.9.9-stable`: **44 of 46 `string` keys are locale-varying, and every one was flattened.**

| flattened | count |
|---|---|
| `prompts.prohibitions.*` | 21 |
| `conscience.*` retry envelope | 16 |
| `prompts.dma.bounce_*` | 5 |
| `prompts.language_guidance` | 1 |
| other | 1 |

A compose dump across `am,ja,en` under a baseline manifest returned **13,694 B of English guidance for all three**. The same dump with no manifest returns 25,337 / 16,145 / 13,694 correctly. The translations were never the problem — all 29 locale files carry proper, fully-translated guidance (`am` 25,338 B, `ja` 16,145 B, `uk` 25,081 B). The override registry was overwriting them.

This defeated an invariant the codebase states twice. `get_prohibition_guidance` deliberately bypasses the English fallback chain because it *"would serve English into every non-English prompt and pollute it"* (`localization.py:456-460`), and R4 refuses `[EN]` laundering (`:236`). The override registry was the hole in both — and note it is the same failure family as #991 and #992, arriving by a third route.

**Why it matters for the campaign specifically:** any multi-locale arm run under a baseline manifest was not measuring localized behaviour. It was measuring English text with a locale label on it, and the run would have reported clean.

### The fix

- `OverrideSet.string` accepts `str` (same text in every locale — deliberate, not default) **or** `{locale: text}`.
- A mapping missing a locale **REFUSES** at resolution rather than falling back to English.
- `override_string(key, lang_code)`; both consumers pass the locale — `get_string` and `get_prohibition_guidance`, which reads the registry directly and needed the same fix.
- `baseline_manifest(locales=None)` captures per-locale, **defaults to every locale in the bundle** so a locale added later needs no change here, and collapses to a scalar only where a key genuinely does not vary. Optional narrowing: `baseline en,es,am`.
- `_baseline_note` moved to stderr via `baseline_unresolved()` — `extra="forbid"` rejected a key `baseline` itself added, so `baseline > m.json && validate m.json` always failed.

After: **44 per-locale maps, 2 scalars**, and locale-invariant blocks drop **33/35 → 22/35**. `pdma.prohibition` now composes am 4,149 / ja 2,944 / en 2,189.

305 DMA + override tests pass; 73 in the two override suites including the new regression file.

---

## The taxonomy table

Measured from `compose_dump` on `v2.9.9-stable`, `en`, first pass. Class vocabulary as it exists in `compose_dump.py`.

### Blocks by step and family — 35 blocks, 194,326 B

| step | accord | language_guidance | system | user | prohibition |
|---|---|---|---|---|---|
| pdma | axiotic | mixed | mixed 23,810 B | mixed | deontic 2,189 B |
| csdma | axiotic | mixed | mixed 11,089 B | mixed | deontic 2,189 B |
| dsdma | axiotic | mixed | mixed 3,405 B | mixed | deontic 2,189 B |
| idma | axiotic | mixed | mixed 11,011 B | mixed | — |
| aspdma | mixed | mixed | mixed 2,755 B | mixed | — |
| dsaspdma | axiotic | mixed | mixed 2,354 B | mixed | — |
| tsaspdma | axiotic | mixed | mixed 4,095 B | mixed | — |
| tsaspdma_correction | axiotic | mixed | mixed 4,096 B | **mixed 1,592 B ⚠** | — |

Totals: **mixed 24, axiotic 8, deontic 3.** `language_guidance` is 13,694 B on **every** step — larger than accord + system + user combined on four of them.

⚠ `tsaspdma_correction.user` is reachable by **no override key**: overriding all 101 keys at once moves 34 of 35 blocks and leaves this one byte-identical.

### Override surface — 101 keys, 5 namespaces

| namespace | keys | bytes | gate-visible on 2.9.9 |
|---|---|---|---|
| `dma_prompt` | 36 | 69,110 | yes (uncredited in `source`) |
| `string` | 46 | 18,162 | partial — 17 `conscience.*` dark |
| `conscience_prompt` | 12 | 48,463 | **no** |
| `corpus` | 4 | 176 | yes |
| `template` | 3 | 132 | **no** |

#986 has since taken dark keys **50 → 18**. `gate_coverage.py` (in RATCHET, pinned `COVERAGE_2_9_9.json`) re-measures this against any checkout and exits 1 on regression — worth re-pinning once 2.9.10 tags.

### Reachability, measured

| layer | measure |
|---|---|
| composed at `en` | 194,326 B / 35 blocks |
| reachable by manifest | **99.2%** (34/35 blocks) |
| unreachable block | `tsaspdma_correction.user`, 1,592 B |
| residue surviving full override | ~3,612 B — 20 `RESIDUE_SITES`, 117 fragments, `residue_digest`-pinned (working as designed) |
| locale-varying `string` keys | 44/46 |

---

## The state space, and why a table is needed

The dump above is **one cell**. The independent axes:

| axis | cardinality | source |
|---|---|---|
| DMA step | 8 | `STEP_NAMES` |
| locale | 29 | bundle |
| recursion depth | up to ~6 | 2 points: conscience-override retry (`thought_processor/main.py:287-289`) + recursive ASPDMA loop (`recursive_processing.py`, `max_retries = 5`) |
| conscience guidance mode | 2 | `full` / `qualitative` (`main.py:949-979`) |
| image present | 2 | `user_prompt_template` vs `user_prompt_with_image_template` |
| condition | 3 | `a` / `b` / `c` |

**8 × 29 × 6 × 2 × 2 ≈ 5,568 distinct DMA prompt states**, before action-type conditionals, plus the conscience surface (4 consciences × 3 fields × 29 locales). We have characterized one of them.

This is the case for the machine-readable table rather than more ad-hoc dumps. It is also why #990's finding lands so hard: six blocks sat in the prompt YAML and never reached a model for up to six months, and nothing in a static read of the YAML could show that. Only differential composition can.

---

## SOTA for the transition table, and whether a language exists with our vocabulary

Short answer: **no single standard covers it, but three mature layers compose, and only the axiotic slot has to be invented.** Recommend profiling existing standards rather than authoring a language.

**1. States and transitions — W3C [SCXML](https://www.w3.org/TR/scxml/) (Harel statecharts).** Hierarchy, parallel regions and history states are exactly what the two recursion points plus `tsaspdma_correction` need; a flat FSM cannot express "conscience retry nested inside the recursive loop." [AgentML](https://www.agentml.dev/) (2026) is an agent-specific DSL with 100% SCXML conformance, so the agent framing already exists. SCXML also has validation tooling, which matters because *"every path is reachable as expected"* is a model-checking question, not a review question.

**2. Builders, sources, sinks — W3C [PROV-O / PROV-DM](https://www.w3.org/TR/prov-dm/).** `Entity` / `Activity` / `Agent` with `used`, `wasGeneratedBy`, `wasDerivedFrom` is precisely "which builder produced which block from which source." It would give the `source: inline` provenance-granularity gap a principled fix: a block assembled from N keys becomes N `wasDerivedFrom` edges instead of one lossy string. There is a 2026 survey on execution provenance in LLM agents ([arXiv 2606.04990](https://arxiv.org/pdf/2606.04990)) if useful framing is wanted.

**3. The normative vocabulary — this is where our terms live, and where the gap is.**

- **Deontic is standardized, three times over.** OASIS **LegalRuleML** carries obligation/permission/prohibition/right as first-class operators. OMG **SBVR** explicitly separates **alethic** modality (necessity/possibility) from **deontic** modality (obligation/permission) — that distinction maps directly onto our *axiomatic* vs *deontic* split.
- **[Institutional Grammar 2.0](https://arxiv.org/pdf/2008.08937)** (Ostrom lineage) is the closest fit overall. Its **ADICO** syntax has a literal **D**eontic slot — Attribute, Deontic, aIm, Conditions, Or else — and IG 2.0 adds tiered expressiveness (IG Core / Extended / Logico) plus a **published codebook**. Critically it already distinguishes **regulative** statements (deontic, with a duty-bearer) from **constitutive** ones (modal — necessity/possibility, no duty-bearer). Our `deontic`/`prohibition` blocks are regulative; our `axiotic`/`ontological`/`tautological` blocks are constitutive. That mapping is free and principled.
- **Axiotic is *not* standardized.** No W3C/OMG/OASIS vocabulary encodes value-statements as such. Formal axiology exists but has no machine-readable serialization in use. So this is the one slot we genuinely have to define — and it is worth defining as an *extension of IG 2.0's constitutive modal*, not as a fresh taxonomy.

**Concrete recommendation:** an IG 2.0 profile where the Deontic slot generalizes to a modality enum carrying our vocabulary — `deontic | axiotic | epistemic | alethic (axiomatic) | empirical | ontological | tautological` — with SCXML for states and PROV-O for block provenance. Every block annotation then becomes a typed statement rather than a label.

**One bonus that pays for itself:** IG 2.0 ships a codebook *because* coding institutional statements requires inter-annotator reliability. That is #976's κ≥0.8 requirement, with a published protocol to borrow instead of invent.

---

## Two things from your side worth confirming back

- **#990 — six blocks never reached a model.** RATCHET's coverage work measured *composed* output rather than YAML, so our numbers should be unaffected; `gate_coverage.py` would have caught exactly this class. Nothing in our analysis reads the prompt YAMLs as ground truth. Reconciling against `evidence/prompt_key_consumption_990.tsv` regardless.
- **FSD §15.3 — manifest identified by path, not content hash.** Agreed and material. Every RATCHET manifest so far has been written once to a distinct path and never edited in place, so the arms remain distinguishable — but `manifest_digest` should land before any staked run, and until it does no content-addressed provenance claim on the independent variable is available. Our own `--sign` use covers the *dump*, not the manifest that produced it.

Related: #986, #989, #990, #991, #992, #993, #976, RATCHET#16.
