### PR TITLE
2.9.14 (1/2) — fleet issues + the QA gate that failed open

### DIFF
--- a/ciris_engine/config/PRICING_DATA.json
+++ b/ciris_engine/config/PRICING_DATA.json
@@ -1,17 +1,21 @@
 {
   "version": "1.0.0",
-  "last_updated": "2025-01-15T10:30:00Z",
+  "last_updated": "2026-08-09",
   "metadata": {
     "update_frequency": "weekly",
     "currency": "USD",
     "units": "per_million_tokens",
     "sources": [
-      "OpenAI API Pricing",
       "Anthropic API Pricing",
-      "Together AI Pricing",
-      "Lambda Labs Pricing"
+      "DeepInfra Pricing",
+      "Groq Pricing",
+      "Lambda Labs Pricing",
+      "OpenAI API Pricing",
+      "OpenRouter Pricing",
+      "Together AI Pricing"
     ],
-    "schema_version": "1.0.0"
+    "schema_version": "1.0.0",
+    "units_note": "Values are CENTS per million tokens despite `currency: USD` \u2014 verified against gpt-4o-mini/gpt-4o/claude-3-opus/claude-3-haiku, all exactly 100x their USD list price."
   },
   "providers": {
     "openai": {
@@ -55,8 +59,14 @@
         }
       },
       "rate_limits": {
-        "tier_1": {"rpm": 500, "tpm": 30000},
-        "tier_2": {"rpm": 5000, "tpm": 450000}
+        "tier_1": {
+          "rpm": 500,
+          "tpm": 30000
+        },
+        "tier_2": {
+          "rpm": 5000,
+          "tpm": 450000
+        }
       },
       "base_url": "https://api.openai.com/v1"
     },
@@ -118,6 +128,24 @@
           "deprecated": false,
           "effective_date": "2024-07-23",
           "description": "Llama 3.1 70B - high-performance open model"
+        },
+        "google/gemma-4-31B-it": {
+          "input_cost": 20.0,
+          "output_cost": 20.0,
+          "context_window": 131072,
+          "active": true,
+          "deprecated": false,
+          "effective_date": "2026-08-09",
+          "description": "Gemma 4 31B IT on Together \u2014 production datum primary. APPROXIMATE list price as of 2026-08-09 \u2014 verify against the provider catalog before relying on it for billing."
+        },
+        "meta-llama/Llama-4-Scout-17B-16E-Instruct": {
+          "input_cost": 18.0,
+          "output_cost": 59.0,
+          "context_window": 131072,
+          "active": true,
+          "deprecated": false,
+          "effective_date": "2026-08-09",
+          "description": "Llama 4 Scout on Together (dedicated endpoint required). APPROXIMATE list price as of 2026-08-09 \u2014 verify against the provider catalog before relying on it for billing."
         }
       },
       "base_url": "https://api.together.xyz/v1"
@@ -141,18 +169,77 @@
         }
       },
       "base_url": "https://api.lambda.ai/v1"
+    },
+    "openrouter": {
+      "display_name": "OpenRouter",
+      "base_url": "https://openrouter.ai/api/v1",
+      "models": {
+        "meta-llama/llama-4-scout": {
+          "input_cost": 8.0,
+          "output_cost": 30.0,
+          "context_window": 131072,
+          "active": true,
+          "deprecated": false,
+          "effective_date": "2026-08-09",
+          "description": "Llama 4 Scout via OpenRouter (routed; DeepInfra observed). APPROXIMATE list price as of 2026-08-09 \u2014 verify against the provider catalog before relying on it for billing."
+        }
+      }
+    },
+    "groq": {
+      "display_name": "Groq",
+      "base_url": "https://api.groq.com/openai/v1",
+      "models": {
+        "meta-llama/llama-4-scout-17b-16e-instruct": {
+          "input_cost": 11.0,
+          "output_cost": 34.0,
+          "context_window": 131072,
+          "active": true,
+          "deprecated": false,
+          "effective_date": "2026-08-09",
+          "description": "Llama 4 Scout on Groq. NOTE 8192 max_tokens cap. APPROXIMATE list price as of 2026-08-09 \u2014 verify against the provider catalog before relying on it for billing."
+        }
+      }
+    },
+    "deepinfra": {
+      "display_name": "DeepInfra",
+      "base_url": "https://api.deepinfra.com/v1/openai",
+      "models": {
+        "Qwen/Qwen3.6-35B-A3B": {
+          "input_cost": 10.0,
+          "output_cost": 30.0,
+          "context_window": 131072,
+          "active": true,
+          "deprecated": false,
+          "effective_date": "2026-08-09",
+          "description": "Qwen3.6 35B on DeepInfra; PDMA/locale eval bed. APPROXIMATE list price as of 2026-08-09 \u2014 verify against the provider catalog before relying on it for billing."
+        }
+      }
     }
   },
   "environmental_factors": {
     "energy_estimates": {
       "model_patterns": {
-        "gpt-4": {"kwh_per_1k_tokens": 0.0005},
-        "gpt-3.5": {"kwh_per_1k_tokens": 0.0003},
-        "claude-3": {"kwh_per_1k_tokens": 0.0004},
-        "llama-405b": {"kwh_per_1k_tokens": 0.0006},
-        "llama-70b": {"kwh_per_1k_tokens": 0.0003},
-        "llama-17b": {"kwh_per_1k_tokens": 0.0002},
-        "default": {"kwh_per_1k_tokens": 0.0003}
+        "gpt-4": {
+          "kwh_per_1k_tokens": 0.0005
+        },
+        "gpt-3.5": {
+          "kwh_per_1k_tokens": 0.0003
+        },
+        "claude-3": {
+          "kwh_per_1k_tokens": 0.0004
+        },
+        "llama-405b": {
+          "kwh_per_1k_tokens": 0.0006
+        },
+        "llama-70b": {
+          "kwh_per_1k_tokens": 0.0003
+        },
+        "llama-17b": {
+          "kwh_per_1k_tokens": 0.0002
+        },
+        "default": {
+          "kwh_per_1k_tokens": 0.0003
+        }
       }
     },
     "carbon_intensity": {
@@ -174,6 +261,71 @@
       "deprecated": false,
       "effective_date": "2024-01-01",
       "description": "Default pricing for unknown models"
+    },
+    "provider_defaults": {
+      "openai": {
+        "input_cost": 250.0,
+        "output_cost": 1000.0,
+        "context_window": 128000,
+        "active": true,
+        "deprecated": false,
+        "effective_date": "2026-08-09",
+        "description": "Unknown OpenAI model \u2014 priced as gpt-4o. APPROXIMATE list price as of 2026-08-09 \u2014 verify against the provider catalog before relying on it for billing."
+      },
+      "anthropic": {
+        "input_cost": 300.0,
+        "output_cost": 1500.0,
+        "context_window": 200000,
+        "active": true,
+        "deprecated": false,
+        "effective_date": "2026-08-09",
+        "description": "Unknown Anthropic model \u2014 priced as claude-3.5-sonnet tier. APPROXIMATE list price as of 2026-08-09 \u2014 verify against the provider catalog before relying on it for billing."
+      },
+      "together": {
+        "input_cost": 20.0,
+        "output_cost": 20.0,
+        "context_window": 131072,
+        "active": true,
+        "deprecated": false,
+        "effective_date": "2026-08-09",
+        "description": "Unknown Together model \u2014 open-weights tier. APPROXIMATE list price as of 2026-08-09 \u2014 verify against the provider catalog before relying on it for billing."
+      },
+      "openrouter": {
+        "input_cost": 30.0,
+        "output_cost": 60.0,
+        "context_window": 131072,
+        "active": true,
+        "deprecated": false,
+        "effective_date": "2026-08-09",
+        "description": "Unknown OpenRouter model \u2014 routed midpoint. APPROXIMATE list price as of 2026-08-09 \u2014 verify against the provider catalog before relying on it for billing."
+      },
+      "groq": {
+        "input_cost": 15.0,
+        "output_cost": 40.0,
+        "context_window": 131072,
+        "active": true,
+        "deprecated": false,
+        "effective_date": "2026-08-09",
+        "description": "Unknown Groq model \u2014 open-weights tier. APPROXIMATE list price as of 2026-08-09 \u2014 verify against the provider catalog before relying on it for billing."
+      },
+      "deepinfra": {
+        "input_cost": 12.0,
+        "output_cost": 35.0,
+        "context_window": 131072,
+        "active": true,
+        "deprecated": false,
+        "effective_date": "2026-08-09",
+        "description": "Unknown DeepInfra model \u2014 open-weights tier. APPROXIMATE list price as of 2026-08-09 \u2014 verify against the provider catalog before relying on it for billing."
+      },
+      "lambda_labs": {
+        "input_cost": 20.0,
+        "output_cost": 20.0,
+        "context_window": 131072,
+        "active": true,
+        "deprecated": false,
+        "effective_date": "2026-08-09",
+        "description": "Unknown Lambda Labs model \u2014 open-weights tier. APPROXIMATE list price as of 2026-08-09 \u2014 verify against the provider catalog before relying on it for billing."
+      }
     }
   }
 }

--- a/ciris_engine/config/pricing_models.py
+++ b/ciris_engine/config/pricing_models.py
@@ -76,9 +76,20 @@ class EnvironmentalFactors(BaseModel):
 
 
 class FallbackPricing(BaseModel):
-    """Fallback pricing for unknown models."""
+    """Fallback pricing for unknown models.
+
+    A single global fallback is wrong in both directions: it understates a premium
+    model (claude-3-opus is 75x the old flat default on output) and overstates a
+    budget one. `provider_defaults` keeps an unseen model in the right order of
+    magnitude for the provider it actually ran on, which is the one thing we always
+    know even when the model name is new.
+    """
 
     unknown_model: ModelConfig = Field(..., description="Default pricing for unknown models")
+    provider_defaults: Dict[str, ModelConfig] = Field(
+        default_factory=dict,
+        description="Per-provider default pricing, used before the global unknown_model fallback",
+    )
 
 
 class PricingMetadata(BaseModel):
@@ -217,8 +228,17 @@ class PricingConfig(BaseModel):
             return self.environmental_factors.carbon_intensity.regions[region]
         return self.environmental_factors.carbon_intensity.global_average_g_co2_per_kwh
 
-    def get_fallback_pricing(self) -> ModelConfig:
-        """Get fallback pricing for unknown models."""
+    def get_fallback_pricing(self, provider_name: Optional[str] = None) -> ModelConfig:
+        """Get fallback pricing for an unknown model.
+
+        Prefers the provider's own default when the provider is known: the model name
+        may be new, but the provider tells us the price tier. Only falls back to the
+        global `unknown_model` when the provider is unknown too.
+        """
+        if provider_name:
+            provider_default = self.fallback_pricing.provider_defaults.get(provider_name)
+            if provider_default:
+                return provider_default
         return self.fallback_pricing.unknown_model
 
     def list_active_models(self, provider_name: Optional[str] = None) -> List[tuple[str, str, ModelConfig]]:

--- a/ciris_engine/logic/adapters/api/routes/system/helpers.py
+++ b/ciris_engine/logic/adapters/api/routes/system/helpers.py
@@ -24,6 +24,12 @@ from .schemas import RuntimeControlResponse, ServiceStatus
 
 logger = logging.getLogger(__name__)
 
+#: (service_type, provider class name) pairs already reported as having no
+#: is_healthy(). Module-level because the defect is a property of the CLASS, not of
+#: any request — the same provider is re-examined on every health poll, and a
+#: per-request scope would report it every time (#935).
+_REPORTED_UNHEALTHCHECKABLE: set[tuple[str, str]] = set()
+
 
 # ============================================================================
 # Time and Uptime Helpers
@@ -174,13 +180,45 @@ async def collect_service_health(request: Request) -> Dict[str, Dict[str, int]]:
                     else:
                         # Unknown stays in `available` but never in `healthy`, so it
                         # drags the ratio toward degraded instead of padding it (#943).
-                        # Warning, not debug: every service inheriting base_service
-                        # has is_healthy(), so this is a registration defect and the
-                        # operator should see it rather than read a quiet 100%.
-                        logger.warning(
-                            f"Provider for {service_type.value} exposes no is_healthy() — counted as NOT healthy. "
-                            f"Provider type: {type(provider).__name__}"
-                        )
+                        #
+                        # WARNING, not debug: every service inheriting base_service has
+                        # is_healthy(), so this is a registration defect and the operator
+                        # should see it rather than read a quiet 100%.
+                        #
+                        # ONCE PER DEFECT, not once per poll (#935). Whether a class
+                        # implements a method is STATIC — it cannot change between polls
+                        # — but this runs on every /v1/system/health check. On datum that
+                        # was 292 identical lines for `tool` and 146 for `wise_authority`
+                        # in a 31-minute window, and the incident log rotated faster than
+                        # the soak it exists to document. The defect identity is
+                        # (service_type, provider class); anything beyond the first
+                        # occurrence of that pair reports a fact already reported.
+                        defect = (service_type.value, type(provider).__name__)
+                        if defect not in _REPORTED_UNHEALTHCHECKABLE:
+                            _REPORTED_UNHEALTHCHECKABLE.add(defect)
+                            logger.warning(
+                                "PROVIDER CANNOT BE HEALTH-CHECKED AND NEVER WILL BE — %s is registered "
+                                "for %s but exposes no is_healthy(), so it is counted as NOT healthy on "
+                                "every check and permanently drags this service's health ratio toward "
+                                "degraded.\n"
+                                "  WHY: every service inheriting base_service implements is_healthy(). A "
+                                "provider without it was registered without going through that base, so "
+                                "this is a registration defect, not a runtime condition.\n"
+                                "  FIX: have %s inherit base_service (or implement is_healthy()), or stop "
+                                "registering it as a %s provider.\n"
+                                "  (Reported once per provider class: the answer is static, and this check "
+                                "runs on every health poll. Repeats: debug.)",
+                                type(provider).__name__,
+                                service_type.value,
+                                type(provider).__name__,
+                                service_type.value,
+                            )
+                        else:
+                            logger.debug(
+                                "Provider %s for %s still exposes no is_healthy()",
+                                type(provider).__name__,
+                                service_type.value,
+                            )
                 services[service_type.value] = {"available": len(providers), "healthy": healthy_count}
     except Exception as e:
         logger.error(f"Error checking service health: {e}")

--- a/ciris_engine/logic/services/runtime/llm_service/pricing_calculator.py
+++ b/ciris_engine/logic/services/runtime/llm_service/pricing_calculator.py
@@ -30,6 +30,10 @@ class LLMPricingCalculator:
             pricing_config: Optional pricing configuration. If None, loads from file.
         """
         self.pricing_config = pricing_config or get_pricing_config()
+        # (provider, model) pairs already reported as unpriced. Whether a model has an
+        # entry is static for the life of the process, so a repeat says nothing new
+        # while this runs on every cost calculation (#935).
+        self._reported_unpriced: set[tuple[str, str]] = set()
         logger.debug(f"Initialized pricing calculator with config version {self.pricing_config.version}")
 
     def calculate_cost_and_impact(
@@ -119,9 +123,41 @@ class LLMPricingCalculator:
         if pattern_config:
             return pattern_config
 
-        # Fall back to unknown model pricing
-        logger.warning(f"No pricing found for model {model_name}, using fallback pricing")
-        return self.pricing_config.get_fallback_pricing()
+        # Fall back to provider-scoped pricing, then the global default.
+        #
+        # ONCE PER (provider, model), not once per call (#935). Whether a model has a
+        # pricing entry is STATIC for the life of the process, but this runs on every
+        # cost calculation — 64 identical lines in a 31-minute window on datum. The
+        # repeat carries nothing the first did not.
+        fallback = self.pricing_config.get_fallback_pricing(provider_name)
+        seen_key = (provider_name or "<unknown>", model_name)
+        if seen_key not in self._reported_unpriced:
+            self._reported_unpriced.add(seen_key)
+            scope = f"the {provider_name} default" if provider_name else "the global default"
+            logger.warning(
+                "MODEL HAS NO PRICING ENTRY — costs for %r are ESTIMATED, not actual, and every "
+                "figure derived from them (billing, budget envelopes, usage reports) is an "
+                "estimate too.\n"
+                "  model     : %s\n"
+                "  provider  : %s\n"
+                "  using     : %s (input=%s output=%s cents/million tokens)\n"
+                "  WHY: the model is absent from ciris_engine/config/PRICING_DATA.json. This is a "
+                "data gap, not a runtime fault — it will not resolve on its own.\n"
+                "  FIX: add the model under providers.%s.models in PRICING_DATA.json with its "
+                "list price in CENTS per million tokens (the file's values are 100x the USD "
+                "figure), then restart or call reload_pricing_config().\n"
+                "  (Reported once per model: the answer is static. Repeats: debug.)",
+                model_name,
+                model_name,
+                provider_name or "<unknown>",
+                scope,
+                fallback.input_cost,
+                fallback.output_cost,
+                provider_name or "<provider>",
+            )
+        else:
+            logger.debug("No pricing entry for %s/%s; using fallback", provider_name, model_name)
+        return fallback
 
     def _try_pattern_matching(self, model_name: str) -> Optional[ModelConfig]:
         """

--- a/tests/ciris_engine/logic/adapters/api/routes/system/test_health_check_noise.py
+++ b/tests/ciris_engine/logic/adapters/api/routes/system/test_health_check_noise.py
@@ -1,0 +1,118 @@
+"""A provider without is_healthy() is reported ONCE, actionably (#935).
+
+Whether a class implements a method is **static** — it cannot change between polls.
+But `get_service_health_summary` runs on every `/v1/system/health` check, so it
+re-reported the same fact hundreds of times an hour. Measured on `datum` running
+2.9.13: 292 identical lines for `tool` and 146 for `wise_authority` in a 31-minute
+window, contributing to an incident log that rotated in well under an hour against a
+multi-week soak.
+
+This is the same defect as the `AUTH_STEP_INFO` flood that 2.4.3 fixed, in a new
+place: a constant, correct observation emitted at WARNING on a hot path.
+
+The fix is NOT silence. The condition is a genuine registration defect and the
+operator must see it — once, with what they need to resolve it.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import Any, List
+
+import pytest
+
+from ciris_engine.logic.adapters.api.routes.system import helpers
+from ciris_engine.schemas.runtime.enums import ServiceType
+
+
+class _NoHealthCheck:
+    """A provider registered without going through base_service."""
+
+
+class _Healthy:
+    async def is_healthy(self) -> bool:
+        return True
+
+
+class _Registry:
+    """Returns the SAME provider for every ServiceType, so one poll exercises the
+    path once per type — which is exactly how datum produced 292 `tool` lines and
+    146 `wise_authority` lines from one defect each."""
+
+    def __init__(self, providers: List[Any]) -> None:
+        self._providers = providers
+
+    def get_services_by_type(self, _t: Any) -> List[Any]:
+        return self._providers
+
+
+class _Request:
+    """Minimal stand-in for the FastAPI Request `collect_service_health` reads."""
+
+    def __init__(self, registry: Any) -> None:
+        self.app = SimpleNamespace(state=SimpleNamespace(service_registry=registry))
+
+
+def _req(providers: List[Any]) -> Any:
+    return _Request(_Registry(providers))
+
+
+@pytest.fixture(autouse=True)
+def _clear_report_state():
+    helpers._REPORTED_UNHEALTHCHECKABLE.clear()
+    yield
+    helpers._REPORTED_UNHEALTHCHECKABLE.clear()
+
+
+@pytest.mark.asyncio
+async def test_reported_once_across_many_polls(caplog: pytest.LogCaptureFixture) -> None:
+    req = _req([_NoHealthCheck()])
+    with caplog.at_level(logging.WARNING):
+        for _ in range(50):  # ~50 health polls
+            await helpers.collect_service_health(req)
+
+    warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+    assert len(warnings) <= len(list(ServiceType)), (
+        f"{len(warnings)} warnings across 50 polls for a static property — this is "
+        "the flood that rotated the incident log (292 lines in 31 min on datum)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_report_is_actionable(caplog: pytest.LogCaptureFixture) -> None:
+    req = _req([_NoHealthCheck()])
+    with caplog.at_level(logging.WARNING):
+        await helpers.collect_service_health(req)
+
+    msgs = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert msgs, "the defect must still be reported — silence is not the fix"
+    msg = msgs[0]
+    assert "_NoHealthCheck" in msg, "must name the offending class"
+    assert "is_healthy" in msg, "must name what is missing"
+    assert "FIX:" in msg, "must state the remedy"
+    assert "registration defect" in msg, "must say it is a registration bug, not a runtime state"
+    # An operator who reads this as transient will wait for it to clear. It never does.
+    assert "NEVER WILL BE" in msg or "static" in msg
+
+
+@pytest.mark.asyncio
+async def test_a_healthy_provider_is_silent(caplog: pytest.LogCaptureFixture) -> None:
+    req = _req([_Healthy()])
+    with caplog.at_level(logging.WARNING):
+        await helpers.collect_service_health(req)
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+@pytest.mark.asyncio
+async def test_unknown_never_counts_as_healthy(caplog: pytest.LogCaptureFixture) -> None:
+    """The #943 property must survive the noise fix.
+
+    An unhealth-checkable provider stays in `available` but never in `healthy`, so it
+    drags the ratio toward degraded rather than padding a quiet 100%.
+    """
+    req = _req([_NoHealthCheck()])
+    summary = await helpers.collect_service_health(req)
+    for _service, counts in summary.items():
+        assert counts["available"] >= counts["healthy"]
+        assert counts["healthy"] == 0, "an unknown provider must not be counted healthy"

--- a/tests/ciris_engine/logic/services/runtime/llm_service/test_pricing_calculator_coverage.py
+++ b/tests/ciris_engine/logic/services/runtime/llm_service/test_pricing_calculator_coverage.py
@@ -492,16 +492,34 @@ class TestLLMPricingCalculatorComprehensive:
             assert any("Calculated usage for" in record.message for record in debug_logs)
 
     def test_logging_fallback_warning(self, caplog):
-        """Test warning logging for fallback pricing."""
+        """An unpriced model warns ONCE, and the warning is actionable (#935).
+
+        The condition is a data gap that cannot resolve on its own, so it must be
+        reported — but it was reported on every cost calculation (64 identical lines
+        in a 31-minute window on datum). Once per model, with the RCA.
+        """
         with caplog.at_level(logging.WARNING):
             calculator = LLMPricingCalculator(pricing_config=self.mock_pricing_config)
 
-            # Use unknown model to trigger fallback
-            calculator.calculate_cost_and_impact("unknown-model", 1000, 500)
+            # Use unknown model to trigger fallback, repeatedly.
+            for _ in range(20):
+                calculator.calculate_cost_and_impact("unknown-model", 1000, 500)
 
-            # Check warning logs
-            warning_logs = [record for record in caplog.records if record.levelno == logging.WARNING]
-            assert any("No pricing found for model unknown-model" in record.message for record in warning_logs)
+            warning_logs = [r for r in caplog.records if r.levelno == logging.WARNING]
+
+            # Reported, and reported once — not twenty times.
+            assert len(warning_logs) == 1, (
+                f"{len(warning_logs)} warnings for one unpriced model across 20 "
+                "calculations; whether a model has an entry is static"
+            )
+
+            msg = warning_logs[0].getMessage()
+            assert "unknown-model" in msg, "must name the model"
+            assert "PRICING_DATA.json" in msg, "must name the file to edit"
+            assert "FIX:" in msg, "must state the remedy"
+            # Costs derived from a fallback are estimates; downstream billing needs
+            # to know that, not just that a lookup missed.
+            assert "ESTIMATED" in msg or "estimate" in msg.lower()
 
     def test_edge_case_zero_tokens(self):
         """Test calculation with zero tokens."""

--- a/tests/tools/qa_runner/test_incidents_gate_fails_closed.py
+++ b/tests/tools/qa_runner/test_incidents_gate_fails_closed.py
@@ -1,0 +1,100 @@
+"""The incidents gate must FAIL when it cannot look (2.9.13 Staged QA race).
+
+`_has_incidents_occurred` used to `return False` when the incidents log was
+absent — no log, therefore no incidents, therefore PASS. That made the gate a coin
+flip on file existence, and it was observed twice on the same commit:
+
+    2.9.13 main run : sqlite   found the log -> FAILED
+                      postgres "NO INCIDENTS LOG FOUND" -> PASSED
+    re-run          : postgres found the log -> FAILED
+                      sqlite   "NO INCIDENTS LOG FOUND" -> PASSED
+
+Both runs had **100% test success on both backends** and identical expected,
+test-induced errors (invalid-state transitions, adapter loads without credentials,
+SIGTERM teardown). Which leg failed depended only on which leg's file existed.
+
+The dangerous half is not the flaky red — it is the green. A leg that passes
+because the log is absent certifies a run nobody checked, and after the fact there
+is no way to tell which historical greens were real.
+
+So: absent log ⇒ fail, loudly, and distinguishably from "incidents were found",
+because the two need different debugging.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from tools.qa_runner.runner import QARunner
+
+
+class _Console:
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+
+    def print(self, msg: Any = "", *a: Any, **k: Any) -> None:
+        self.lines.append(str(msg))
+
+    @property
+    def text(self) -> str:
+        return "\n".join(self.lines)
+
+
+def _runner(backend: str, tmp_path: Path) -> Any:
+    r = QARunner.__new__(QARunner)
+    r.console = _Console()
+    r.server_manager = SimpleNamespace(database_backend=backend)
+    r._startup_incidents_position = 0
+    return r
+
+
+def test_missing_log_fails_closed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The exact 2.9.13 race: no file must NOT mean clean."""
+    monkeypatch.chdir(tmp_path)  # logs/<backend>/ does not exist here
+    r = _runner("postgres", tmp_path)
+
+    assert r._has_incidents_occurred() is True, (
+        "a missing incidents log reported 'no incidents' and PASSED the leg — this "
+        "is the coin flip that made two runs of the same commit fail on opposite backends"
+    )
+
+
+def test_missing_log_is_reported_as_uncertifiable_not_as_incidents(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """'Could not check' and 'found incidents' need different debugging."""
+    monkeypatch.chdir(tmp_path)
+    r = _runner("sqlite", tmp_path)
+    r._has_incidents_occurred()
+
+    out = r.console.text
+    assert "CANNOT CERTIFY" in out, "must say the run is uncertified"
+    assert "sqlite" in out, "must name the backend whose log is missing"
+    assert "incidents_latest.log" in out, "must name the expected path"
+    assert "FIX:" in out, "must state the remedy"
+    # And it must be flagged so the summary does not claim incidents were detected.
+    assert getattr(r, "_incidents_unverifiable", False) is True
+
+
+def test_present_but_unchanged_log_is_genuinely_clean(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Fail-closed must not turn every clean run red.
+
+    A log that exists and has not grown since startup is a real pass — that is the
+    steady state, and it is distinguishable from absence.
+    """
+    monkeypatch.chdir(tmp_path)
+    log = tmp_path / "logs" / "sqlite" / "incidents_latest.log"
+    log.parent.mkdir(parents=True)
+    log.write_text("=== header ===\n")
+
+    r = _runner("sqlite", tmp_path)
+    r._startup_incidents_position = log.stat().st_size  # nothing new since startup
+
+    assert r._has_incidents_occurred() is False
+    assert getattr(r, "_incidents_unverifiable", False) is False

--- a/tools/qa_runner/runner.py
+++ b/tools/qa_runner/runner.py
@@ -526,8 +526,18 @@ class QARunner:
         # Final incidents reminder - CANNOT be missed
         if has_incidents:
             self.console.print("\n" + "=" * 60)
-            self.console.print("[bold red]🚨 CRITICAL: INCIDENTS DETECTED DURING TESTING! 🚨[/bold red]")
-            self.console.print("[bold red]REVIEW THE INCIDENTS LOG ABOVE IMMEDIATELY![/bold red]")
+            if getattr(self, "_incidents_unverifiable", False):
+                # NOT the same failure as "incidents found". This one means the gate
+                # could not look at all — which used to silently PASS, making every
+                # green run only as trustworthy as the log file having existed.
+                self.console.print("[bold red]🚨 RUN NOT CERTIFIED: THE INCIDENTS GATE COULD NOT RUN 🚨[/bold red]")
+                self.console.print(
+                    "[bold red]No incidents were found because none could be looked for. "
+                    "See the CANNOT CERTIFY block above for the expected path.[/bold red]"
+                )
+            else:
+                self.console.print("[bold red]🚨 CRITICAL: INCIDENTS DETECTED DURING TESTING! 🚨[/bold red]")
+                self.console.print("[bold red]REVIEW THE INCIDENTS LOG ABOVE IMMEDIATELY![/bold red]")
             self.console.print("=" * 60)
             return False  # Force failure if incidents occurred
         else:
@@ -813,11 +823,44 @@ class QARunner:
             self._startup_incidents_position = 0
 
     def _has_incidents_occurred(self) -> bool:
-        """Check if any NEW incidents occurred during testing."""
+        """Check if any NEW incidents occurred during testing.
+
+        FAILS CLOSED when the log is missing. A gate that cannot look must not
+        report clean.
+
+        This used to `return False` — no log, therefore no incidents, therefore
+        PASS. That made the whole gate a coin flip, and it was observed twice: on
+        2.9.13's main run the sqlite leg found the log and failed while postgres
+        printed "NO INCIDENTS LOG FOUND" and passed; on the re-run the two legs
+        SWAPPED. Both runs had 100% test success on both backends and identical
+        expected, test-induced errors. Which leg failed depended only on which
+        one's file existed.
+
+        The consequence is worse than a flaky red: a leg that passes because the
+        log is absent certifies a run nobody checked. Every green Staged QA in
+        this repo's history is therefore only as trustworthy as the file having
+        been there, and we cannot tell after the fact which ones were.
+        """
         incidents_log = self._incidents_log_path()
 
         if not incidents_log.exists():
-            return False
+            self.console.print(
+                "\n[bold red]❌ CANNOT CERTIFY THIS RUN — the incidents log does not exist.[/bold red]"
+            )
+            self.console.print(
+                f"[red]   expected : {incidents_log.resolve()}[/red]\n"
+                f"[red]   backend  : {getattr(getattr(self, 'server_manager', None), 'database_backend', '<unknown>')}[/red]\n"
+                "[red]   WHY: this gate reads that file to decide whether the agent raised "
+                "ERROR/CRITICAL during testing. With no file there is nothing to read, so a "
+                "'pass' would mean 'not checked', not 'clean'.[/red]\n"
+                "[red]   FIX: confirm the server started and configured file logging for this "
+                "backend (logs/<backend>/incidents_latest.log is created at startup). A run that "
+                "cannot be checked is a failed run, not a clean one.[/red]"
+            )
+            # Distinguish "could not check" from "checked and found incidents" —
+            # they need different debugging and must not read alike.
+            self._incidents_unverifiable = True
+            return True  # fail closed
 
         # Only check for new content added since startup
         try:


### PR DESCRIPTION
## 2.9.14, part 1 — fleet issues from the 2.9.13 upgrade

Three fixes from the manager team's fleet review, plus the QA harness race that made CI itself untrustworthy. **The wizard redesign lands in a companion PR; the 2.9.14 version bump rides with that one** so two branches don't both bump.

### 1. The incidents gate failed open — CI has been passing partly by luck

```python
if not incidents_log.exists():
    return False        # no log = "no incidents" = PASS
```

Observed twice on the **same commit**:

| run | postgres | sqlite |
|---|---|---|
| 2.9.13 main | `NO INCIDENTS LOG FOUND` → **pass** | found log → **fail** |
| re-run | found log → **fail** | `NO INCIDENTS LOG FOUND` → **pass** |

The legs swapped. Both runs: **100% test success on both backends**, identical expected test-induced errors (invalid-state transitions, adapter loads without credentials, SIGTERM teardown). Which leg failed depended only on which leg's file existed.

The flaky red isn't the dangerous half. **A leg that passes because the log is absent certifies a run nobody checked**, and there's no way to tell after the fact which historical greens were real. Same class as the 71-hour trace stall and the silently-ignored template.

Now fails closed, reports `CANNOT CERTIFY` with the expected path, the backend, why a pass would be meaningless, and the remedy — flagged separately from "incidents were found", because the two need different debugging. A present-but-unchanged log is still a genuine pass, and a test pins that so fail-closed doesn't turn the steady state red.

### 2. `#935` — provider health noise (measured)

`exposes no is_healthy()` re-reported a **static** fact on every health poll: 292 lines for `tool` and 146 for `wise_authority` in a 31-minute window on datum, ~2,900/hour overall — **2.6× the 2.7.6 flood** that 2.4.3 and 2.9.6 fixed.

**950 → 19 warnings across 50 polls (98% reduction)**, the 19 being one per service type — the true defect count. Silence isn't the fix: it's a genuine registration defect, so it reports once per `(service_type, provider class)` and the report carries the RCA — which class, why it can never pass a health check, that it's a registration bug rather than a runtime state, and what to change. The `#943` property (unknown never counts as healthy) is preserved and tested.

### 3. `#935` — pricing had zero coverage of what we actually run

`PRICING_DATA.json` carried 10 models across 4 providers and **none of the live matrix**, so every production cost calculation missed. Now **15 models across 7 providers**, adding OpenRouter, Groq and DeepInfra which had no entry at all.

**Per-provider defaults.** One global fallback was wrong in both directions — it understated an unknown Anthropic model by **75× on output** (20 vs 1500 cents/M). The model name may be new; the provider is always known and tells us the tier.

Units were verified before anything was touched: values are **cents** per million tokens despite `currency: USD` — confirmed as exactly 100× list price against four models spanning a 100× range, and recorded in `metadata.units_note`. Getting that backwards would have mispriced everything by 100×.

⚠️ **The added prices are approximate list prices** as of 2026-08-09, marked as such in every description. They beat "no entry", but they are not authoritative and want verification against provider catalogs before anyone bills on them.

### Also verified, no change needed

`#935`'s original two causes are **already fixed** — `AUTH_STEP_INFO` → debug in 2.4.3, and the `key` attribute in v2.9.6 (2026-06-12). The fleet saw them on processes with 7–11 weeks uptime, started ~2026-06-11. The manager team's controlled comparison confirms it: 2.9.13 datum shows **0** of both; the 2.7.6 controls show 2,696 and 3,600.

`#1021` is **substrate-side** — the anti-Goodhart guard fires because on a cohabited node the scorer's own key *is* the agent's key. Working as designed; the defect is that it's attempted at all and logged per-cycle. Belongs in `CIRISServer/src/scorer.rs`.

### Tests

`216` tools tests, `148` API route tests, `66` pricing/cost tests — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018umjfoyNwpa7BWVmzoayTM
