### PR TITLE
fix(ci): safety evidence sync has been red for 7 days — main now requires a PR

### DIFF
--- a/.github/workflows/safety-evidence-sync.yml
+++ b/.github/workflows/safety-evidence-sync.yml
@@ -51,6 +51,8 @@ concurrency:
 permissions:
   contents: write
   actions: read               # listing + downloading artifacts
+  pull-requests: write        # main is ruleset-protected: evidence lands via PR,
+                              # not a direct push (see the delivery step)
 
 jobs:
   sync:
@@ -104,11 +106,33 @@ jobs:
             exit 1
           fi
 
-      - name: Commit
+      - name: Open/refresh the evidence PR
         if: steps.diff.outputs.changed != '0' && inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # PUSHES TO A BRANCH, NOT TO MAIN.
+          #
+          # This step used to `git push origin main` and had been failing every
+          # day since 2026-08-08 — seven consecutive scheduled runs — with
+          #
+          #   remote: error: GH013: Repository rule violations found for refs/heads/main
+          #   remote: - Changes must be made through a pull request.
+          #
+          # A repository ruleset now requires PRs for main. Nothing about the
+          # harvest was broken; the delivery was illegal. Meanwhile the artifacts
+          # this job exists to outlive kept ticking toward their 90-day expiry,
+          # which is the exact loss the workflow was written to prevent, arriving
+          # by a different route than the one it guarded.
+          #
+          # A long-lived branch is durable storage in its own right: once these
+          # bundles are pushed to the remote they are off the artifact clock even
+          # before anyone merges. So the retention guarantee holds at push time,
+          # and the PR is how it reaches main.
+          BRANCH=evidence/safety-sync
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
           git add qa_reports/safety_battery qa_reports/safety_interpret
           git commit -m "evidence: sync safety-battery bundles from expiring artifacts
 
@@ -117,7 +141,27 @@ jobs:
           of the bytes and a separate retention question.
 
           bundles: ${{ steps.diff.outputs.bundles_battery }} battery, ${{ steps.diff.outputs.bundles_interpret }} interpret"
-          git push origin main
+
+          # Force-push: one accumulating branch rather than a new PR per day.
+          # Safe because nothing but this job writes it and its content is
+          # regenerated from artifacts each run.
+          git push -f origin "$BRANCH"
+
+          if gh pr view "$BRANCH" --json state --jq .state 2>/dev/null | grep -q OPEN; then
+            echo "PR already open for $BRANCH — refreshed it."
+          else
+            gh pr create --base main --head "$BRANCH" \
+              --title "evidence: safety-battery bundles harvested from expiring artifacts" \
+              --body "Automated by \`safety-evidence-sync\`. Copies battery evidence out of
+          GitHub Actions artifacts (90-day expiry) into the repo, which has none.
+
+          Holding ${{ steps.diff.outputs.bundles_battery }} battery and
+          ${{ steps.diff.outputs.bundles_interpret }} interpret bundles.
+
+          Data only — no code. Traces are excluded (99.9% of the bytes, separate
+          retention question). The branch is force-updated by each run, so this PR
+          stays current; merging it is safe at any time."
+          fi
 
       - name: Nothing to do
         if: steps.diff.outputs.changed == '0'


### PR DESCRIPTION
## The failure

`Safety evidence sync` has failed **every scheduled run since 2026-08-08** — seven consecutive days:

```
remote: error: GH013: Repository rule violations found for refs/heads/main
remote: - Changes must be made through a pull request.
! [remote rejected]     main -> main (push declined due to repository rule violations)
```

A repository ruleset now requires pull requests for `main` — the same rule that made the 2.9.14 merge need `--admin`.

## Why it matters more than a red check

Nothing about the harvest was broken. `tools/harvest_safety_evidence.py` ran fine every day; only the **delivery** was illegal, so the job died at the last step with all the work done.

The workflow exists because Actions artifacts expire at 90 days and safety-battery evidence was days from the cliff when it was written. For the past week that copy has not been made, while the artifacts kept aging — the exact loss this job guards against, arriving by a route it did not cover.

## The fix

Push to a long-lived `evidence/safety-sync` branch and open (or refresh) a PR, instead of pushing to `main`.

The retention guarantee holds at **push** time, not merge time: once bundles are on the remote they are off the artifact clock, so a PR waiting on a human costs nothing that matters.

- Force-pushed each run, so it is one accumulating PR rather than a new one per day. Safe because nothing else writes that branch and its contents are regenerated from artifacts every run.
- Each run rebases onto current `main` (checkout is `ref: main`, then `checkout -B`), so the PR never goes stale.
- Added `pull-requests: write`; the job only had `contents: write`.

## Not doing

**Not** adding a ruleset bypass for the bot. The rule is doing its job; the workflow was the thing out of step.

**Not** bumping the version — CI-only, and 2.9.14 was tagged minutes ago, so a bump would immediately desync `main`'s version string from the release tag for no runtime change.

## Verification

YAML parses; 6 steps resolve in order. No `push origin main` remains in the file outside the explanatory comment. The first scheduled run after merge (11:40 UTC) is the real test — or trigger `workflow_dispatch` to check sooner.
