### PR TITLE
2.9.15 — upgrade no longer bounces the owner to the wizard, desktop gets its Google button

### DIFF
--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -6,11 +6,11 @@ from typing import List
 from ciris_engine.schemas.runtime.canonical_peer import CanonicalBootstrapPeer
 
 # Version information
-CIRIS_VERSION = "2.9.14-stable"
+CIRIS_VERSION = "2.9.15-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
 CIRIS_VERSION_MINOR = 9
-CIRIS_VERSION_PATCH = 14
+CIRIS_VERSION_PATCH = 15
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/ciris_engine/logic/adapters/api/routes/setup/dependencies.py
+++ b/ciris_engine/logic/adapters/api/routes/setup/dependencies.py
@@ -13,6 +13,72 @@ from ciris_engine.logic.setup.first_run import get_default_config_path, is_first
 logger = logging.getLogger(__name__)
 
 
+#: WA roles that constitute an OWNER. `observer` is excluded deliberately: the
+#: agent mints observer certificates for its adapters on every boot, so counting
+#: them would report "setup complete" on a genuinely empty install and defeat the
+#: #794 self-heal this sits alongside.
+_OWNER_ROLES = ("root", "authority")
+
+
+def _node_owner_present() -> Optional[bool]:
+    """True if the NODE holds an active human owner certificate.
+
+    2.9.14 moved identity to the substrate, and the brain's WA store now
+    deliberately SKIPS node-owner rows (`wa-root-*`) because they are
+    substrate-owned federation identities, not brain `WACertificate`s — see
+    `_is_brain_wa_row` (CIRISAgent#922, which fixed a completeSetup 500).
+
+    Two correct changes composing into a wrong answer. On an install whose
+    owner was created by node self-claim, the ONLY human row is `wa-root-…`;
+    the brain skips it, `has_system_admin_user()` reports "no admin", and
+    `is_setup_required()` takes the #794 bugged-install branch — bouncing a
+    healthy upgraded install into the setup wizard with its credentials sitting
+    intact on disk.
+
+    Reproduced on a real 2.9.14 upgrade:
+
+        cirislens_wa_cert:
+          wa-root-eric-moore-…  name=emoore  role=root  active=1
+          apiplatform_observer / wallet_observer / …   (minted every boot)
+
+        /v1/setup/status -> setup_required=true, first_run=false,
+                            config_exists=true          -> wizard
+
+    So ask the store that owns identity now, by ROLE — persist's
+    `wa_cert_list_by_role` already filters to active rows, and querying only
+    the owner roles keeps the minted observers out by construction rather than
+    by name-matching.
+
+    Returns None — never False — when the substrate cannot be read, so an
+    unreachable store falls back to the brain's answer instead of asserting
+    "no owner" and forcing the wizard on.
+    """
+    try:
+        from ciris_engine.logic.persistence.stores.authentication_store import (
+            _list_active_by_role,
+        )
+    except ImportError:  # pragma: no cover - defensive
+        return None
+
+    found = False
+    for role in _OWNER_ROLES:
+        try:
+            rows = _list_active_by_role(role)
+        except Exception as e:  # pragma: no cover - substrate unreadable
+            logger.debug("[SETUP] node-owner probe failed for role %s: %s", role, e)
+            return None
+        if rows:
+            logger.info(
+                "[SETUP] node holds %d active %r certificate(s) — setup is complete "
+                "even though the brain's user store reports no SYSTEM_ADMIN "
+                "(node-owner rows are skipped there by design).",
+                len(rows),
+                role,
+            )
+            found = True
+    return found
+
+
 async def has_system_admin_user(request: Request) -> Optional[bool]:
     """Return True if at least one SYSTEM_ADMIN user exists, False if not,
     None if we can't tell (auth service unavailable yet).
@@ -101,6 +167,13 @@ async def is_setup_required(request: Request) -> bool:
         return False
 
     has_admin = await has_system_admin_user(request)
+    if has_admin is False:
+        # The brain says "no admin". Before declaring a bugged install, ask the
+        # store that owns identity as of 2.9.14 — the brain skips node-owner
+        # rows by design, so its "no" is not evidence of absence on a
+        # node-claimed install.
+        if _node_owner_present() is True:
+            return False
     return has_admin is False
 
 

--- a/client/androidApp/build.gradle
+++ b/client/androidApp/build.gradle
@@ -25,8 +25,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 35
-        versionCode 151
-        versionName "2.9.14"
+        versionCode 152
+        versionName "2.9.15"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/client/androidApp/src/main/python/version.py
+++ b/client/androidApp/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.9.14"
+__version__ = "android-2.9.15"
 
 
 def get_version() -> str:

--- a/client/desktopApp/build.gradle.kts
+++ b/client/desktopApp/build.gradle.kts
@@ -34,7 +34,7 @@ compose.desktop {
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "CIRIS"
-            packageVersion = "2.9.14"
+            packageVersion = "2.9.15"
             description = "CIRIS Agent Desktop Application"
             vendor = "CIRIS L3C"
 

--- a/client/iosApp/iosApp/Info.plist
+++ b/client/iosApp/iosApp/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.14</string>
+	<string>2.9.15</string>
 	<key>CFBundleVersion</key>
-	<string>309</string>
+	<string>310</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/CIRISApp.kt
+++ b/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/CIRISApp.kt
@@ -1846,7 +1846,17 @@ fun CIRISApp(
                     errorMessage = loginErrorMessage,
                     ownerHint = ownerHint,
                     observerBlocked = observerBlocked,
-                    showLocalLoginForm = (googleSignInCallback == null && isFirstRun == false),
+                    // Start the local form EXPANDED only where there is no sign-in
+                    // alternative. A null callback used to mean exactly that — but desktop
+                    // now has the node's browser flow (#1028), and forcing the form there
+                    // hides a Google button whose handler is already fully implemented.
+                    // That is what shipped in 2.9.14. wasmJs and anything else passing
+                    // null keeps the previous behaviour.
+                    showLocalLoginForm = (
+                        googleSignInCallback == null &&
+                            !ai.ciris.mobile.shared.platform.isDesktop() &&
+                            isFirstRun == false
+                    ),
                     isFirstRun = isFirstRun ?: true,
                     // NOTE: no fedID sign-in option here by design — the fedID is the
                     // founder's identity, minted in the first-run wizard and accessed

--- a/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/screens/LoginScreen.kt
+++ b/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/screens/LoginScreen.kt
@@ -103,7 +103,13 @@ fun LoginScreen(
     var showResetConfirm by remember { mutableStateOf(false) }
     val focusManager = LocalFocusManager.current
 
-    // For desktop, always show login form (not OAuth buttons)
+    // Desktop USED to mean "local login only", because there was no native
+    // Google SDK and nothing could complete a browser sign-in. ciris-server
+    // 0.5.165 changed that: the node serves the browser flow and the app polls
+    // /v1/auth/oauth/handoff for the session (CIRISAgent#1028). The handler
+    // behind `onGoogleSignIn` already implements it — see CIRISApp's desktop
+    // branch — so this flag no longer decides whether OAuth is POSSIBLE, only
+    // whether the local form starts expanded.
     val isDesktopMode = isDesktop()
 
     // Localized strings
@@ -210,8 +216,12 @@ fun LoginScreen(
                             modifier = Modifier.padding(top = 16.dp)
                         )
                     }
-                } else if (isDesktopMode || showLoginForm) {
-                    // Desktop mode or Local Login form - show username/password fields
+                } else if (showLoginForm) {
+                    // Local Login form - show username/password fields.
+                    // `isDesktopMode` deliberately NOT part of this condition: it
+                    // short-circuited desktop straight here, making the OAuth branch
+                    // below unreachable, so the Google button never rendered on
+                    // desktop even though its handler was fully implemented.
                     LocalLoginForm(
                         username = username,
                         onUsernameChange = { username = it },
@@ -222,7 +232,10 @@ fun LoginScreen(
                                 onLocalLoginSubmit(username, password)
                             }
                         },
-                        onBack = if (!isDesktopMode) {{ showLoginForm = false }} else null,
+                        // Back is available everywhere now. It was null on desktop
+                        // because the form was the only screen there and there was
+                        // nothing to go back TO; with OAuth buttons present there is.
+                        onBack = { showLoginForm = false },
                         errorMessage = errorMessage,
                         focusManager = focusManager
                     )

--- a/tests/adapters/api/routes/setup/test_node_owner_counts_as_setup_done.py
+++ b/tests/adapters/api/routes/setup/test_node_owner_counts_as_setup_done.py
@@ -1,0 +1,174 @@
+"""A node-claimed owner must count as "setup complete" — or upgrades bounce to the wizard.
+
+THE BUG, reproduced on a real 2.9.14 upgrade of an installed agent:
+
+    cirislens_wa_cert:
+      wa-root-eric-moore-…   name=emoore   role=root   active=1
+      apiplatform_observer / wallet_observer / …       (minted every boot)
+
+    GET /v1/setup/status
+      -> setup_required=true, first_run=false, config_exists=true
+    client -> setup wizard, owner locked out, credentials intact on disk
+
+Two individually-correct changes composed into a wrong answer:
+
+  1. 2.9.14 moved identity to the substrate. The owner of a node-claimed
+     install is a `wa-root-…` row in the node's store.
+  2. CIRISAgent#922 made the brain's WA store deliberately SKIP those rows —
+     they are substrate-owned federation identities, not brain
+     `WACertificate`s — to fix a completeSetup 500.
+
+`has_system_admin_user()` reads the BRAIN's user cache, which by (2) can no
+longer see the only human. It answers "no admin", and `is_setup_required()`
+takes the #794 bugged-install self-heal branch ("config exists but the founding
+admin was lost"), which is exactly wrong here: nothing was lost.
+
+The self-heal must survive. These tests pin both directions — a real owner
+suppresses the wizard, a genuinely empty install still triggers it — because a
+fix that only stopped the false positive would silently disable #794 recovery.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from ciris_engine.logic.adapters.api.routes.setup import dependencies as deps
+
+
+class _Req:
+    """Stand-in for the FastAPI Request; only `.app.state` is consulted."""
+
+    class _App:
+        class _State:
+            auth_service = None
+
+        state = _State()
+
+    app = _App()
+
+
+@pytest.fixture
+def req() -> Any:
+    return _Req()
+
+
+def _patch_roles(monkeypatch: pytest.MonkeyPatch, table: Dict[str, List[dict]]) -> None:
+    """Fake the substrate's by-role listing (already active-filtered, as persist is)."""
+
+    def fake(role: str, limit: int = 1000) -> List[dict]:
+        return table.get(role, [])
+
+    import ciris_engine.logic.persistence.stores.authentication_store as store
+
+    monkeypatch.setattr(store, "_list_active_by_role", fake, raising=True)
+
+
+def _no_brain_admin(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The brain reports no SYSTEM_ADMIN — what it does on a node-claimed install."""
+
+    async def fake(_request: Any) -> Optional[bool]:
+        return False
+
+    monkeypatch.setattr(deps, "has_system_admin_user", fake, raising=True)
+
+
+def _config_exists(monkeypatch: pytest.MonkeyPatch, exists: bool = True) -> None:
+    class _P:
+        def exists(self) -> bool:
+            return exists
+
+    monkeypatch.setattr(deps, "get_default_config_path", lambda: _P(), raising=True)
+    monkeypatch.setattr(deps, "is_first_run", lambda: False, raising=True)
+
+
+@pytest.mark.asyncio
+async def test_node_root_owner_means_setup_is_not_required(monkeypatch, req) -> None:
+    """THE REGRESSION: owner exists on the node, brain can't see it, no wizard."""
+    _config_exists(monkeypatch)
+    _no_brain_admin(monkeypatch)
+    _patch_roles(
+        monkeypatch,
+        {"root": [{"wa_id": "wa-root-eric-moore-v2-portable-abc", "name": "emoore", "active": 1}]},
+    )
+
+    assert await deps.is_setup_required(req) is False, (
+        "an active node-owner root certificate must count as setup-complete; "
+        "otherwise every node-claimed install is bounced into the wizard on upgrade"
+    )
+
+
+@pytest.mark.asyncio
+async def test_authority_role_also_counts(monkeypatch, req) -> None:
+    """`authority` is an owner role too — only `observer` is self-minted."""
+    _config_exists(monkeypatch)
+    _no_brain_admin(monkeypatch)
+    _patch_roles(monkeypatch, {"authority": [{"wa_id": "wa-2026-01-01-AAAAAA", "name": "ops"}]})
+
+    assert await deps.is_setup_required(req) is False
+
+
+@pytest.mark.asyncio
+async def test_794_self_heal_still_fires_on_a_genuinely_empty_store(monkeypatch, req) -> None:
+    """The other direction, and the reason this is not just `return False`.
+
+    Config says configured, brain has no admin, and the node has no owner
+    either — the real bugged-install state #794 exists to recover. If this ever
+    returns False the recovery path is silently dead and the user has no way
+    back in, which is strictly worse than the false wizard this fix removes.
+    """
+    _config_exists(monkeypatch)
+    _no_brain_admin(monkeypatch)
+    _patch_roles(monkeypatch, {})  # no root, no authority
+
+    assert await deps.is_setup_required(req) is True
+
+
+@pytest.mark.asyncio
+async def test_observers_alone_do_not_count_as_an_owner(monkeypatch, req) -> None:
+    """Adapter observers are minted on EVERY boot.
+
+    Counting them would make a brand-new empty install report "setup complete"
+    — the failure mode that makes a self-heal useless. Excluded by ROLE rather
+    than by name matching, so a differently-named observer cannot slip through.
+    """
+    _config_exists(monkeypatch)
+    _no_brain_admin(monkeypatch)
+    _patch_roles(
+        monkeypatch,
+        {"observer": [{"wa_id": "wa-2026-08-14-2C136E", "name": "apiplatform_observer"}]},
+    )
+
+    assert await deps.is_setup_required(req) is True
+
+
+@pytest.mark.asyncio
+async def test_unreadable_substrate_defers_to_the_brain(monkeypatch, req) -> None:
+    """A store that raises must not be read as "no owner".
+
+    Asserting absence from a failed probe would force the wizard exactly when
+    the substrate is unhealthy — the moment a spurious re-setup is most
+    destructive. The probe returns None and the brain's answer stands.
+    """
+    _config_exists(monkeypatch)
+    _no_brain_admin(monkeypatch)
+
+    import ciris_engine.logic.persistence.stores.authentication_store as store
+
+    def boom(role: str, limit: int = 1000) -> List[dict]:
+        raise RuntimeError("persist engine not wired")
+
+    monkeypatch.setattr(store, "_list_active_by_role", boom, raising=True)
+
+    assert deps._node_owner_present() is None
+    assert await deps.is_setup_required(req) is True
+
+
+@pytest.mark.asyncio
+async def test_first_run_still_short_circuits(monkeypatch, req) -> None:
+    """A true first run stays a first run regardless of what the node holds."""
+    monkeypatch.setattr(deps, "is_first_run", lambda: True, raising=True)
+    _patch_roles(monkeypatch, {"root": [{"wa_id": "wa-root-x", "name": "someone"}]})
+
+    assert await deps.is_setup_required(req) is True


### PR DESCRIPTION
Two regressions in 2.9.14's own changes, both found on a real upgrade of an installed agent on localhost.

## 1. The upgrade locked the owner out (setup wizard)

Upgrading landed the owner in the **first-run wizard** with credentials sitting intact on disk:

```
cirislens_wa_cert:
  wa-root-eric-moore-…   name=emoore   role=root   active=1
  apiplatform_observer / wallet_observer / …       (minted every boot)

GET /v1/setup/status
  -> setup_required=true, first_run=false, config_exists=true   -> wizard
```

Note that response contradicts itself: `first_run=false` **and** `config_exists=true`, yet `setup_required=true`. The backend logged `NOT first run` on every check — the wizard came from `setup_required` alone.

Two individually-correct changes composed into a wrong answer:

1. 2.9.14 moved identity to the substrate, so a node-claimed install's owner is a `wa-root-…` row in the node's store.
2. #922 made the brain's WA store deliberately **skip** those rows — substrate-owned federation identities, not brain `WACertificate`s — which fixed a completeSetup 500.

`has_system_admin_user()` reads the brain's user cache, which by (2) can no longer see the only human. It answers "no admin", and `is_setup_required()` takes the #794 bugged-install branch — *"config exists but the founding admin was lost"* — which is precisely wrong, because nothing was lost.

**Fix:** before declaring a bugged install, ask the store that owns identity now — by **role** (`root`, `authority`) via persist's already-active-filtered `wa_cert_list_by_role`, so the observers minted on every boot are excluded by construction rather than by name matching. Returns `None`, never `False`, when the substrate can't be read, so an unreachable store falls back to the brain's answer instead of forcing a re-setup exactly when the substrate is unhealthy.

The **#794 self-heal had to survive**, so the tests pin both directions: 2 fail without the fix, and 4 pass with *and* without it — a genuinely empty store still triggers recovery, observers alone never satisfy it, an unreadable substrate defers, and a true first run still short-circuits. A fix that only killed the false positive would have silently disabled the recovery path, which is worse than the bug.

## 2. Desktop never showed the Google button (#1028)

2.9.14 was meant to bring Google sign-in to desktop. The log said why on every frame:

```
[Screen.Login] Rendering login screen, googleSignInCallback=NULL, isFirstRun=false
```

The work was all present — `oauthBrowserLoginUrl()` and `collectOAuthHandoff()` ported from ciris-server 0.5.165, and a complete desktop branch in `onGoogleSignIn` (nonce → browser → poll, 204 = not yet). None of it was reachable:

1. `LoginScreen`: `else if (isDesktopMode || showLoginForm)` sent desktop straight to the local form, making the OAuth branch unreachable.
2. `CIRISApp`: `showLocalLoginForm` expands whenever there is no **native** callback — always true on desktop, which signs in through the browser and never sets one.

Both were correct when desktop had no way to complete a sign-in; neither was revisited when the node grew one.

**Not** changing `googleSignInCallback = null` in `desktopApp/Main.kt` — that value is right. `NativeSignInResult` carries an **ID token for exchange**, while the handoff returns an **already-issued session bearer**; wiring desktop through that callback would feed an access token into an exchange path. Only the comment there is stale.

## Verification

- 32 tests pass across the setup suite; the 6 new ones proven to fail without the fix.
- `:shared:compileKotlinDesktop` passes.
- **Not proven:** the Google round-trip beyond the browser hand-off. That depends on the node having a Google client configured, which this box does not. The button renders and the handler runs; completion is unverified here.

## Adoption status (#1028 / #1029)

Re-checked against what shipped, rather than assumed:

| ask | state |
|---|---|
| `/v1/auth/*` proxied to the node | `auth_proxy.py` present |
| duplicated Python deleted | `routes/auth.py` removed in `201d76f02` |
| `_decode_google_jwt_locally` unverified-JWT hazard | gone with it (survives only as a comment) |
| pin floor ≥ 0.5.169 | `0.5.172` |
| desktop Google sign-in "inherited for free" | **was not** — closed by this PR |

That last row is why these stayed open: the auth fold was complete, the desktop half was not.
