### PR TITLE
2.9.16 — verify status loads, node-claimed owners get their partnership, no dialling a placeholder key

### DIFF
--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -6,11 +6,11 @@ from typing import List
 from ciris_engine.schemas.runtime.canonical_peer import CanonicalBootstrapPeer
 
 # Version information
-CIRIS_VERSION = "2.9.15-stable"
+CIRIS_VERSION = "2.9.16-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
 CIRIS_VERSION_MINOR = 9
-CIRIS_VERSION_PATCH = 15
+CIRIS_VERSION_PATCH = 16
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/ciris_engine/logic/adapters/api/routes/auth_proxy.py
+++ b/ciris_engine/logic/adapters/api/routes/auth_proxy.py
@@ -154,6 +154,55 @@ def _log_agent_side_cert_inventory() -> None:
         logger.debug("auth proxy: could not enumerate agent-side certs: %s", exc)
 
 
+@router.get("/system/verify-status", include_in_schema=False)
+async def proxy_verify_status_to_node(request: Request) -> Response:
+    """Relay `GET /v1/system/verify-status` to the node.
+
+    THE BUG THIS CLOSES. The client asks for CIRISVerify status every 30s. In
+    node mode it calls `GET /v1/system/verify-status`; in AGENT mode it calls
+    `GET /v1/auth/attestation`, which the Python router used to serve with a GET
+    handler. 2.9.14 deleted that router and proxied `/v1/auth/*` to the node —
+    whose attestation route is POST-only. So the agent-mode GET became a 405,
+    38 times in one session on a live install, and verify never loaded:
+
+        :8080 /v1/auth/attestation      GET=405   <- what the client calls
+        :4243 /v1/auth/attestation      GET=405   <- node: POST-only (the cause)
+        :4243 /v1/system/verify-status  GET=200   <- where the data actually is
+        :8080 /v1/system/verify-status  GET=404   <- but we exposed no route to it
+
+    The data was one hop away the whole time. Verify is substrate-owned now, so
+    the answer is to expose the node's read-only route through the agent's front
+    door rather than reinstate a Python attestation handler — which would be the
+    duplication #1028 exists to remove.
+
+    Deliberately NOT proxying `/v1/system/*` wholesale: that prefix is the
+    brain's (agent, telemetry, runtime control), and a catch-all here would
+    shadow those routes. One exact path, because exactly one moved.
+    """
+    url = f"{NODE_UPSTREAM}/v1/system/verify-status"
+    headers = {k: v for k, v in request.headers.items() if k.lower() not in _HOP_BY_HOP}
+
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT, follow_redirects=False) as client:
+            upstream = await client.get(url, params=request.query_params, headers=headers)
+    except httpx.RequestError:
+        # Same reasoning as the auth proxy: name the UPSTREAM, never the caller's
+        # path, and answer 502 — the node being unreachable is infrastructure,
+        # not a verdict about this request.
+        logger.exception("verify-status proxy could not reach the node at %s", NODE_UPSTREAM)
+        return Response(
+            content=b'{"detail":"verification service unavailable"}',
+            status_code=502,
+            media_type="application/json",
+        )
+
+    return Response(
+        content=upstream.content,
+        status_code=upstream.status_code,
+        headers={k: v for k, v in upstream.headers.items() if k.lower() not in _HOP_BY_HOP},
+    )
+
+
 @router.api_route(
     "/auth/{path:path}",
     methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"],

--- a/ciris_engine/logic/runtime/config_migration.py
+++ b/ciris_engine/logic/runtime/config_migration.py
@@ -309,22 +309,72 @@ async def migrate_founding_partnerships(runtime: Any) -> None:
     from ciris_engine.schemas.services.authority_core import WARole
     from ciris_engine.schemas.services.graph_core import GraphScope
 
-    root_was = [wa for wa in all_was if getattr(wa, "role", None) == WARole.ROOT]
-    if not root_was:
+    # (wa_id, name) pairs, because the two sources return different shapes.
+    roots: list[tuple[str, str]] = [
+        (wa.wa_id, wa.name) for wa in all_was if getattr(wa, "role", None) == WARole.ROOT
+    ]
+
+    # AND the node-owner roots, which `list_was()` cannot return.
+    #
+    # STEWARDSHIP AND PARTNERSHIP ARE CO-ESTABLISHED. Stewardship is over a
+    # NODE, partnership is with an AGENT, and claiming a node establishes both
+    # at the same moment by the same act. The substrate holds up its half — a
+    # claimed install carries `ownership:responsible_party:node:v1` — but the
+    # partnership half had no counterpart on that path, so it simply never
+    # happened.
+    #
+    # The cause is a filter that is correct in itself: `list_was()` ends with
+    # `if _is_brain_wa_row(r)`, excluding `wa-root-*` rows because they are
+    # substrate-owned federation identities rather than brain WACertificates
+    # (#922). An owner minted by node self-claim is therefore invisible here,
+    # `root_was` comes back empty, and a live install logs exactly this while
+    # holding a perfectly good root:
+    #
+    #     [PARTNERSHIP_MIGRATION] No ROOT WAs found - nothing to backfill
+    #
+    # That is the same filter behind the 2.9.15 setup-wizard lockout. Third
+    # consequence of one correct decision: nothing on the self-claim path does
+    # the work the brain's classic path does for a newly-minted owner.
+    #
+    # Read by ROLE from the substrate store, which persist already filters to
+    # active rows — the same primitive the setup probe uses, so the two agree
+    # about who the owner is rather than each deciding separately.
+    try:
+        from ciris_engine.logic.persistence.stores.authentication_store import (
+            _list_active_by_role,
+        )
+
+        known = {wa_id for wa_id, _ in roots}
+        for row in _list_active_by_role(WARole.ROOT.value):
+            node_wa_id = str(row.get("wa_id") or "")
+            if node_wa_id and node_wa_id not in known:
+                roots.append((node_wa_id, str(row.get("name") or node_wa_id)))
+                logger.info(
+                    "[PARTNERSHIP_MIGRATION] including node-owner root %s — invisible to "
+                    "list_was() by design (#922), but stewardship and partnership are "
+                    "established together",
+                    node_wa_id,
+                )
+    except Exception as e:  # pragma: no cover - substrate unreadable
+        # Not fatal: the brain-side roots above are still worth backfilling, and
+        # asserting "no node owner" from a failed read would be the same mistake
+        # in the other direction.
+        logger.warning("[PARTNERSHIP_MIGRATION] could not read node-owner roots: %s", e)
+
+    if not roots:
         logger.info("[PARTNERSHIP_MIGRATION] No ROOT WAs found - nothing to backfill")
         return
 
     backfilled = 0
-    for wa in root_was:
-        wa_id = wa.wa_id
+    for wa_id, wa_name in roots:
         # Check consent/{wa_id} (canonical) and consent/{name} (legacy)
         existing_by_waid = get_graph_node(f"consent/{wa_id}", GraphScope.LOCAL)
-        existing_by_name = get_graph_node(f"consent/{wa.name}", GraphScope.LOCAL)
+        existing_by_name = get_graph_node(f"consent/{wa_name}", GraphScope.LOCAL)
         if existing_by_waid is not None:
             logger.debug(f"[PARTNERSHIP_MIGRATION] consent/{wa_id} already exists - skipping")
             continue
         if existing_by_name is not None:
-            logger.debug(f"[PARTNERSHIP_MIGRATION] consent/{wa.name} (legacy) already exists - skipping")
+            logger.debug(f"[PARTNERSHIP_MIGRATION] consent/{wa_name} (legacy) already exists - skipping")
             continue
 
         try:

--- a/ciris_engine/logic/services/runtime/llm_service/service.py
+++ b/ciris_engine/logic/services/runtime/llm_service/service.py
@@ -639,6 +639,68 @@ def _detect_provider_from_env() -> LLMProvider:
     return LLMProvider.OPENAI
 
 
+#: Keys that are obviously not credentials — placeholders we or a setup flow
+#: wrote, never something a provider issued. Matched case-insensitively and
+#: exactly, so a real key that merely CONTAINS one of these is unaffected.
+_PLACEHOLDER_API_KEYS = frozenset(
+    {
+        "sk-test",
+        "test",
+        "sk-placeholder",
+        "placeholder",
+        "changeme",
+        "change-me",
+        "your-api-key",
+        "your-api-key-here",
+        "your_api_key_here",
+        "dummy",
+        "example",
+        "todo",
+        "none",
+        "null",
+        "xxx",
+    }
+)
+
+#: Hosts where a short/dummy key is definitely wrong. A LOCAL endpoint is the
+#: opposite case — Ollama and llama.cpp are routinely handed "ollama" or "none"
+#: as a key precisely because they ignore it, and refusing those would break
+#: local inference to fix a cloud typo.
+_REAL_OPENAI_HOSTS = ("api.openai.com",)
+
+
+def _is_placeholder_api_key(api_key: str, base_url: Optional[str]) -> bool:
+    """True if this key cannot possibly authenticate and we should not try.
+
+    Attempting anyway is not free. On a live install `OPENAI_API_KEY=sk-test`
+    (7 chars) produced a 401 from every DMA in the shutdown chain — the agent
+    deliberates about accepting shutdown, so simply STOPPING it emitted
+    `Incorrect API key provided: sk-test` three times over, plus tracebacks,
+    from a user who had asked nothing. Worse, health reported
+    `provider=openai` as ready, because readiness checked configuration rather
+    than whether the credential could work.
+
+    Scoped to keys bound for the real OpenAI endpoint. Anything with a custom
+    base_url is left alone: local runtimes are handed placeholder keys ON
+    PURPOSE (they ignore the value), and a check that broke `jetson.local`
+    Ollama to catch a cloud typo would be a bad trade.
+    """
+    key = (api_key or "").strip()
+    if not key:
+        return False  # the existing empty-key guard owns this case
+
+    host = (base_url or "").strip().lower()
+    if host and not any(h in host for h in _REAL_OPENAI_HOSTS):
+        return False
+
+    if key.lower() in _PLACEHOLDER_API_KEYS:
+        return True
+    # Real OpenAI keys are ~51 chars ("sk-" + 48); the project variants are
+    # longer still. 20 is far below any issued key and far above the
+    # placeholders above, so it catches truncation without judging format.
+    return key.startswith("sk-") and len(key) < 20
+
+
 def _get_api_key_for_provider(provider: LLMProvider) -> str:
     """Get the appropriate API key for the given provider.
 
@@ -760,6 +822,22 @@ class OpenAICompatibleClient(BaseService, LLMServiceProtocol):
             provider_name = provider.value if hasattr(provider, "value") else str(provider)
             raise RuntimeError(
                 f"No API key found for {provider_name}. Please set the appropriate API key environment variable."
+            )
+
+        # A placeholder key is treated exactly like NO key: refuse here rather
+        # than register a provider that can only 401. Same failure path, one
+        # honest line, instead of a wall of `Incorrect API key provided` from
+        # every DMA the next time anything needs the model — including the
+        # shutdown deliberation, which fires when the user merely stops the
+        # agent. NOT logging the key itself: it is a credential slot by
+        # contract, whatever happens to be sitting in it.
+        if _is_placeholder_api_key(api_key, base_url):
+            provider_name = provider.value if hasattr(provider, "value") else str(provider)
+            raise RuntimeError(
+                f"The {provider_name} API key is a placeholder, not a credential "
+                f"(length {len(api_key.strip())}). Refusing to connect — it can only "
+                f"return 401. Set a real key, or point base_url at a local runtime "
+                f"that does not need one."
             )
 
         # Initialize client based on provider

--- a/client/androidApp/build.gradle
+++ b/client/androidApp/build.gradle
@@ -25,8 +25,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 35
-        versionCode 152
-        versionName "2.9.15"
+        versionCode 153
+        versionName "2.9.16"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/client/androidApp/src/main/python/version.py
+++ b/client/androidApp/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.9.15"
+__version__ = "android-2.9.16"
 
 
 def get_version() -> str:

--- a/client/desktopApp/build.gradle.kts
+++ b/client/desktopApp/build.gradle.kts
@@ -34,7 +34,7 @@ compose.desktop {
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "CIRIS"
-            packageVersion = "2.9.15"
+            packageVersion = "2.9.16"
             description = "CIRIS Agent Desktop Application"
             vendor = "CIRIS L3C"
 

--- a/client/iosApp/iosApp/Info.plist
+++ b/client/iosApp/iosApp/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.15</string>
+	<string>2.9.16</string>
 	<key>CFBundleVersion</key>
-	<string>310</string>
+	<string>311</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/tests/adapters/api/routes/test_verify_status_proxy.py
+++ b/tests/adapters/api/routes/test_verify_status_proxy.py
@@ -1,0 +1,140 @@
+"""`GET /v1/system/verify-status` must reach the node — verify never loaded without it.
+
+THE BUG. The client polls CIRISVerify status every 30s. In agent mode it asks
+`GET /v1/auth/attestation`, which the Python auth router served with a GET
+handler until 2.9.14 deleted that router and proxied `/v1/auth/*` to the node.
+The node's attestation route is POST-only, so the agent-mode GET became a 405 —
+38 of them in a single session on a live install — and the verify card never
+populated.
+
+Measured on that install:
+
+    :8080 /v1/auth/attestation      GET=405   <- what the client calls
+    :4243 /v1/auth/attestation      GET=405   <- node: POST-only (the cause)
+    :4243 /v1/system/verify-status  GET=200   <- where the data actually is
+    :8080 /v1/system/verify-status  GET=404   <- no route exposed it
+
+The data was one hop away. Verify is substrate-owned now, so the fix exposes the
+node's read-only route rather than reinstating a Python attestation handler,
+which would restore exactly the duplication #1028 removed.
+
+The second test is the one that would catch a careless fix: `/v1/system/*` is
+the BRAIN's prefix — agent, telemetry, runtime control all live there. A
+catch-all proxy would have swallowed them, trading a broken verify card for a
+broken everything-else.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+def test_exactly_one_system_path_is_proxied() -> None:
+    """The proxy must claim ONE path, not the `/system/*` prefix.
+
+    A `{path:path}` catch-all here would shadow the brain's own system routes.
+    Asserting on the registered route rather than on behaviour, because the
+    damage from getting this wrong shows up in unrelated endpoints that no test
+    in this file would think to exercise.
+    """
+    from ciris_engine.logic.adapters.api.routes import auth_proxy
+
+    system_routes = [
+        r for r in auth_proxy.router.routes if "/system" in getattr(r, "path", "")
+    ]
+    assert len(system_routes) == 1, f"expected one system route, got {[r.path for r in system_routes]}"
+
+    route = system_routes[0]
+    assert route.path == "/system/verify-status", (
+        "the proxy must name the exact path that moved to the substrate; a prefix "
+        "or a {path:path} wildcard would shadow the brain's own /v1/system/* routes"
+    )
+    assert set(route.methods or set()) == {"GET"}, (
+        f"read-only route; got {route.methods}. The node's verify-status is a GET, "
+        "and accepting writes here would invent a surface the substrate does not have"
+    )
+
+
+@pytest.mark.asyncio
+async def test_relays_the_nodes_answer_verbatim(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Body and status pass through unchanged — no interpretation."""
+    from ciris_engine.logic.adapters.api.routes import auth_proxy
+
+    payload = b'{"verify_loaded":true,"key_id":"ciris-agent-bootstrap-xyz"}'
+    seen: dict[str, Any] = {}
+
+    class _Resp:
+        content = payload
+        status_code = 200
+        headers = {"content-type": "application/json"}
+
+    class _Client:
+        def __init__(self, **kw: Any) -> None: ...
+        async def __aenter__(self) -> "_Client":
+            return self
+        async def __aexit__(self, *a: Any) -> None: ...
+        async def get(self, url: str, **kw: Any) -> _Resp:
+            seen["url"] = url
+            return _Resp()
+
+    monkeypatch.setattr(auth_proxy.httpx, "AsyncClient", _Client)
+
+    class _Req:
+        method = "GET"
+        headers: dict[str, str] = {}
+        query_params: dict[str, str] = {}
+
+    resp = await auth_proxy.proxy_verify_status_to_node(_Req())  # type: ignore[arg-type]
+
+    assert seen["url"].endswith("/v1/system/verify-status")
+    assert seen["url"].startswith(auth_proxy.NODE_UPSTREAM)
+    assert resp.status_code == 200
+    assert resp.body == payload
+
+
+@pytest.mark.asyncio
+async def test_unreachable_node_is_502_not_a_verdict(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A node we cannot reach is infrastructure, not an attestation result.
+
+    Answering 200-with-empty or 404 here would let the client render "not
+    verified" for what is actually "could not ask" — the same collapse the auth
+    proxy keeps 401 and 503 apart to avoid.
+    """
+    from ciris_engine.logic.adapters.api.routes import auth_proxy
+
+    class _Boom:
+        def __init__(self, **kw: Any) -> None: ...
+        async def __aenter__(self) -> "_Boom":
+            return self
+        async def __aexit__(self, *a: Any) -> None: ...
+        async def get(self, *a: Any, **kw: Any) -> Any:
+            raise auth_proxy.httpx.ConnectError("node down")
+
+    monkeypatch.setattr(auth_proxy.httpx, "AsyncClient", _Boom)
+
+    class _Req:
+        method = "GET"
+        headers: dict[str, str] = {}
+        query_params: dict[str, str] = {}
+
+    resp = await auth_proxy.proxy_verify_status_to_node(_Req())  # type: ignore[arg-type]
+    assert resp.status_code == 502
+
+
+def test_the_failure_log_names_the_upstream_not_the_caller() -> None:
+    """CWE-117: never log caller-controlled input.
+
+    This route takes no path parameter, so there is nothing user-controlled to
+    leak today — the guard is against someone adding one later and reaching for
+    the request to make the message friendlier. Sonar S5145 was raised twice on
+    this file already.
+    """
+    import inspect
+
+    from ciris_engine.logic.adapters.api.routes import auth_proxy
+
+    src = inspect.getsource(auth_proxy.proxy_verify_status_to_node)
+    assert "NODE_UPSTREAM" in src
+    assert "request.url" not in src and "request.path" not in src

--- a/tests/ciris_engine/logic/services/runtime/test_placeholder_api_key.py
+++ b/tests/ciris_engine/logic/services/runtime/test_placeholder_api_key.py
@@ -1,0 +1,81 @@
+"""Never dial OpenAI with a key we can see is a placeholder.
+
+On a live install `OPENAI_API_KEY=sk-test` (7 characters) was registered as a
+working provider. Nothing noticed until something needed the model — and the
+first thing that did was the SHUTDOWN deliberation, because the agent reasons
+about accepting shutdown. So merely stopping the agent produced:
+
+    LLM UNEXPECTED ERROR - InstructorRetryException
+    Error code: 401 - Incorrect API key provided: sk-test
+    DSDMA Ally evaluation failed for thought ID th_seed_SHUTDOWN_…
+    CSDMA evaluation failed for thought ID th_seed_SHUTDOWN_…
+    DMA 'ethical_pdma' failed: run_pdma failed after 3 attempts
+
+from a user who had asked the agent nothing at all. Health had reported
+`provider=openai` READY throughout, because readiness checked configuration
+rather than whether the credential could authenticate.
+
+THE FALSE POSITIVE THAT MATTERS MORE THAN THE BUG. Local runtimes are handed
+placeholder keys ON PURPOSE — Ollama and llama.cpp ignore the value, so
+`api_key="ollama"` against `jetson.local:11434` is CORRECT configuration, not a
+mistake. A check that broke local inference to catch a cloud typo would be a bad
+trade, so the guard only fires for keys bound to the real OpenAI endpoint.
+Half the cases below exist to pin that.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ciris_engine.logic.services.runtime.llm_service.service import _is_placeholder_api_key
+
+
+@pytest.mark.parametrize(
+    "key,base_url,why",
+    [
+        ("sk-test", None, "the exact key from the live install"),
+        ("sk-test", "https://api.openai.com/v1", "same, with the endpoint stated"),
+        ("changeme", None, "placeholder literal"),
+        ("your-api-key-here", None, "placeholder literal"),
+        ("SK-TEST", None, "case-insensitive"),
+        ("  sk-test  ", None, "whitespace-padded"),
+        ("sk-abc", None, "truncated sk- key: far below any issued length"),
+    ],
+)
+def test_obvious_placeholders_are_refused(key: str, base_url: str | None, why: str) -> None:
+    assert _is_placeholder_api_key(key, base_url) is True, why
+
+
+@pytest.mark.parametrize(
+    "key,base_url,why",
+    [
+        ("sk-" + "a" * 48, None, "a real-shaped OpenAI key"),
+        ("sk-proj-" + "b" * 60, None, "a project key"),
+        ("sk-" + "a" * 48, "https://api.openai.com/v1", "real key, explicit endpoint"),
+        ("", None, "empty is the EXISTING guard's job; double-handling would change its error"),
+        ("ollama", "http://jetson.local:11434/v1", "LOCAL runtime — dummy key is correct config"),
+        ("none", "http://127.0.0.1:8000/v1", "local llama.cpp ignores the key entirely"),
+        ("sk-test", "https://api.together.xyz/v1", "third-party endpoint — not ours to judge"),
+        ("gsk_" + "c" * 40, "https://api.groq.com/openai/v1", "groq key, different shape"),
+        ("sk-test-but-actually-a-very-long-real-key-000000", None, "CONTAINS a placeholder but is long"),
+    ],
+)
+def test_everything_else_is_left_alone(key: str, base_url: str | None, why: str) -> None:
+    assert _is_placeholder_api_key(key, base_url) is False, why
+
+
+def test_the_refusal_names_the_problem_without_printing_the_key() -> None:
+    """The error must not echo the credential slot's contents.
+
+    `sk-test` is harmless, but this code path cannot know that — whatever sits
+    in that variable is a credential by contract, and a log line does not get to
+    assume otherwise. Length is the diagnostic; the value is not.
+    """
+    import inspect
+
+    from ciris_engine.logic.services.runtime.llm_service import service
+
+    src = inspect.getsource(service.OpenAICompatibleClient.__init__)
+    guard = src[src.index("_is_placeholder_api_key") :][:900]
+    assert "len(api_key" in guard, "length is what makes the message actionable"
+    assert "{api_key}" not in guard, "must never interpolate the key itself into the message"

--- a/tests/logic/runtime/test_founding_partnership_node_owner.py
+++ b/tests/logic/runtime/test_founding_partnership_node_owner.py
@@ -1,0 +1,160 @@
+"""A node-claimed owner must get a founding partnership — stewardship and partnership co-establish.
+
+Stewardship is over a NODE. Partnership is with an AGENT. Claiming a node
+establishes both, at the same moment, by the same act.
+
+On a live 2.9.15 install the substrate held up its half and the brain did not:
+
+    attestation_subjects:
+      ownership:responsible_party:node:v1   x4     <- stewardship, established
+      consent:stream:*                      NONE   <- partnership, never happened
+
+with the cause printed plainly in the boot log, on an install that owns a
+perfectly good root certificate:
+
+    [PARTNERSHIP_MIGRATION] No ROOT WAs found - nothing to backfill
+
+`migrate_founding_partnerships()` enumerates via `auth_service.list_was()`,
+which ends `if _is_brain_wa_row(r)` — excluding `wa-root-*` rows because they
+are substrate-owned federation identities, not brain WACertificates (#922).
+An owner minted by node self-claim is invisible to it.
+
+That filter is correct. What was missing is that nothing on the self-claim path
+does the work the brain's classic path does for a newly-minted owner. It is the
+same filter behind the 2.9.15 setup-wizard lockout — third consequence of one
+correct decision, which is why the last test here pins the *reason* rather than
+the symptom.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+import pytest
+
+from ciris_engine.logic.runtime import config_migration as cm
+from ciris_engine.schemas.services.authority_core import WARole
+
+
+class _WA:
+    def __init__(self, wa_id: str, name: str, role: Any) -> None:
+        self.wa_id, self.name, self.role = wa_id, name, role
+
+
+class _Auth:
+    def __init__(self, was: List[_WA]) -> None:
+        self._was = was
+
+    async def list_was(self, active_only: bool = True) -> List[_WA]:
+        # Mirrors the real filter: node-owner rows are NEVER returned here.
+        return [w for w in self._was if not w.wa_id.startswith("wa-root-")]
+
+
+class _Runtime:
+    def __init__(self, was: List[_WA]) -> None:
+        class _SI:
+            auth_service = _Auth(was)
+
+        self.service_initializer = _SI()
+
+
+@pytest.fixture
+def wiring(monkeypatch: pytest.MonkeyPatch):
+    """Not first-run, nothing already recorded, and capture who gets a partnership."""
+    monkeypatch.setattr(cm, "is_first_run", lambda: False, raising=False)
+    import ciris_engine.logic.setup.first_run as fr
+
+    monkeypatch.setattr(fr, "is_first_run", lambda: False, raising=True)
+
+    import ciris_engine.logic.persistence.models.graph as graph
+
+    monkeypatch.setattr(graph, "get_graph_node", lambda *a, **k: None, raising=True)
+
+    created: List[str] = []
+    import ciris_engine.logic.adapters.api.routes.setup.complete as complete
+
+    monkeypatch.setattr(complete, "_create_founding_partnership", lambda wa_id: created.append(wa_id), raising=True)
+    return created
+
+
+def _patch_substrate_roots(monkeypatch: pytest.MonkeyPatch, rows: Optional[List[dict]], boom: bool = False) -> None:
+    import ciris_engine.logic.persistence.stores.authentication_store as store
+
+    def fake(role: str, limit: int = 1000) -> List[dict]:
+        if boom:
+            raise RuntimeError("persist engine not wired")
+        return rows or []
+
+    monkeypatch.setattr(store, "_list_active_by_role", fake, raising=True)
+
+
+@pytest.mark.asyncio
+async def test_node_owner_root_gets_a_founding_partnership(monkeypatch, wiring) -> None:
+    """THE BUG: the only human is a wa-root-*, and list_was() cannot see them."""
+    created = wiring
+    _patch_substrate_roots(
+        monkeypatch,
+        [{"wa_id": "wa-root-eric-moore-v2-portable-abc", "name": "emoore"}],
+    )
+
+    # Brain-side list holds only observers — exactly the live install's shape.
+    await cm.migrate_founding_partnerships(
+        _Runtime([_WA("wa-2026-08-14-2C136E", "apiplatform_observer", WARole.OBSERVER)])
+    )
+
+    assert created == ["wa-root-eric-moore-v2-portable-abc"], (
+        "the node-claimed owner must receive the partnership half of the claim; "
+        "without this the install logs 'No ROOT WAs found' while holding a root"
+    )
+
+
+@pytest.mark.asyncio
+async def test_classic_brain_root_still_backfills(monkeypatch, wiring) -> None:
+    """The pre-existing path must not regress."""
+    created = wiring
+    _patch_substrate_roots(monkeypatch, [])
+
+    await cm.migrate_founding_partnerships(_Runtime([_WA("wa-2026-01-01-AAAAAA", "founder", WARole.ROOT)]))
+
+    assert created == ["wa-2026-01-01-AAAAAA"]
+
+
+@pytest.mark.asyncio
+async def test_no_duplicate_when_both_sources_name_the_same_root(monkeypatch, wiring) -> None:
+    """Dedupe by wa_id — a root visible to both must be partnered once, not twice."""
+    created = wiring
+    _patch_substrate_roots(monkeypatch, [{"wa_id": "wa-2026-01-01-AAAAAA", "name": "founder"}])
+
+    await cm.migrate_founding_partnerships(_Runtime([_WA("wa-2026-01-01-AAAAAA", "founder", WARole.ROOT)]))
+
+    assert created == ["wa-2026-01-01-AAAAAA"]
+
+
+@pytest.mark.asyncio
+async def test_unreadable_substrate_still_backfills_brain_roots(monkeypatch, wiring) -> None:
+    """A failed substrate read must not cost the roots we CAN see.
+
+    Aborting here would turn a degraded substrate into a second missing
+    partnership — the same "assert absence from a failed probe" mistake the
+    2.9.15 setup fix avoids in the other direction.
+    """
+    created = wiring
+    _patch_substrate_roots(monkeypatch, None, boom=True)
+
+    await cm.migrate_founding_partnerships(_Runtime([_WA("wa-2026-01-01-AAAAAA", "founder", WARole.ROOT)]))
+
+    assert created == ["wa-2026-01-01-AAAAAA"]
+
+
+@pytest.mark.asyncio
+async def test_existing_consent_is_not_recreated(monkeypatch, wiring) -> None:
+    """Idempotent: a root that already has a consent node is skipped."""
+    created = wiring
+    import ciris_engine.logic.persistence.models.graph as graph
+
+    monkeypatch.setattr(graph, "get_graph_node", lambda node_id, scope: object(), raising=True)
+    _patch_substrate_roots(monkeypatch, [{"wa_id": "wa-root-x", "name": "someone"}])
+
+    await cm.migrate_founding_partnerships(_Runtime([]))
+
+    assert created == []


### PR DESCRIPTION
Three fixes, all found by reading the logs from a real 2.9.15 install after an upgrade. Every one of them was invisible to CI and visible in a log line.

## 1. Verify status never loaded — `GET /v1/auth/attestation` → 405

The client polls CIRISVerify every 30s and logged this **38 times in one session**:

```
E/CIRISApiClient [getVerifyStatus] Verify status failed: HTTP 405 Method Not Allowed
```

2.9.14 proxied `/v1/auth/*` to the node. The deleted Python router served attestation with a **GET**; the node's is **POST-only**. Measured, not reasoned about:

```
:8080 /v1/auth/attestation      GET=405   <- what the client calls
:4243 /v1/auth/attestation      GET=405   <- node: POST-only (the cause)
:4243 /v1/system/verify-status  GET=200   <- where the data actually is
:8080 /v1/system/verify-status  GET=404   <- but nothing exposed it
```

Exposes the node's read-only route through the agent's front door — **one exact path**, not the `/system/*` prefix, which is the brain's (60 routes). A catch-all would have traded a broken verify card for a broken everything-else; a test asserts the route is exactly `/system/verify-status`, GET-only, colliding with none of the 60.

Unreachable node → 502, not an empty 200: "could not ask" must not render as "not verified".

**This does not fix** CIRISVerify treating the license as revoked after a `429 Too Many Requests` (fail-secure maps any failure to revoked). That is upstream and independent — expect the card to now LOAD and possibly say revoked.

## 2. A node-claimed owner never got a partnership

Stewardship is over a **node**; partnership is with an **agent**; claiming a node establishes both by the same act. The substrate held up its half and the brain did not:

```
attestation_subjects:
  ownership:responsible_party:node:v1   x4     <- stewardship, established
  consent:stream:*                      NONE   <- partnership, never happened
```

with the cause printed at every boot on an install owning a perfectly good root:

```
[PARTNERSHIP_MIGRATION] No ROOT WAs found - nothing to backfill
```

`migrate_founding_partnerships()` enumerates via `list_was()`, which ends `if _is_brain_wa_row(r)` — excluding `wa-root-*` as substrate-owned federation identities (#922). The owner is invisible, so `_create_founding_partnership()` never runs.

Fixed at the **backfill**, not at claim time: it runs every boot, so it heals installs already claimed rather than only new ones. Reads by role from the substrate store — the same primitive the 2.9.15 setup probe uses, so both agree on who the owner is instead of each deciding separately. A failed substrate read logs and continues with brain-side roots.

**This is the third consequence of #922's filter** (setup lockout in 2.9.15, brain reporting "no admin", and now this). The filter is correct each time; what is missing is that nothing on the self-claim path does what the brain's classic path does for a new owner. That path deserves a deliberate audit rather than a fourth incident.

## 3. Dialling OpenAI with a key we can see is fake

`OPENAI_API_KEY=sk-test` (7 chars) was registered as a working provider. The first thing to need the model was the **shutdown deliberation** — the agent reasons about accepting shutdown — so merely stopping the agent emitted 401s from all three DMAs, to a user who had asked nothing.

Health reported `provider=openai` **ready** throughout, because readiness checked whether a provider was configured, not whether the credential could authenticate.

Now refused at init, exactly like no key.

**The false positive mattered more than the bug.** Local runtimes are handed dummy keys on purpose — Ollama ignores the value, so `api_key="ollama"` against `jetson.local` is *correct*. So the guard fires only for keys bound to `api.openai.com`; any custom `base_url` is untouched, including together.xyz and groq. Nine of seventeen tests pin exactly that. The refusal reports the key's **length**, never its value.

## Verification

- 17 + 5 + 4 new tests. Each fix's key test **fails without the change**; the guard tests pass with *and* without, so nothing silently disables an existing path.
- 305 pass across the LLM service suite, 32 across setup, mypy clean on all four touched modules.
- Route-collision check run against the real app: 60 brain `/system` routes, ours claims 1, zero overlap.

## Correction recorded

I originally diagnosed #2 as a read-path problem — "the attestation exists, the reader looks in the wrong store". That was **wrong**: the three `consent:*` attestations are `subject=ciris-canonical-1-…`, the federation trace-sharing axis, while a per-user stream would be `consent:stream:<sha256(user_id)>:v1` and none exists. Both stores were empty because the record was never authored. A review pass caught it by checking against a copy of the live DB instead of accepting the summary.
