### PR TITLE
fix(setup): an OAuth user is asked for a password they never set

### DIFF
--- a/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupState.kt
+++ b/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupState.kt
@@ -455,6 +455,45 @@ data class SetupFormState(
     val submissionError: String? = null
 ) {
     /**
+     * **Did this user authenticate through an external provider?** — the ONE
+     * derivation, because answering it twice is what broke setup.
+     *
+     * `/v1/setup/complete` computes `is_oauth_user = bool(oauth_provider)` and,
+     * when true, GENERATES a random password for an account that will never use
+     * one. When false it refuses with *"New user password must be at least 8
+     * characters"* — correct for a password account, and nonsense to someone who
+     * has just signed in with Google.
+     *
+     * The two call sites disagreed. The CIRIS-proxy branch passed
+     * [oauthProvider] straight through; the BYOK branch required
+     * `isGoogleAuth && googleUserId != null`. So a BYOK user who signed in with
+     * OAuth, but whose provider returned no subject id, read as a PASSWORD user
+     * and was asked mid-wizard for a password they had never set.
+     *
+     * [googleUserId] is evidence about WHICH account, not about WHETHER OAuth
+     * happened, so it must not gate this. [isGoogleAuth] is the authoritative
+     * signal and covers Apple too — it is set from `isAuth` for both providers,
+     * despite the name.
+     *
+     * HA add-on mode counts: SUPERVISOR_TOKEN is external auth with no password
+     * either.
+     */
+    val isExternalAuth: Boolean
+        get() = isGoogleAuth || isHAAddonMode
+
+    /**
+     * The provider to send as `oauth_provider`, or null for a genuine password
+     * account. Paired with [isExternalAuth] so the flag and the value cannot
+     * disagree.
+     */
+    val effectiveOAuthProvider: String?
+        get() = when {
+            isHAAddonMode -> "home_assistant"
+            isGoogleAuth -> oauthProvider
+            else -> null
+        }
+
+    /**
      * Check if using CIRIS proxy mode.
      * Source: SetupViewModel.kt:125-127
      */

--- a/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupViewModel.kt
+++ b/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupViewModel.kt
@@ -1756,15 +1756,22 @@ class SetupViewModel(
             // For BYOK mode, we still need OAuth fields if user authenticated via OAuth
             // This allows OAuth users to use their own API keys while still using OAuth for login
             // HA addon mode is treated as external auth (SUPERVISOR_TOKEN) - no password needed
-            val isOAuthUser = currentState.isGoogleAuth && currentState.googleUserId != null
-            val isExternalAuthUser = isOAuthUser || currentState.isHAAddonMode
+            // ONE derivation, shared with the CIRIS-proxy branch — see
+            // SetupFormState.isExternalAuth. This used to read
+            // `isGoogleAuth && googleUserId != null`, a DIFFERENT question than
+            // the proxy branch asked: an OAuth sign-in whose provider returned no
+            // subject id fell through as a PASSWORD account, and
+            // /v1/setup/complete correctly refused it with "New user password
+            // must be at least 8 characters" — to someone who had just signed in
+            // with Google and never set a password.
+            //
+            // `googleUserId` is evidence about WHICH account, not about WHETHER
+            // OAuth happened, so it must not gate this.
+            val isOAuthUser = currentState.isGoogleAuth
+            val isExternalAuthUser = currentState.isExternalAuth
 
             // Determine the effective OAuth provider
-            val effectiveOAuthProvider = when {
-                currentState.isHAAddonMode -> "home_assistant"
-                isOAuthUser -> currentState.oauthProvider
-                else -> null
-            }
+            val effectiveOAuthProvider = currentState.effectiveOAuthProvider
 
             CompleteSetupRequest(
                 llm_provider = providerId,

--- a/client/shared/src/commonTest/kotlin/ai/ciris/mobile/shared/viewmodels/SetupExternalAuthTest.kt
+++ b/client/shared/src/commonTest/kotlin/ai/ciris/mobile/shared/viewmodels/SetupExternalAuthTest.kt
@@ -1,0 +1,78 @@
+package ai.ciris.mobile.shared.viewmodels
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * **An OAuth user is never asked for a password.**
+ *
+ * `/v1/setup/complete` computes `is_oauth_user = bool(oauth_provider)`. When true
+ * it GENERATES a random password for an account that will never use one; when
+ * false it refuses:
+ *
+ * ```
+ * HTTP 400 {"detail":"New user password must be at least 8 characters"}
+ * ```
+ *
+ * That refusal is correct for a password account and nonsense to someone who has
+ * just signed in with Google — which is exactly what a user hit, mid-wizard, on
+ * the BYOK path.
+ *
+ * The cause was two answers to one question. The CIRIS-proxy branch passed
+ * `oauthProvider` straight through; the BYOK branch required
+ * `isGoogleAuth && googleUserId != null`. A provider that returns no subject id
+ * therefore read as a PASSWORD account on one path and an OAuth account on the
+ * other.
+ *
+ * These pin the derivation itself, so the two branches cannot drift apart again.
+ */
+class SetupExternalAuthTest {
+
+    @Test
+    fun oauth_without_a_subject_id_is_still_oauth() {
+        // The reported case: signed in, no subject id came back.
+        val s = SetupFormState(isGoogleAuth = true, googleUserId = null, oauthProvider = "google")
+
+        assertTrue(
+            s.isExternalAuth,
+            "an OAuth sign-in with no subject id read as a PASSWORD account — this is " +
+                "the state that produced 'New user password must be at least 8 characters' " +
+                "for a user who never set one",
+        )
+        assertEquals(
+            "google",
+            s.effectiveOAuthProvider,
+            "oauth_provider must still be sent, or the server generates no password and refuses",
+        )
+    }
+
+    @Test
+    fun apple_is_oauth_too() {
+        // `isGoogleAuth` is set from `isAuth` for BOTH providers despite the name;
+        // a check written against Google alone would take Apple users down the
+        // password path.
+        val s = SetupFormState(isGoogleAuth = true, googleUserId = "apple-sub-123", oauthProvider = "apple")
+        assertTrue(s.isExternalAuth)
+        assertEquals("apple", s.effectiveOAuthProvider)
+    }
+
+    @Test
+    fun ha_addon_is_external_auth_but_not_oauth() {
+        val s = SetupFormState(isHAAddonMode = true)
+        assertTrue(s.isExternalAuth, "SUPERVISOR_TOKEN is external auth — no password either")
+        assertEquals("home_assistant", s.effectiveOAuthProvider)
+    }
+
+    @Test
+    fun a_genuine_password_account_is_not_external() {
+        val s = SetupFormState(isGoogleAuth = false, googleUserId = null)
+        assertTrue(!s.isExternalAuth, "a password user must still be required to set one")
+        assertNull(
+            s.effectiveOAuthProvider,
+            "sending an oauth_provider here would make the server generate a random " +
+                "password and silently skip the password the user actually chose",
+        )
+    }
+}


### PR DESCRIPTION
Reported from the desktop wizard, mid-setup:

```
HTTP 400 {"detail":"New user password must be at least 8 characters"}
```

**The server is right.** `/v1/setup/complete` computes `is_oauth_user = bool(oauth_provider)`; when true it generates a random password for an account that will never use one, and when false it requires a real one. The wizard was telling it this was a **password account**.

## One question, two answers

The two completion branches disagreed about what makes a user an OAuth user:

| branch | test |
|---|---|
| CIRIS-proxy | `oauth_provider = currentState.oauthProvider` |
| BYOK | `isGoogleAuth && currentState.googleUserId != null` |

So the same signed-in user is an OAuth account on one path and a password account on the other. The reporter was on **BYOK** (own API key), where an OAuth sign-in whose provider returned no subject id fell through to the password branch — and was asked for a password that does not exist.

`googleUserId` is evidence about **which account**, not about **whether OAuth happened**. It must not gate this.

## The fix

`SetupFormState.isExternalAuth` and `SetupFormState.effectiveOAuthProvider` are now the single derivation both branches read, so the flag and the value it is paired with cannot disagree — and the two paths cannot drift apart again.

## A second, latent bug this surfaced

`isGoogleAuth` is **misnamed**: it is set from `isAuth` for both Google *and* Apple. Any check written against "Google" literally sends Apple users down the password path. The field now documents this, and `apple_is_oauth_too` covers it.

## Tests

`SetupExternalAuthTest` — **4/4**, pinning the derivation rather than either call site (verified from the JUnit XML, `tests="4" skipped="0" failures="0"`, since a task that runs nothing also reports BUILD SUCCESSFUL):

- OAuth with a null subject id is still OAuth — *the reported case*
- Apple is OAuth too
- HA add-on is external auth but not OAuth (SUPERVISOR_TOKEN, no password either)
- a genuine password account is **not** external — or the server would silently generate a random password and discard the one the user chose

## Provenance

Found while adopting this client into CIRISServer, which vendors it. The identical fix is landing there; this is the upstream half so the two trees don't diverge on it.