### PR TITLE
2.9.20 — repair .env paths already poisoned on disk (Windows)

### DIFF
--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -6,11 +6,11 @@ from typing import List
 from ciris_engine.schemas.runtime.canonical_peer import CanonicalBootstrapPeer
 
 # Version information
-CIRIS_VERSION = "2.9.19-stable"
+CIRIS_VERSION = "2.9.20-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
 CIRIS_VERSION_MINOR = 9
-CIRIS_VERSION_PATCH = 19
+CIRIS_VERSION_PATCH = 20
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/ciris_engine/logic/config/env_utils.py
+++ b/ciris_engine/logic/config/env_utils.py
@@ -35,9 +35,16 @@ logger = logging.getLogger(__name__)
 
 _PATH_VALUED_ENV_VARS = frozenset(
     {
+        # Both spellings on purpose. The wizard WRITES `SECRETS_DB_PATH` /
+        # `AUDIT_LOG_PATH`; the config layer READS `CIRIS_SECRETS_DB_PATH` /
+        # `CIRIS_AUDIT_DB_PATH`. Those names do not match — a separate bug, and
+        # the reason a repair list built from either side alone would miss half
+        # the keys. Cover both so this set cannot drift from either.
         "CIRIS_DB_PATH",
         "CIRIS_SECRETS_DB_PATH",
         "CIRIS_AUDIT_DB_PATH",
+        "SECRETS_DB_PATH",
+        "AUDIT_LOG_PATH",
         "CIRIS_DATA_DIR",
         "CIRIS_HOME",
         "CIRIS_LOG_DIR",

--- a/ciris_engine/logic/config/env_utils.py
+++ b/ciris_engine/logic/config/env_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 from typing import Dict, Optional
@@ -27,13 +28,56 @@ def load_env_file(path: Path | str = Path(".env"), *, force: bool = False) -> No
     _ENV_PATH = Path(path)
 
 
+#: Config keys whose value names a FILESYSTEM PATH. Only these are repaired — a
+#: control character cannot legally appear in one (WinError 123 is the OS saying
+#: so), whereas in arbitrary config it might be intentional.
+logger = logging.getLogger(__name__)
+
+_PATH_VALUED_ENV_VARS = frozenset(
+    {
+        "CIRIS_DB_PATH",
+        "CIRIS_SECRETS_DB_PATH",
+        "CIRIS_AUDIT_DB_PATH",
+        "CIRIS_DATA_DIR",
+        "CIRIS_HOME",
+        "CIRIS_LOG_DIR",
+        "CIRIS_AGENT_ROOT",
+        "CIRIS_LICENSED_PACKAGE_PATH",
+        "CIRIS_MODULE_PATH",
+        "CIRIS_VERIFY_BINARY_PATH",
+    }
+)
+
+
 def get_env_var(name: str, default: Optional[str] = None) -> Optional[str]:
-    """Retrieve a variable with environment variable overriding .env values."""
+    """Retrieve a variable with environment variable overriding .env values.
+
+    Path values are repaired on the way out. Fixing the WRITERS (2.9.19) stops
+    NEW corruption and does nothing for the .env files already on disk — a user
+    upgraded to that release and hit the identical WinError 123, because his file
+    had been poisoned by an earlier version. Repairing here means the upgrade
+    alone is enough: no manual .env surgery, no reinstall.
+    """
     if not _ENV_LOADED:
         load_env_file()
     val = os.getenv(name)
-    if val is not None:
-        return val
-    if name in _ENV_VALUES:
-        return _ENV_VALUES[name]
-    return default
+    if val is None and name in _ENV_VALUES:
+        val = _ENV_VALUES[name]
+    if val is None:
+        return default
+
+    if name in _PATH_VALUED_ENV_VARS:
+        from ciris_engine.logic.utils.env_file import repair_dotenv_escapes
+
+        repaired = repair_dotenv_escapes(val)
+        if repaired != val:
+            # Name the VARIABLE, never the value — the path is user data, and
+            # the corrupted form has already travelled through enough logs.
+            logger.warning(
+                "[ENV] %s contained a control character from .env escape processing and was "
+                "repaired in memory. Re-run setup, or rewrite that line with doubled "
+                "backslashes or forward slashes, to fix the file itself.",
+                name,
+            )
+        return repaired
+    return val

--- a/ciris_engine/logic/setup/wizard.py
+++ b/ciris_engine/logic/setup/wizard.py
@@ -112,6 +112,9 @@ def prompt_llm_configuration() -> tuple[str, str, str, str]:
 
 
 
+from ciris_engine.logic.utils.env_file import env_path_value
+
+
 def _env_quoted(value: str) -> str:
     """Escape a value for a DOUBLE-QUOTED `.env` line.
 
@@ -171,7 +174,7 @@ def create_env_file(
     if is_android() or is_ios():
         # Use absolute path for mobile - tilde doesn't expand
         # Must match ios_main.py / android_main.py CIRIS_DATA_DIR setting
-        data_dir = _env_quoted(str(get_ciris_home()))
+        data_dir = _env_quoted(env_path_value(get_ciris_home()))
     else:
         # Desktop: honor CIRIS_HOME via get_data_dir() instead of
         # hardcoding ~/ciris/data. Previously this was literal
@@ -187,7 +190,7 @@ def create_env_file(
         # gives that, anchored at get_ciris_home().
         from ciris_engine.logic.utils.path_resolution import get_data_dir
 
-        data_dir = _env_quoted(str(get_data_dir()))
+        data_dir = _env_quoted(env_path_value(get_data_dir()))
 
     # Log what we received for debugging
     logger.info(f"[create_env_file] Received llm_provider='{llm_provider}', llm_base_url='{llm_base_url}'")

--- a/ciris_engine/logic/utils/env_file.py
+++ b/ciris_engine/logic/utils/env_file.py
@@ -68,3 +68,52 @@ def env_unquoted(value: str) -> str:
     Backslash LAST here, mirroring `env_quoted` doing it first.
     """
     return value.replace('\\"', '"').replace("\\\\", "\\")
+
+
+#: dotenv's POSIX escape set, inverted. `\f` + `ranc` became one FORM FEED on
+#: read, so mapping the control character back to the two characters that
+#: produced it reconstructs the original text exactly.
+_ESCAPE_SOURCE = {
+    "\x07": r"\a",
+    "\x08": r"\b",
+    "\x0c": r"\f",
+    "\n": r"\n",
+    "\r": r"\r",
+    "\t": r"\t",
+    "\x0b": r"\v",
+    "\x00": r"\0",
+}
+
+
+def repair_dotenv_escapes(value: str) -> str:
+    """Undo escape processing that a `.env` read applied to a Windows path.
+
+    WHY THIS IS NEEDED AFTER THE WRITE SIDE WAS FIXED. Escaping the writers
+    stops NEW corruption; it does nothing for the `.env` files already on disk.
+    Every Windows user whose home directory triggers an escape holds a file
+    poisoned by an earlier version, and on upgrade gets the identical failure:
+
+        CIRIS_DB_PATH read back as C:\\Users\\<FF>ranc\\ciris\\data\\...
+        OSError: [WinError 123]
+
+    A user hit exactly this AFTER installing the release that fixed the writers,
+    which is how we learned that fixing the writers and fixing the USERS are two
+    different problems. The upgrade alone has to be enough.
+
+    The inverse is exact: dotenv turned `\\f` into a form feed, and a control
+    character in this position can only have come from the two-character escape
+    that produced it. So `C:\\Users\\<FF>ranc` becomes `C:\\Users\\franc` again.
+
+    SAFE BECAUSE OF WHERE IT IS APPLIED — config values naming a FILESYSTEM
+    PATH. A control character is not legal in a Windows path (WinError 123 is
+    the OS saying so), so there is no value this can damage. Deliberately not
+    applied to arbitrary config, where a control character might be intentional.
+
+    Idempotent: a repaired value has no control characters left to match.
+    """
+    if not value or not any(ord(c) < 32 for c in value):
+        return value
+    out = value
+    for ctrl, source in _ESCAPE_SOURCE.items():
+        out = out.replace(ctrl, source)
+    return out

--- a/ciris_engine/logic/utils/env_file.py
+++ b/ciris_engine/logic/utils/env_file.py
@@ -117,3 +117,20 @@ def repair_dotenv_escapes(value: str) -> str:
     for ctrl, source in _ESCAPE_SOURCE.items():
         out = out.replace(ctrl, source)
     return out
+
+
+def env_path_value(path: object) -> str:
+    """Render a filesystem path for a `.env` line, backslash-free.
+
+    Windows accepts forward slashes everywhere — `os`, `pathlib`, `open`, and
+    the Win32 API all normalise them — so writing `C:/Users/franc/ciris` instead
+    of `C:\\Users\\franc\\ciris` costs nothing and removes the hazard by
+    construction: a value with no backslashes cannot be mangled by escape
+    processing, no matter which writer produces it or which reader consumes it.
+
+    This is the belt to `env_quoted`'s braces. Escaping is a rule every writer
+    must remember; forward slashes are a property of the value itself. Three
+    separate sites got the escaping wrong before this existed, so the value not
+    needing the rule is worth more than the rule being applied correctly.
+    """
+    return str(path).replace("\\", "/")

--- a/client/androidApp/build.gradle
+++ b/client/androidApp/build.gradle
@@ -25,8 +25,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 35
-        versionCode 156
-        versionName "2.9.19"
+        versionCode 157
+        versionName "2.9.20"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/client/androidApp/src/main/python/version.py
+++ b/client/androidApp/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.9.19"
+__version__ = "android-2.9.20"
 
 
 def get_version() -> str:

--- a/client/desktopApp/build.gradle.kts
+++ b/client/desktopApp/build.gradle.kts
@@ -34,7 +34,7 @@ compose.desktop {
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "CIRIS"
-            packageVersion = "2.9.19"
+            packageVersion = "2.9.20"
             description = "CIRIS Agent Desktop Application"
             vendor = "CIRIS L3C"
 

--- a/client/iosApp/iosApp/Info.plist
+++ b/client/iosApp/iosApp/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.19</string>
+	<string>2.9.20</string>
 	<key>CFBundleVersion</key>
-	<string>316</string>
+	<string>317</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/tests/logic/utils/test_env_file_windows_paths.py
+++ b/tests/logic/utils/test_env_file_windows_paths.py
@@ -181,3 +181,79 @@ def test_env_quoted_and_env_unquoted_are_exact_inverses() -> None:
 
     for value in WINDOWS_PATHS + [r'C:\a\b "quoted" \c', "", "plain", "/posix/path", "a\\\\b"]:
         assert env_unquoted(env_quoted(value)) == value, f"not an inverse for {value!r}"
+
+
+# ---------------------------------------------------------------------------
+# REPAIR ON READ. 2.9.19 fixed the writers, which stops NEW corruption and does
+# nothing for the .env files already on disk. A user installed 2.9.19 and hit
+# the IDENTICAL WinError 123, because his file was poisoned by an earlier
+# version. Fixing the writers and fixing the USERS are two different problems.
+# ---------------------------------------------------------------------------
+
+POISONED = {
+    "C:\\Users\x0cranc\\ciris\\data": r"C:\Users\franc\ciris\data",   # \f — reported
+    "C:\\Users\x0bictor\\ciris": r"C:\Users\victor\ciris",            # \v
+    "C:\\Users\tom\\ciris": r"C:\Users\tom\ciris",                    # \t
+    "C:\\Users\rachel\\ciris": r"C:\Users\rachel\ciris",              # \r
+    "C:\\Users\nancy\\ciris": r"C:\Users\nancy\ciris",                # \n
+    "C:\\Users\x08en\\ciris": r"C:\Users\ben\ciris",                  # \b
+    "C:\\Users\x07lice\\ciris": r"C:\Users\alice\ciris",              # \a
+}
+
+
+@pytest.mark.parametrize("poisoned,expected", sorted(POISONED.items()))
+def test_a_poisoned_value_is_repaired(poisoned: str, expected: str) -> None:
+    from ciris_engine.logic.utils.env_file import repair_dotenv_escapes
+
+    assert repair_dotenv_escapes(poisoned) == expected
+
+
+def test_repair_is_idempotent_and_leaves_clean_values_alone() -> None:
+    """Runs on every read, so it must never degrade an already-good value."""
+    from ciris_engine.logic.utils.env_file import repair_dotenv_escapes
+
+    for clean in (r"C:\Users\franc\ciris", "C:/Users/franc/ciris", "/home/e/ciris", ""):
+        assert repair_dotenv_escapes(clean) == clean
+    once = repair_dotenv_escapes("C:\\Users\x0cranc")
+    assert repair_dotenv_escapes(once) == once
+
+
+def test_get_env_var_repairs_path_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The assertion that matters: the CALLER must get a usable path.
+
+    The standalone helper passing while `get_env_var` returned the corrupted
+    value is precisely the shape of this bug — a fix verified at the wrong layer.
+    """
+    import ciris_engine.logic.config.env_utils as eu
+
+    monkeypatch.setattr(eu, "_ENV_LOADED", True, raising=False)
+    monkeypatch.setenv("CIRIS_DB_PATH", "C:\\Users\x0cranc\\ciris\\data\\ciris_engine.db")
+
+    got = eu.get_env_var("CIRIS_DB_PATH")
+
+    assert got == r"C:\Users\franc\ciris\data\ciris_engine.db"
+    assert not [c for c in got if ord(c) < 32]
+
+
+def test_non_path_keys_are_left_untouched(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only PATH values are repaired — elsewhere a control char may be deliberate."""
+    import ciris_engine.logic.config.env_utils as eu
+
+    monkeypatch.setattr(eu, "_ENV_LOADED", True, raising=False)
+    monkeypatch.setenv("SOME_OTHER_VALUE", "keep\x0cthis")
+
+    assert eu.get_env_var("SOME_OTHER_VALUE") == "keep\x0cthis"
+
+
+def test_the_repair_log_does_not_print_the_path(monkeypatch: pytest.MonkeyPatch, caplog) -> None:
+    """The value is user data, and the corrupted form has been through enough logs."""
+    import ciris_engine.logic.config.env_utils as eu
+
+    monkeypatch.setattr(eu, "_ENV_LOADED", True, raising=False)
+    monkeypatch.setenv("CIRIS_DB_PATH", "C:\\Users\x0cranc\\ciris\\data")
+
+    with caplog.at_level("WARNING"):
+        eu.get_env_var("CIRIS_DB_PATH")
+
+    assert "CIRIS_DB_PATH" in caplog.text
+    assert "franc" not in caplog.text

--- a/tests/logic/utils/test_env_file_windows_paths.py
+++ b/tests/logic/utils/test_env_file_windows_paths.py
@@ -257,3 +257,46 @@ def test_the_repair_log_does_not_print_the_path(monkeypatch: pytest.MonkeyPatch,
 
     assert "CIRIS_DB_PATH" in caplog.text
     assert "franc" not in caplog.text
+
+
+def test_wizard_written_key_spellings_are_repaired(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The wizard writes SECRETS_DB_PATH; the config layer reads CIRIS_SECRETS_DB_PATH.
+
+    Those names do not match — a real bug of its own — and it means a repair set
+    built from either side alone misses half the keys. A live user's .env had
+    exactly these two lines still carrying backslashes.
+    """
+    import ciris_engine.logic.config.env_utils as eu
+
+    monkeypatch.setattr(eu, "_ENV_LOADED", True, raising=False)
+    for key in ("SECRETS_DB_PATH", "AUDIT_LOG_PATH", "CIRIS_SECRETS_DB_PATH", "CIRIS_AUDIT_DB_PATH"):
+        monkeypatch.setenv(key, "C:\\Users\x0cranc\\ciris\\data\\x.db")
+        assert eu.get_env_var(key) == r"C:\Users\franc\ciris\data\x.db", key
+
+
+@pytest.mark.parametrize("path", WINDOWS_PATHS)
+def test_env_path_value_removes_the_hazard_entirely(path: str) -> None:
+    """Forward slashes cannot be mangled, by construction.
+
+    Escaping is a rule every writer has to remember, and three separate sites
+    got it wrong. A value with no backslashes needs no rule — this is the belt
+    to env_quoted's braces.
+    """
+    from ciris_engine.logic.utils.env_file import env_path_value
+
+    v = env_path_value(path)
+    assert "\\" not in v
+
+
+def test_forward_slash_paths_roundtrip_untouched(tmp_path: Path) -> None:
+    """And they survive the write/read pair with no escaping needed at all."""
+    dotenv = pytest.importorskip("dotenv")
+    from ciris_engine.logic.utils.env_file import env_path_value
+
+    v = env_path_value(r"C:\Users\franc\ciris\data")
+    env = tmp_path / ".env"
+    env.write_text(env_line("CIRIS_DATA_DIR", v), encoding="utf-8")
+
+    got = dotenv.dotenv_values(str(env))["CIRIS_DATA_DIR"]
+    assert got == "C:/Users/franc/ciris/data"
+    assert not [c for c in got if ord(c) < 32]


### PR DESCRIPTION
A user installed 2.9.19 — the release that fixed the `.env` writers — and hit the identical `WinError 123`.

His log localises it precisely:

```
[CIRIS STARTUP] CIRIS_HOME: C:\Users\franc\ciris          <- COMPUTED, correct
Found configured .env at C:\Users\franc\ciris\.env        <- correct
OSError: [WinError 123] ... 'C:\Users\x0cranc\ciris\data' <- READ FROM .env, corrupted
```

2.9.19 stopped us writing new corruption. It never repaired the files already on disk — and every Windows user whose home directory triggers a dotenv escape is holding one. **Fixing the writers and fixing the users are two different problems**, and I verified the wheel contained the write-side fix and took that as proof the bug was closed.

Path-valued config keys are now repaired on read. The inverse is exact: dotenv turned `\f` into a form feed, so a control character in that position can only have come from the escape that produced it — `C:\Users\<FF>ranc` reconstructs to `C:\Users\franc`.

Scoped to keys naming a filesystem path, where a control character is illegal by definition and a repair cannot damage anything. Arbitrary config is untouched, since a control character there might be deliberate. Idempotent; logs the variable name, never the value.

**The upgrade is now sufficient on its own** — no manual `.env` editing, no reinstall.

Tests assert through `get_env_var`, not just the helper — the helper passing while the caller returned the corrupted value is exactly how this got missed.