### PR TITLE
ci(windows): drive the desktop UI on a Windows runner

### DIFF
--- a/.github/workflows/windows-desktop-ui.yml
+++ b/.github/workflows/windows-desktop-ui.yml
@@ -1,0 +1,185 @@
+# Windows desktop UI QA — the check that would have caught the form-feed bug.
+#
+# WHY THIS EXISTS. A Windows user hit the same total boot failure THREE TIMES
+# across 2.9.17, 2.9.18 and 2.9.19:
+#
+#     OSError: [WinError 123] ... 'C:\Users\x0cranc\ciris\data'
+#
+# `.env` applies POSIX escape processing inside double quotes, so `\franc`
+# read back as a FORM FEED plus `ranc`. Every round we fixed a writer, shipped,
+# and he hit it again through a door we had not shut. Nothing in CI could see
+# it, because:
+#
+#   * it needs a REAL WINDOWS FILESYSTEM — no Linux runner produces WinError 123;
+#   * it needs a HOME DIRECTORY WHOSE PATH TRIGGERS AN ESCAPE — `\f`, `\t`, `\n`,
+#     `\v`, `\b`, `\a`, `\r`, `\0`, `\x`, `\u`;
+#   * it needs TWO BOOTS — the third occurrence was the env SYNC un-escaping a
+#     file the wizard had just written correctly, which only bites on the
+#     SECOND start. A single-boot test passed while users were broken;
+#   * it needs the WHEEL, not a source checkout — that is what `pip install`
+#     actually delivers.
+#
+# So this job reproduces the user's machine rather than approximating it, and
+# drives the real UI through the app's CIRIS_TEST_MODE server (`/click`,
+# `/input`, `/wait` against testTags) instead of poking the API underneath it.
+# The bugs of the last four releases were all in the seam between the UI and
+# the runtime, which is exactly what an API-level test cannot see.
+
+name: Windows Desktop UI
+
+on:
+  workflow_dispatch:
+    inputs:
+      home_flavour:
+        description: "Escape trigger to exercise in the home path"
+        default: "franc"
+        type: choice
+        options: ["franc", "tom", "nancy", "victor", "ben"]
+  # DISPATCH-ONLY UNTIL PROVEN GREEN. A brand-new workflow needs iterations, and
+  # a failing new gate on an in-flight release PR is exactly how this release
+  # cycle already lost time twice. Once it passes twice in a row, add:
+  #
+  #   pull_request:
+  #     paths:
+  #       - "ciris_engine/logic/setup/**"
+  #       - "ciris_engine/logic/config/**"
+  #       - "ciris_engine/logic/utils/env_file.py"
+  #       - "ciris_engine/logic/utils/path_resolution.py"
+  #       - "ciris_engine/logic/adapters/api/routes/setup/**"
+  #       - "client/**"
+  #
+  # NOTE when enabling: a pull_request path filter is CUMULATIVE, not per-push —
+  # once any commit in a PR has matched, every later push re-triggers the job.
+
+concurrency:
+  group: windows-ui-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  desktop-ui:
+    runs-on: windows-latest
+    timeout-minutes: 45
+
+    env:
+      # THE POINT OF THE WHOLE JOB. A home directory whose path contains a
+      # backslash followed by an escape character. `\f` is the reported one —
+      # `C:\Users\...\franc\ciris` is byte-for-byte the shape that failed.
+      #
+      # Not left to the runner's default `C:\Users\runneradmin`: that happens to
+      # contain `\r`, so it would catch this by luck. A guard that works by
+      # accident stops working the day the runner image changes its username.
+      CIRIS_UI_HOME_FLAVOUR: ${{ github.event.inputs.home_flavour || 'franc' }}
+      CIRIS_TEST_MODE: "true"
+      CIRIS_TESTING_MODE: "true"
+      CIRIS_TEST_PORT: "8091"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Pin a home path that triggers an escape
+        shell: pwsh
+        run: |
+          $home_dir = "$env:USERPROFILE\$env:CIRIS_UI_HOME_FLAVOUR\ciris"
+          New-Item -ItemType Directory -Force -Path $home_dir | Out-Null
+          "CIRIS_HOME=$home_dir" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          Write-Host "CIRIS_HOME = $home_dir"
+          # Fail early if the path does NOT contain an escape trigger — this job
+          # is worthless without one, and a silently-safe path would make it a
+          # gate that cannot fail.
+          if ($home_dir -notmatch '\\[abfnrtv0xu]') {
+            Write-Error "home path contains no escape trigger; this job would prove nothing"
+            exit 1
+          }
+
+      # Build and install the WHEEL, not the checkout. `pip install .` would
+      # exercise a source tree users never receive.
+      - name: Build and install the wheel
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --wheel --outdir dist
+          $wheel = (Get-ChildItem dist\*.whl | Select-Object -First 1).FullName
+          Write-Host "installing $wheel"
+          python -m pip install "$wheel"
+          python -m pip install requests
+
+      - name: Build the desktop app
+        shell: pwsh
+        working-directory: client
+        run: ./gradlew.bat :desktopApp:packageUberJarForCurrentOS --no-daemon --stacktrace
+
+      # ── BOOT 1 — first run, full setup driven through the UI ──────────────
+      - name: Boot 1 — setup wizard and local login, via the UI
+        shell: pwsh
+        run: |
+          python -m tools.qa_runner.modules.web_ui desktop-setup `
+            --launch --headless --mock-llm `
+            --username qaadmin --password "qa_test_password_12345" `
+            --provider local `
+            --json-report boot1.json -v
+        env:
+          CIRIS_FORCE_FIRST_RUN: "1"
+
+      - name: Boot 1 — assert no control character reached any path
+        shell: pwsh
+        run: python tools/dev/assert_no_control_chars_in_env.py --home "$env:CIRIS_HOME" --label boot1
+
+      # ── BOOT 2 — THE ONE THAT CATCHES IT ─────────────────────────────────
+      # The env sync rewrites .env on every start. In 2.9.19 it un-escaped what
+      # the wizard had just written correctly, so boot 1 was always clean and
+      # boot 2 was broken. Restarting is the entire value of this step.
+      - name: Boot 2 — restart and log in again, via the UI
+        shell: pwsh
+        run: |
+          python -m tools.qa_runner.modules.web_ui desktop-login `
+            --launch --headless `
+            --username qaadmin --password "qa_test_password_12345" `
+            --json-report boot2.json -v
+
+      - name: Boot 2 — assert no control character reached any path
+        shell: pwsh
+        run: python tools/dev/assert_no_control_chars_in_env.py --home "$env:CIRIS_HOME" --label boot2
+
+      # ── OAUTH ────────────────────────────────────────────────────────────
+      # Deliberately NOT a real Google sign-in: that needs interactive consent
+      # and account credentials, which do not belong in CI. What broke hosted
+      # OAuth was never the consent screen — it was the redirect_uri we SEND
+      # (CIRISServer#421: the agent-id segment was dropped, and the base fell
+      # back to loopback). That is fully observable from the authorize redirect,
+      # so this asserts the URL the UI's sign-in button actually produces.
+      - name: OAuth — the sign-in button must emit a usable redirect_uri
+        shell: pwsh
+        run: |
+          python -m tools.qa_runner.modules.web_ui desktop-up --launch --headless --json-report oauth_up.json -v
+          python tools/dev/assert_oauth_redirect_uri.py --agent-port 8080 --provider google
+
+      - name: Collect artifacts
+        if: always()
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path artifacts | Out-Null
+          Copy-Item boot1.json,boot2.json,oauth_up.json artifacts -ErrorAction SilentlyContinue
+          if (Test-Path "$env:CIRIS_HOME\logs") { Copy-Item "$env:CIRIS_HOME\logs" artifacts\logs -Recurse -ErrorAction SilentlyContinue }
+          # .env carries secrets — ship the SHAPE, never the values, so a failed
+          # run is diagnosable without leaking keys into a public artifact.
+          if (Test-Path "$env:CIRIS_HOME\.env") {
+            Get-Content "$env:CIRIS_HOME\.env" |
+              ForEach-Object { $_ -replace '=".*"', '=<redacted>' } |
+              Out-File artifacts\env.shape.txt -Encoding utf8
+          }
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: windows-desktop-ui
+          path: artifacts
+          retention-days: 7

--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -6,11 +6,11 @@ from typing import List
 from ciris_engine.schemas.runtime.canonical_peer import CanonicalBootstrapPeer
 
 # Version information
-CIRIS_VERSION = "2.9.19-stable"
+CIRIS_VERSION = "2.9.20-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
 CIRIS_VERSION_MINOR = 9
-CIRIS_VERSION_PATCH = 19
+CIRIS_VERSION_PATCH = 20
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/ciris_engine/logic/config/env_utils.py
+++ b/ciris_engine/logic/config/env_utils.py
@@ -35,9 +35,16 @@ logger = logging.getLogger(__name__)
 
 _PATH_VALUED_ENV_VARS = frozenset(
     {
+        # Both spellings on purpose. The wizard WRITES `SECRETS_DB_PATH` /
+        # `AUDIT_LOG_PATH`; the config layer READS `CIRIS_SECRETS_DB_PATH` /
+        # `CIRIS_AUDIT_DB_PATH`. Those names do not match — a separate bug, and
+        # the reason a repair list built from either side alone would miss half
+        # the keys. Cover both so this set cannot drift from either.
         "CIRIS_DB_PATH",
         "CIRIS_SECRETS_DB_PATH",
         "CIRIS_AUDIT_DB_PATH",
+        "SECRETS_DB_PATH",
+        "AUDIT_LOG_PATH",
         "CIRIS_DATA_DIR",
         "CIRIS_HOME",
         "CIRIS_LOG_DIR",

--- a/ciris_engine/logic/config/env_utils.py
+++ b/ciris_engine/logic/config/env_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 from typing import Dict, Optional
@@ -27,13 +28,56 @@ def load_env_file(path: Path | str = Path(".env"), *, force: bool = False) -> No
     _ENV_PATH = Path(path)
 
 
+#: Config keys whose value names a FILESYSTEM PATH. Only these are repaired — a
+#: control character cannot legally appear in one (WinError 123 is the OS saying
+#: so), whereas in arbitrary config it might be intentional.
+logger = logging.getLogger(__name__)
+
+_PATH_VALUED_ENV_VARS = frozenset(
+    {
+        "CIRIS_DB_PATH",
+        "CIRIS_SECRETS_DB_PATH",
+        "CIRIS_AUDIT_DB_PATH",
+        "CIRIS_DATA_DIR",
+        "CIRIS_HOME",
+        "CIRIS_LOG_DIR",
+        "CIRIS_AGENT_ROOT",
+        "CIRIS_LICENSED_PACKAGE_PATH",
+        "CIRIS_MODULE_PATH",
+        "CIRIS_VERIFY_BINARY_PATH",
+    }
+)
+
+
 def get_env_var(name: str, default: Optional[str] = None) -> Optional[str]:
-    """Retrieve a variable with environment variable overriding .env values."""
+    """Retrieve a variable with environment variable overriding .env values.
+
+    Path values are repaired on the way out. Fixing the WRITERS (2.9.19) stops
+    NEW corruption and does nothing for the .env files already on disk — a user
+    upgraded to that release and hit the identical WinError 123, because his file
+    had been poisoned by an earlier version. Repairing here means the upgrade
+    alone is enough: no manual .env surgery, no reinstall.
+    """
     if not _ENV_LOADED:
         load_env_file()
     val = os.getenv(name)
-    if val is not None:
-        return val
-    if name in _ENV_VALUES:
-        return _ENV_VALUES[name]
-    return default
+    if val is None and name in _ENV_VALUES:
+        val = _ENV_VALUES[name]
+    if val is None:
+        return default
+
+    if name in _PATH_VALUED_ENV_VARS:
+        from ciris_engine.logic.utils.env_file import repair_dotenv_escapes
+
+        repaired = repair_dotenv_escapes(val)
+        if repaired != val:
+            # Name the VARIABLE, never the value — the path is user data, and
+            # the corrupted form has already travelled through enough logs.
+            logger.warning(
+                "[ENV] %s contained a control character from .env escape processing and was "
+                "repaired in memory. Re-run setup, or rewrite that line with doubled "
+                "backslashes or forward slashes, to fix the file itself.",
+                name,
+            )
+        return repaired
+    return val

--- a/ciris_engine/logic/setup/wizard.py
+++ b/ciris_engine/logic/setup/wizard.py
@@ -112,6 +112,9 @@ def prompt_llm_configuration() -> tuple[str, str, str, str]:
 
 
 
+from ciris_engine.logic.utils.env_file import env_path_value
+
+
 def _env_quoted(value: str) -> str:
     """Escape a value for a DOUBLE-QUOTED `.env` line.
 
@@ -171,7 +174,7 @@ def create_env_file(
     if is_android() or is_ios():
         # Use absolute path for mobile - tilde doesn't expand
         # Must match ios_main.py / android_main.py CIRIS_DATA_DIR setting
-        data_dir = _env_quoted(str(get_ciris_home()))
+        data_dir = _env_quoted(env_path_value(get_ciris_home()))
     else:
         # Desktop: honor CIRIS_HOME via get_data_dir() instead of
         # hardcoding ~/ciris/data. Previously this was literal
@@ -187,7 +190,7 @@ def create_env_file(
         # gives that, anchored at get_ciris_home().
         from ciris_engine.logic.utils.path_resolution import get_data_dir
 
-        data_dir = _env_quoted(str(get_data_dir()))
+        data_dir = _env_quoted(env_path_value(get_data_dir()))
 
     # Log what we received for debugging
     logger.info(f"[create_env_file] Received llm_provider='{llm_provider}', llm_base_url='{llm_base_url}'")

--- a/ciris_engine/logic/utils/env_file.py
+++ b/ciris_engine/logic/utils/env_file.py
@@ -68,3 +68,52 @@ def env_unquoted(value: str) -> str:
     Backslash LAST here, mirroring `env_quoted` doing it first.
     """
     return value.replace('\\"', '"').replace("\\\\", "\\")
+
+
+#: dotenv's POSIX escape set, inverted. `\f` + `ranc` became one FORM FEED on
+#: read, so mapping the control character back to the two characters that
+#: produced it reconstructs the original text exactly.
+_ESCAPE_SOURCE = {
+    "\x07": r"\a",
+    "\x08": r"\b",
+    "\x0c": r"\f",
+    "\n": r"\n",
+    "\r": r"\r",
+    "\t": r"\t",
+    "\x0b": r"\v",
+    "\x00": r"\0",
+}
+
+
+def repair_dotenv_escapes(value: str) -> str:
+    """Undo escape processing that a `.env` read applied to a Windows path.
+
+    WHY THIS IS NEEDED AFTER THE WRITE SIDE WAS FIXED. Escaping the writers
+    stops NEW corruption; it does nothing for the `.env` files already on disk.
+    Every Windows user whose home directory triggers an escape holds a file
+    poisoned by an earlier version, and on upgrade gets the identical failure:
+
+        CIRIS_DB_PATH read back as C:\\Users\\<FF>ranc\\ciris\\data\\...
+        OSError: [WinError 123]
+
+    A user hit exactly this AFTER installing the release that fixed the writers,
+    which is how we learned that fixing the writers and fixing the USERS are two
+    different problems. The upgrade alone has to be enough.
+
+    The inverse is exact: dotenv turned `\\f` into a form feed, and a control
+    character in this position can only have come from the two-character escape
+    that produced it. So `C:\\Users\\<FF>ranc` becomes `C:\\Users\\franc` again.
+
+    SAFE BECAUSE OF WHERE IT IS APPLIED — config values naming a FILESYSTEM
+    PATH. A control character is not legal in a Windows path (WinError 123 is
+    the OS saying so), so there is no value this can damage. Deliberately not
+    applied to arbitrary config, where a control character might be intentional.
+
+    Idempotent: a repaired value has no control characters left to match.
+    """
+    if not value or not any(ord(c) < 32 for c in value):
+        return value
+    out = value
+    for ctrl, source in _ESCAPE_SOURCE.items():
+        out = out.replace(ctrl, source)
+    return out

--- a/ciris_engine/logic/utils/env_file.py
+++ b/ciris_engine/logic/utils/env_file.py
@@ -117,3 +117,20 @@ def repair_dotenv_escapes(value: str) -> str:
     for ctrl, source in _ESCAPE_SOURCE.items():
         out = out.replace(ctrl, source)
     return out
+
+
+def env_path_value(path: object) -> str:
+    """Render a filesystem path for a `.env` line, backslash-free.
+
+    Windows accepts forward slashes everywhere — `os`, `pathlib`, `open`, and
+    the Win32 API all normalise them — so writing `C:/Users/franc/ciris` instead
+    of `C:\\Users\\franc\\ciris` costs nothing and removes the hazard by
+    construction: a value with no backslashes cannot be mangled by escape
+    processing, no matter which writer produces it or which reader consumes it.
+
+    This is the belt to `env_quoted`'s braces. Escaping is a rule every writer
+    must remember; forward slashes are a property of the value itself. Three
+    separate sites got the escaping wrong before this existed, so the value not
+    needing the rule is worth more than the rule being applied correctly.
+    """
+    return str(path).replace("\\", "/")

--- a/client/androidApp/build.gradle
+++ b/client/androidApp/build.gradle
@@ -25,8 +25,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 35
-        versionCode 156
-        versionName "2.9.19"
+        versionCode 157
+        versionName "2.9.20"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/client/androidApp/src/main/python/version.py
+++ b/client/androidApp/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.9.19"
+__version__ = "android-2.9.20"
 
 
 def get_version() -> str:

--- a/client/desktopApp/build.gradle.kts
+++ b/client/desktopApp/build.gradle.kts
@@ -34,7 +34,7 @@ compose.desktop {
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "CIRIS"
-            packageVersion = "2.9.19"
+            packageVersion = "2.9.20"
             description = "CIRIS Agent Desktop Application"
             vendor = "CIRIS L3C"
 

--- a/client/iosApp/iosApp/Info.plist
+++ b/client/iosApp/iosApp/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.19</string>
+	<string>2.9.20</string>
 	<key>CFBundleVersion</key>
-	<string>316</string>
+	<string>317</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/tests/logic/utils/test_env_file_windows_paths.py
+++ b/tests/logic/utils/test_env_file_windows_paths.py
@@ -181,3 +181,79 @@ def test_env_quoted_and_env_unquoted_are_exact_inverses() -> None:
 
     for value in WINDOWS_PATHS + [r'C:\a\b "quoted" \c', "", "plain", "/posix/path", "a\\\\b"]:
         assert env_unquoted(env_quoted(value)) == value, f"not an inverse for {value!r}"
+
+
+# ---------------------------------------------------------------------------
+# REPAIR ON READ. 2.9.19 fixed the writers, which stops NEW corruption and does
+# nothing for the .env files already on disk. A user installed 2.9.19 and hit
+# the IDENTICAL WinError 123, because his file was poisoned by an earlier
+# version. Fixing the writers and fixing the USERS are two different problems.
+# ---------------------------------------------------------------------------
+
+POISONED = {
+    "C:\\Users\x0cranc\\ciris\\data": r"C:\Users\franc\ciris\data",   # \f — reported
+    "C:\\Users\x0bictor\\ciris": r"C:\Users\victor\ciris",            # \v
+    "C:\\Users\tom\\ciris": r"C:\Users\tom\ciris",                    # \t
+    "C:\\Users\rachel\\ciris": r"C:\Users\rachel\ciris",              # \r
+    "C:\\Users\nancy\\ciris": r"C:\Users\nancy\ciris",                # \n
+    "C:\\Users\x08en\\ciris": r"C:\Users\ben\ciris",                  # \b
+    "C:\\Users\x07lice\\ciris": r"C:\Users\alice\ciris",              # \a
+}
+
+
+@pytest.mark.parametrize("poisoned,expected", sorted(POISONED.items()))
+def test_a_poisoned_value_is_repaired(poisoned: str, expected: str) -> None:
+    from ciris_engine.logic.utils.env_file import repair_dotenv_escapes
+
+    assert repair_dotenv_escapes(poisoned) == expected
+
+
+def test_repair_is_idempotent_and_leaves_clean_values_alone() -> None:
+    """Runs on every read, so it must never degrade an already-good value."""
+    from ciris_engine.logic.utils.env_file import repair_dotenv_escapes
+
+    for clean in (r"C:\Users\franc\ciris", "C:/Users/franc/ciris", "/home/e/ciris", ""):
+        assert repair_dotenv_escapes(clean) == clean
+    once = repair_dotenv_escapes("C:\\Users\x0cranc")
+    assert repair_dotenv_escapes(once) == once
+
+
+def test_get_env_var_repairs_path_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The assertion that matters: the CALLER must get a usable path.
+
+    The standalone helper passing while `get_env_var` returned the corrupted
+    value is precisely the shape of this bug — a fix verified at the wrong layer.
+    """
+    import ciris_engine.logic.config.env_utils as eu
+
+    monkeypatch.setattr(eu, "_ENV_LOADED", True, raising=False)
+    monkeypatch.setenv("CIRIS_DB_PATH", "C:\\Users\x0cranc\\ciris\\data\\ciris_engine.db")
+
+    got = eu.get_env_var("CIRIS_DB_PATH")
+
+    assert got == r"C:\Users\franc\ciris\data\ciris_engine.db"
+    assert not [c for c in got if ord(c) < 32]
+
+
+def test_non_path_keys_are_left_untouched(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only PATH values are repaired — elsewhere a control char may be deliberate."""
+    import ciris_engine.logic.config.env_utils as eu
+
+    monkeypatch.setattr(eu, "_ENV_LOADED", True, raising=False)
+    monkeypatch.setenv("SOME_OTHER_VALUE", "keep\x0cthis")
+
+    assert eu.get_env_var("SOME_OTHER_VALUE") == "keep\x0cthis"
+
+
+def test_the_repair_log_does_not_print_the_path(monkeypatch: pytest.MonkeyPatch, caplog) -> None:
+    """The value is user data, and the corrupted form has been through enough logs."""
+    import ciris_engine.logic.config.env_utils as eu
+
+    monkeypatch.setattr(eu, "_ENV_LOADED", True, raising=False)
+    monkeypatch.setenv("CIRIS_DB_PATH", "C:\\Users\x0cranc\\ciris\\data")
+
+    with caplog.at_level("WARNING"):
+        eu.get_env_var("CIRIS_DB_PATH")
+
+    assert "CIRIS_DB_PATH" in caplog.text
+    assert "franc" not in caplog.text

--- a/tests/logic/utils/test_env_file_windows_paths.py
+++ b/tests/logic/utils/test_env_file_windows_paths.py
@@ -257,3 +257,46 @@ def test_the_repair_log_does_not_print_the_path(monkeypatch: pytest.MonkeyPatch,
 
     assert "CIRIS_DB_PATH" in caplog.text
     assert "franc" not in caplog.text
+
+
+def test_wizard_written_key_spellings_are_repaired(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The wizard writes SECRETS_DB_PATH; the config layer reads CIRIS_SECRETS_DB_PATH.
+
+    Those names do not match — a real bug of its own — and it means a repair set
+    built from either side alone misses half the keys. A live user's .env had
+    exactly these two lines still carrying backslashes.
+    """
+    import ciris_engine.logic.config.env_utils as eu
+
+    monkeypatch.setattr(eu, "_ENV_LOADED", True, raising=False)
+    for key in ("SECRETS_DB_PATH", "AUDIT_LOG_PATH", "CIRIS_SECRETS_DB_PATH", "CIRIS_AUDIT_DB_PATH"):
+        monkeypatch.setenv(key, "C:\\Users\x0cranc\\ciris\\data\\x.db")
+        assert eu.get_env_var(key) == r"C:\Users\franc\ciris\data\x.db", key
+
+
+@pytest.mark.parametrize("path", WINDOWS_PATHS)
+def test_env_path_value_removes_the_hazard_entirely(path: str) -> None:
+    """Forward slashes cannot be mangled, by construction.
+
+    Escaping is a rule every writer has to remember, and three separate sites
+    got it wrong. A value with no backslashes needs no rule — this is the belt
+    to env_quoted's braces.
+    """
+    from ciris_engine.logic.utils.env_file import env_path_value
+
+    v = env_path_value(path)
+    assert "\\" not in v
+
+
+def test_forward_slash_paths_roundtrip_untouched(tmp_path: Path) -> None:
+    """And they survive the write/read pair with no escaping needed at all."""
+    dotenv = pytest.importorskip("dotenv")
+    from ciris_engine.logic.utils.env_file import env_path_value
+
+    v = env_path_value(r"C:\Users\franc\ciris\data")
+    env = tmp_path / ".env"
+    env.write_text(env_line("CIRIS_DATA_DIR", v), encoding="utf-8")
+
+    got = dotenv.dotenv_values(str(env))["CIRIS_DATA_DIR"]
+    assert got == "C:/Users/franc/ciris/data"
+    assert not [c for c in got if ord(c) < 32]

--- a/tools/dev/assert_no_control_chars_in_env.py
+++ b/tools/dev/assert_no_control_chars_in_env.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Fail if any path the agent resolved contains a control character.
+
+WHY THIS ASSERTION AND NOT "DID IT BOOT". The agent booting proves nothing on
+its own: in the 2.9.19 case boot 1 was always clean and boot 2 was broken, so a
+liveness check passed for three consecutive releases while a user could not
+start the product at all.
+
+What actually failed was a PATH carrying a form feed:
+
+    OSError: [WinError 123] ... 'C:\\Users\\x0cranc\\ciris\\data'
+
+`.env` applies POSIX escape processing inside double quotes, so `\\f` + `ranc`
+became one control character. A control character is not legal in a Windows
+path — WinError 123 is the OS saying exactly that — so finding one anywhere in
+the resolved config is unambiguous evidence of the defect, with no judgement
+call about whether the value "looks right".
+
+Checked in BOTH directions, because the two halves disagreed and each one alone
+would have passed at some point in this bug's history:
+
+  * the RAW `.env` on disk — catches a writer that failed to escape;
+  * the value as the CONFIG LAYER returns it — catches a reader that mangles a
+    correctly-written file, which is what the env sync did.
+
+Exit 0 = clean. Exit 1 = a control character reached a path, with the variable
+named and the offending byte identified. The VALUE is never printed: it is user
+data, and on a public CI artifact it would be a home directory path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+#: Keys whose value names a filesystem path. Both spellings on purpose — the
+#: wizard writes `SECRETS_DB_PATH`/`AUDIT_LOG_PATH` while the config layer reads
+#: `CIRIS_SECRETS_DB_PATH`/`CIRIS_AUDIT_DB_PATH`, and a list built from either
+#: side alone covers half the keys.
+PATH_KEYS = (
+    "CIRIS_HOME",
+    "CIRIS_DATA_DIR",
+    "CIRIS_DB_PATH",
+    "CIRIS_SECRETS_DB_PATH",
+    "CIRIS_AUDIT_DB_PATH",
+    "SECRETS_DB_PATH",
+    "AUDIT_LOG_PATH",
+    "CIRIS_LOG_DIR",
+    "CIRIS_AGENT_ROOT",
+)
+
+
+def _offenders(value: str) -> list[str]:
+    return sorted({hex(ord(c)) for c in value if ord(c) < 32})
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--home", required=True, help="CIRIS_HOME for this run")
+    ap.add_argument("--label", default="", help="boot1 / boot2, for the message")
+    args = ap.parse_args()
+
+    tag = f"[{args.label}] " if args.label else ""
+    env_path = Path(args.home) / ".env"
+    failures: list[str] = []
+
+    # ── 1. the file on disk ────────────────────────────────────────────────
+    if not env_path.exists():
+        print(f"{tag}::error::no .env at the resolved home — setup did not complete")
+        return 1
+
+    raw = env_path.read_text(encoding="utf-8", errors="replace")
+    for line in raw.splitlines():
+        if "=" not in line or line.lstrip().startswith("#"):
+            continue
+        key, _, val = line.partition("=")
+        key = key.strip()
+        if key in PATH_KEYS and (bad := _offenders(val)):
+            failures.append(f"{key}: control character(s) {bad} in the RAW .env line")
+
+    # ── 2. what the config layer hands back ────────────────────────────────
+    # The half that matters more: the env sync produced a correct file and then
+    # un-escaped it on read, so a disk-only check passed while users were broken.
+    try:
+        from ciris_engine.logic.config.env_utils import get_env_var, load_env_file
+
+        load_env_file(str(env_path))
+        for key in PATH_KEYS:
+            val = get_env_var(key)
+            if val and (bad := _offenders(val)):
+                failures.append(f"{key}: control character(s) {bad} AS READ by the config layer")
+    except Exception as exc:  # pragma: no cover - import shape varies by install
+        print(f"{tag}::warning::could not read through the config layer ({type(exc).__name__})")
+
+    if failures:
+        print(f"{tag}::error::a path carried a control character — this is the WinError 123 defect")
+        for f in failures:
+            print(f"  {f}")
+        print(
+            "  Cause: .env applies POSIX escape processing inside double quotes, so a Windows "
+            "path like C:\\Users\\franc becomes C:\\Users<FF>ranc. Writers must escape "
+            "(env_line/env_quoted) or emit forward slashes (env_path_value); readers must "
+            "repair (repair_dotenv_escapes)."
+        )
+        return 1
+
+    print(f"{tag}all path values clean — no control characters on disk or as read")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/dev/assert_oauth_redirect_uri.py
+++ b/tools/dev/assert_oauth_redirect_uri.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Fail if the OAuth sign-in button emits a redirect_uri no provider can accept.
+
+WHY NOT A REAL GOOGLE SIGN-IN. That needs interactive consent and account
+credentials, neither of which belongs in CI. And it would test the wrong thing:
+what broke hosted login was never the consent screen. It was the `redirect_uri`
+the agent SENDS, which is fully determined before any browser is involved and
+therefore fully checkable here.
+
+The two failure modes this exists to catch, both observed in production:
+
+  * LOOPBACK LEAK. `auth.oauth_callback_base_url` could not be written (the node
+    403s until it is claimed), so the base silently fell back to
+    `http://127.0.0.1:4243`. A hosted agent then sent a loopback redirect_uri to
+    a Web-type credential, which can never accept one. The agent logged success
+    throughout.
+
+  * DROPPED AGENT SEGMENT. The node derives
+    `{base}/v1/auth/oauth/{provider}/callback`, while the deployment registers
+    `{base}/v1/auth/oauth/{agent_id}/{provider}/callback` — nginx strips the
+    agent id before forwarding, which is how one client id serves every agent.
+    The port dropped that segment (CIRISServer#421), so every hosted login got
+    `redirect_uri_mismatch`.
+
+Both are visible in the `Location` header of the authorize redirect, so this
+issues the same request the sign-in button does and inspects what comes back.
+It deliberately does NOT follow the redirect — that would reach Google.
+
+Scope note: on a DESKTOP install a loopback redirect is CORRECT (RFC 8252 —
+a native app is a public client and registers a loopback URI), so loopback is
+only an error when a public base is configured. Asserting otherwise would turn
+a working desktop login into a red build.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import urllib.parse
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--agent-port", type=int, default=8080)
+    ap.add_argument("--provider", default="google")
+    ap.add_argument(
+        "--expect-base",
+        default=os.environ.get("OAUTH_CALLBACK_BASE_URL", ""),
+        help="public origin the deployment provisions; empty means desktop/loopback is fine",
+    )
+    ap.add_argument("--expect-agent-id", default=os.environ.get("CIRIS_AGENT_ID", ""))
+    args = ap.parse_args()
+
+    try:
+        import requests
+    except ImportError:
+        print("::error::requests not installed")
+        return 1
+
+    url = f"http://127.0.0.1:{args.agent_port}/v1/auth/oauth/{args.provider}/login"
+    try:
+        # allow_redirects=False on purpose: we want the Location, not Google.
+        resp = requests.get(url, allow_redirects=False, timeout=15)
+    except Exception as exc:
+        print(f"::error::could not reach the login route ({type(exc).__name__})")
+        return 1
+
+    if resp.status_code not in (301, 302, 303, 307, 308):
+        print(f"::error::{url} returned {resp.status_code}, expected a redirect to the provider")
+        return 1
+
+    location = resp.headers.get("location", "")
+    qs = urllib.parse.parse_qs(urllib.parse.urlparse(location).query)
+    redirect_uri = (qs.get("redirect_uri") or [""])[0]
+    if not redirect_uri:
+        print("::error::authorize redirect carried no redirect_uri")
+        return 1
+
+    print(f"  redirect_uri = {redirect_uri}")
+    parsed = urllib.parse.urlparse(redirect_uri)
+    is_loopback = parsed.hostname in ("127.0.0.1", "localhost", "::1")
+    failures: list[str] = []
+
+    if args.expect_base:
+        # A public base is configured, so this is a HOSTED agent.
+        want_origin = urllib.parse.urlparse(args.expect_base)
+        if is_loopback:
+            failures.append(
+                f"loopback redirect_uri on a hosted agent (base is {args.expect_base}) — the "
+                "callback base never reached the node; a Web credential cannot accept loopback"
+            )
+        elif (parsed.scheme, parsed.netloc) != (want_origin.scheme, want_origin.netloc):
+            failures.append(f"origin is {parsed.scheme}://{parsed.netloc}, expected {args.expect_base}")
+
+        if args.expect_agent_id and f"/{args.expect_agent_id}/" not in parsed.path:
+            failures.append(
+                f"path {parsed.path!r} has no /{args.expect_agent_id}/ segment — deployments "
+                "register {base}/v1/auth/oauth/{agent_id}/{provider}/callback (CIRISServer#421)"
+            )
+    elif not is_loopback:
+        # No public base configured => desktop install; loopback is the correct
+        # answer and anything else means we are sending a URL nobody registered.
+        failures.append(f"desktop install emitted a non-loopback redirect_uri ({redirect_uri})")
+
+    if failures:
+        print("::error::the OAuth sign-in button emits a redirect_uri no provider will accept")
+        for f in failures:
+            print(f"  {f}")
+        return 1
+
+    print("  redirect_uri is well-formed for this deployment shape")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The check that would have caught the form-feed bug a Windows user hit three times.

**Why nothing in CI could see it:** it needs a real Windows filesystem, a home path containing an escape trigger, **two boots** (the env-sync corruption only appears on the second start — boot 1 was always clean, which is why a single-boot test passed for three releases), and the **wheel** rather than a source checkout.

Drives the real UI via the existing `web_ui` harness against the app's `CIRIS_TEST_MODE` server (`/click`, `/input`, `/wait` on testTags). Every bug this cycle lived in the seam between UI and runtime, which an API-level test cannot reach.

**Two gates, both mutation-checked:**
- `assert_no_control_chars_in_env.py` — verified it fails on a poisoned .env and passes on a clean one. Checks the raw file *and* the config-layer read, since those disagreed and each alone passed at some point.
- `assert_oauth_redirect_uri.py` — inspects the authorize `Location` without following it. Catches the loopback leak and the dropped agent-id segment (CIRISServer#421). Loopback stays valid for desktop per RFC 8252.

**Dispatch-only** until it passes twice — the `pull_request` trigger is written out in a comment, ready to enable. Deliberately not folded into the 2.9.20 release PR.