### PR TITLE
ci(windows): capture UI state per step — screenshot plus element tree

### DIFF
--- a/.github/workflows/windows-desktop-ui.yml
+++ b/.github/workflows/windows-desktop-ui.yml
@@ -168,6 +168,15 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path artifacts | Out-Null
           Copy-Item boot1.json,boot2.json,oauth_up.json artifacts -ErrorAction SilentlyContinue
+          # Per-step UI captures. The PNGs come from AWT Robot, which grabs the
+          # SCREEN and needs a real display — on a runner with no interactive
+          # desktop session they may be missing or black, which is expected and
+          # not a failure. The .tree.json files are plain text, need no display,
+          # and are the ones worth diffing between a passing and failing run.
+          if (Test-Path ui_captures) { Copy-Item ui_captures artifacts\ui_captures -Recurse -ErrorAction SilentlyContinue }
+          Write-Host "UI captures collected:"
+          Get-ChildItem -Recurse artifacts\ui_captures -ErrorAction SilentlyContinue |
+            ForEach-Object { Write-Host "  $($_.Name)  $($_.Length) bytes" }
           if (Test-Path "$env:CIRIS_HOME\logs") { Copy-Item "$env:CIRIS_HOME\logs" artifacts\logs -Recurse -ErrorAction SilentlyContinue }
           # .env carries secrets — ship the SHAPE, never the values, so a failed
           # run is diagnosable without leaking keys into a public artifact.

--- a/tools/qa_runner/modules/web_ui/desktop_app_helper.py
+++ b/tools/qa_runner/modules/web_ui/desktop_app_helper.py
@@ -129,6 +129,65 @@ class DesktopAppHelper:
         self._current_screen = data.get("screen", "unknown")
         return self._current_screen
 
+    async def capture_step(self, label: str, out_dir: "str | Path" = "ui_captures") -> dict:
+        """Snapshot the UI at a named step: PNG, element tree, and screen name.
+
+        WHY BOTH, AND WHY THE TREE MATTERS MORE IN CI. The PNG comes from AWT
+        `Robot.createScreenCapture`, which grabs the SCREEN rather than rendering
+        the window. It needs a real display, so on a CI runner with no
+        interactive desktop session it will throw or hand back a black frame.
+        Locally it is the fastest way to see what went wrong; in CI it may be
+        worth nothing.
+
+        The tree has the opposite property: plain text, no display required,
+        greppable and diffable across runs. For "which step did the UI stop
+        matching what we expected", a tree dump usually beats a picture — you
+        can diff the passing run against the failing one.
+
+        So this captures both and NEVER raises. A troubleshooting aid that can
+        fail a test it was only meant to explain is worse than no aid at all —
+        the first Windows run failed inside the harness, and a capture helper
+        that added its own failure mode would have buried the real cause.
+
+        Returns what it managed to collect, so the caller can log the gaps.
+        """
+        from pathlib import Path as _Path
+
+        out = _Path(out_dir)
+        out.mkdir(parents=True, exist_ok=True)
+        got: dict = {"label": label, "screen": None, "tree": None, "png": None, "errors": []}
+
+        if not self._client:
+            got["errors"].append("not connected")
+            return got
+
+        try:
+            got["screen"] = await self.get_screen()
+        except Exception as e:
+            got["errors"].append(f"screen: {type(e).__name__}")
+
+        try:
+            resp = await self._client.get("/tree")
+            tree_path = out / f"{label}.tree.json"
+            tree_path.write_text(resp.text, encoding="utf-8")
+            got["tree"] = str(tree_path)
+        except Exception as e:
+            got["errors"].append(f"tree: {type(e).__name__}")
+
+        try:
+            resp = await self._client.get("/screenshot")
+            if resp.status_code == 200 and resp.content:
+                png_path = out / f"{label}.png"
+                png_path.write_bytes(resp.content)
+                got["png"] = str(png_path)
+            else:
+                got["errors"].append(f"screenshot: HTTP {resp.status_code}")
+        except Exception as e:
+            # Expected on a headless runner — Robot needs a display.
+            got["errors"].append(f"screenshot: {type(e).__name__}")
+
+        return got
+
     async def get_elements(self) -> List[ElementInfo]:
         """Get all UI elements currently visible."""
         if not self._client:


### PR DESCRIPTION
The Windows failures ahead are UI-state problems, and a log line won't explain them.

The desktop test server already exposed `GET /screenshot` — the Python helper never used it.

`capture_step()` takes **both** a PNG and the element tree, because they fail in opposite conditions:

- the **PNG** comes from AWT `Robot.createScreenCapture`, which grabs the *screen* rather than rendering the window. It needs a real display, so on a runner with no interactive desktop session it will throw or return a black frame. Excellent locally, possibly worthless in CI.
- the **tree** is plain text, needs no display, and is greppable and diffable. For "which step did the UI stop matching what we expected", diffing a passing run against a failing one beats a picture.

It **never raises**. A troubleshooting aid that can fail the test it was meant to explain is worse than none — the first Windows run died *inside* the harness, and a capture helper with its own failure mode would have buried the cause.

The workflow collects `ui_captures/` and lists what it got, so a missing PNG shows up as an expected gap rather than a silent one.