### PR TITLE
2.9.23 — if it does not work, the console and logs will tell you why

### DIFF
--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -6,11 +6,11 @@ from typing import List
 from ciris_engine.schemas.runtime.canonical_peer import CanonicalBootstrapPeer
 
 # Version information
-CIRIS_VERSION = "2.9.22-stable"
+CIRIS_VERSION = "2.9.23-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
 CIRIS_VERSION_MINOR = 9
-CIRIS_VERSION_PATCH = 22
+CIRIS_VERSION_PATCH = 23
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/ciris_engine/logic/adapters/api/routes/system/health.py
+++ b/ciris_engine/logic/adapters/api/routes/system/health.py
@@ -150,6 +150,202 @@ def _hardware_trust_warnings(request: Request) -> list[SystemWarning]:
     return []
 
 
+
+def _adapter_load_failure_warnings(request: Request) -> list[SystemWarning]:
+    """Configured adapters that never loaded (CIRISAgent#1057).
+
+    SELF-DIAGNOSING FOR CIRISMANAGER. Manager GENERATES the adapter config, so
+    it is the component that can fix a stale name — but it had no way to learn
+    the name was stale. A fleet ran for several releases with `sync` and
+    `ciris_covenant_metrics` (renamed to ciris_accord_metrics) failing to import
+    on EVERY agent, one agent serving with none of its configured adapters, and
+    every health check reporting `healthy`. The only evidence was a log line
+    inside the container.
+
+    Two distinct codes, because they need two different fixes:
+
+      adapters_config_stale  — the module does not exist. The config names an
+                               adapter that was renamed or removed. Manager can
+                               reconcile this itself.
+      adapters_failed_to_load — the adapter exists but blew up starting. A code
+                               or credentials problem; a human looks at it.
+
+    Severity escalates to `error` when NOTHING a config asked for is running,
+    which is the state that must never again read as healthy.
+    """
+    runtime = getattr(request.app.state, "runtime", None)
+    failures = list(getattr(runtime, "adapter_load_failures", []) or []) if runtime else []
+    if not failures:
+        return []
+
+    live = len(getattr(runtime, "adapters", []) or [])
+    # Communication adapters the operator asked for, ignoring the internal ones
+    # (ciris_verify / wallet / ciris_accord_metrics) that always auto-load — an
+    # agent with only those is not talking to anyone.
+    _INTERNAL = {"ciris_verify", "wallet", "ciris_accord_metrics"}
+    external_live = len(
+        [a for a in (getattr(runtime, "adapters", []) or []) if getattr(a, "adapter_type", "") not in _INTERNAL]
+    )
+    severity = "error" if external_live == 0 else "warning"
+
+    out: list[SystemWarning] = []
+    stale = [f for f in failures if getattr(f, "is_missing_module", False)]
+    broken = [f for f in failures if not getattr(f, "is_missing_module", False)]
+
+    if stale:
+        names = ", ".join(sorted({f.adapter_type for f in stale}))
+        out.append(
+            SystemWarning(
+                code="adapters_config_stale",
+                message=(
+                    f"Configured adapter(s) do not exist and were skipped: {names}. "
+                    f"{external_live} of {external_live + len(failures)} configured adapters are running. "
+                    "The config names an adapter that was renamed or removed — regenerate it."
+                ),
+                severity=severity,
+                action_url="/settings/adapters",
+            )
+        )
+    if broken:
+        names = ", ".join(sorted({f"{f.adapter_type} ({f.error_type})" for f in broken}))
+        out.append(
+            SystemWarning(
+                code="adapters_failed_to_load",
+                message=f"Configured adapter(s) failed to start: {names}",
+                severity=severity,
+                action_url="/settings/adapters",
+            )
+        )
+    return out
+
+
+def _occurrence_warnings(request: Request) -> list[SystemWarning]:
+    """Report the occurrence identity this process actually resolved (#1048).
+
+    scout2 ran as occurrence 002 while declaring itself single-occurrence, and
+    nothing outside the container could see the contradiction. Manager assigns
+    the occurrence id, so it is exactly who needs to know when the agent
+    disagrees about what it was assigned.
+
+    Emitted at `info` when consistent — this is a STATE REPORT, not only an
+    alarm. Manager can reconcile what it assigned against what the agent
+    resolved without waiting for something to break.
+    """
+    try:
+        from ciris_engine.logic.utils.occurrence_utils import (
+            DEFAULT_OCCURRENCE_ID,
+            get_current_occurrence_id,
+            is_multi_occurrence_deployment,
+        )
+
+        occ = get_current_occurrence_id()
+        multi = is_multi_occurrence_deployment()
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug(f"Could not resolve occurrence info: {e}")
+        return []
+
+    if occ == DEFAULT_OCCURRENCE_ID and not multi:
+        return []
+    return [
+        SystemWarning(
+            code="occurrence_identity",
+            message=f"occurrence_id={occ} multi_occurrence={multi}",
+            severity="info",
+            action_url=None,
+        )
+    ]
+
+
+def _claim_persistence_warnings(request: Request) -> list[SystemWarning]:
+    """Shared-task claims that reported success but left no row (#1057).
+
+    THE ONE THAT COST THE MOST TO FIND. datum logged a successful claim on every
+    boot while its store had no such row, span in WAKEUP to round 66 finding no
+    thoughts, and reported healthy throughout. Detecting it required someone to
+    inventory the database by hand.
+
+    try_claim_shared_task now reads the row back and records a failure here when
+    it is absent, so the condition announces itself to CIRISManager instead of
+    waiting to be discovered.
+    """
+    try:
+        from ciris_engine.logic.persistence.models.tasks import get_shared_claim_failures
+
+        failures = get_shared_claim_failures()
+    except Exception as e:
+        logger.debug(f"Could not read shared claim failures: {e}")
+        return []
+    if not failures:
+        return []
+    ids = ", ".join(sorted({str(f.get("task_id")) for f in failures})[:5])
+    return [
+        SystemWarning(
+            code="shared_claim_not_persisted",
+            message=(
+                f"{len(failures)} shared-task claim(s) reported success but no row is present: {ids}. "
+                "The agent cannot obtain work and will spin. Verify it reads the same database it writes."
+            ),
+            severity="error",
+            action_url="/settings/tasks",
+        )
+    ]
+
+
+def _stale_shared_task_warnings(request: Request) -> list[SystemWarning]:
+    """A shared task stuck ACTIVE across days (#1018, seen again in #1057).
+
+    datum booted with SHUTDOWN_SHARED_20260731 still ACTIVE 17 days later,
+    `updated_at` never moved from `created_at`, and it was the newest row in the
+    store. Nothing surfaced that. A shared task is claimed by one occurrence on
+    behalf of all of them, so one that never settles is a fleet-level fact and
+    belongs in the fleet-level health surface.
+    """
+    try:
+        from ciris_engine.logic.persistence.models.tasks import get_all_tasks
+        from ciris_engine.schemas.runtime.enums import TaskStatus
+
+        tasks = get_all_tasks(agent_occurrence_id="__shared__") or []
+    except Exception as e:
+        logger.debug(f"Could not check shared tasks: {e}")
+        return []
+
+    now = datetime.now(timezone.utc)
+    stale = []
+    for task in tasks:
+        status = getattr(task, "status", None)
+        status_val = getattr(status, "value", status)
+        if status_val not in ("active", "pending", "processing"):
+            continue
+        updated = getattr(task, "updated_at", None) or getattr(task, "created_at", None)
+        if not updated:
+            continue
+        try:
+            ts = datetime.fromisoformat(str(updated).replace("Z", "+00:00"))
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+        except (ValueError, TypeError):
+            continue
+        age_hours = (now - ts).total_seconds() / 3600.0
+        if age_hours >= 24:
+            stale.append((getattr(task, "task_id", "?"), age_hours))
+
+    if not stale:
+        return []
+    worst = max(h for _, h in stale)
+    names = ", ".join(sorted(tid for tid, _ in stale)[:5])
+    return [
+        SystemWarning(
+            code="shared_task_stranded",
+            message=(
+                f"{len(stale)} shared task(s) unsettled for over 24h (oldest {worst / 24:.1f} days): {names}. "
+                "A shared task is claimed on behalf of every occurrence; one that never settles blocks them all."
+            ),
+            severity="error",
+            action_url="/settings/tasks",
+        )
+    ]
+
+
 async def collect_system_warnings(request: Request) -> tuple[bool, list[SystemWarning]]:
     """Collect system-level warnings and check degraded mode.
 
@@ -160,6 +356,12 @@ async def collect_system_warnings(request: Request) -> tuple[bool, list[SystemWa
     warnings = llm_warnings.copy()
     warnings.extend(await _adapter_reauth_warnings(request))
     warnings.extend(_hardware_trust_warnings(request))
+    # #1057 — fleet conditions that previously lived only in container logs.
+    # Manager polls this endpoint; anything it must act on has to be here.
+    warnings.extend(_adapter_load_failure_warnings(request))
+    warnings.extend(_occurrence_warnings(request))
+    warnings.extend(_stale_shared_task_warnings(request))
+    warnings.extend(_claim_persistence_warnings(request))
     return not has_working_llm, warnings
 
 

--- a/ciris_engine/logic/adapters/api/routes/system/health.py
+++ b/ciris_engine/logic/adapters/api/routes/system/health.py
@@ -302,9 +302,8 @@ def _stale_shared_task_warnings(request: Request) -> list[SystemWarning]:
     """
     try:
         from ciris_engine.logic.persistence.models.tasks import get_all_tasks
-        from ciris_engine.schemas.runtime.enums import TaskStatus
 
-        tasks = get_all_tasks(agent_occurrence_id="__shared__") or []
+        tasks = get_all_tasks(occurrence_id="__shared__") or []
     except Exception as e:
         logger.debug(f"Could not check shared tasks: {e}")
         return []

--- a/ciris_engine/logic/persistence/db/core.py
+++ b/ciris_engine/logic/persistence/db/core.py
@@ -616,14 +616,28 @@ def _bootstrap_persist_engine(db_path: Optional[str]) -> None:
         #
         # Imported defensively: an older pin without the symbol must degrade to
         # the previous behaviour (refused full_traces) rather than fail to boot.
+        # HELD OUT OF 2.9.23, deliberately, pending measurement.
+        #
+        # The wiring itself is correct and verified against the pinned wheel
+        # (ciris_server.egress_scrub exists; Engine's third parameter is
+        # `scrubber`). It is held because Staged QA (all_1) reproduces four
+        # failures on this branch that main does not have, and the one that
+        # matters is timing-bound:
+        #
+        #   accord_metrics::Verb Second Pass Trace — waits up to 60s for trace
+        #   files that appear only after a complete_trace envelope ships plus a
+        #   5s flush; its own comment records a thought taking ~36s under CI
+        #   load. Three agent_mode failures alongside it are 10s READ TIMEOUTS.
+        #
+        # egress_scrub adds per-trace work at persist and its result tuple
+        # carries `ner_ran`, so it may run NER on every trace. That is a
+        # plausible latency regression on exactly that path, and shipping one
+        # into the fleet this release exists to rescue is the wrong trade.
+        #
+        # Causation is NOT proven — holding it here is also the A/B that proves
+        # or clears it. Re-enable together with _AGENT_INSTALLS_SCRUBBER once
+        # the per-trace cost is measured.
         scrubber = None
-        try:
-            from ciris_server import egress_scrub as scrubber  # type: ignore[no-redef, import-untyped, unused-ignore]
-        except ImportError:
-            logger.warning(
-                "ciris_server.egress_scrub unavailable on this pin — persist will install NullScrubber "
-                "and full_traces batches will be refused (CIRISServer#418)"
-            )
 
         return Engine(
             dsn,

--- a/ciris_engine/logic/persistence/db/core.py
+++ b/ciris_engine/logic/persistence/db/core.py
@@ -618,7 +618,7 @@ def _bootstrap_persist_engine(db_path: Optional[str]) -> None:
         # the previous behaviour (refused full_traces) rather than fail to boot.
         scrubber = None
         try:
-            from ciris_server import egress_scrub as scrubber  # type: ignore[no-redef]
+            from ciris_server import egress_scrub as scrubber  # type: ignore[no-redef, import-untyped, unused-ignore]
         except ImportError:
             logger.warning(
                 "ciris_server.egress_scrub unavailable on this pin — persist will install NullScrubber "

--- a/ciris_engine/logic/persistence/db/core.py
+++ b/ciris_engine/logic/persistence/db/core.py
@@ -600,9 +600,35 @@ def _bootstrap_persist_engine(db_path: Optional[str]) -> None:
     )
 
     def _construct_engine() -> "Engine":
+        # SCRUBBER (CIRISServer#418, CIRISAgent#11). `scrubber=None` — the
+        # constructor default we used to take — installs persist's NullScrubber,
+        # which redacts NOTHING and, since persist v32.1.0, has its full_traces
+        # batches REFUSED outright:
+        #
+        #     ValueError: ('scrub_treatment_mismatch', 'label=full_traces ...')
+        #
+        # The binding has been on every supported pin since ciris-server 0.5.174
+        # and is present in the 0.5.176 we pin (verified against the wheel:
+        # `ciris_server.egress_scrub`, and Engine's third parameter is
+        # `scrubber`). The crate's scrubber was already wired into both RUST
+        # ingest paths; the agent reaches persist through PYTHON, so it alone
+        # never saw one. This closes that gap rather than changing the design.
+        #
+        # Imported defensively: an older pin without the symbol must degrade to
+        # the previous behaviour (refused full_traces) rather than fail to boot.
+        scrubber = None
+        try:
+            from ciris_server import egress_scrub as scrubber  # type: ignore[no-redef]
+        except ImportError:
+            logger.warning(
+                "ciris_server.egress_scrub unavailable on this pin — persist will install NullScrubber "
+                "and full_traces batches will be refused (CIRISServer#418)"
+            )
+
         return Engine(
             dsn,
             signing_key_id,
+            scrubber=scrubber,
             identity_dir=str(identity_dir),
             keystore_alias=signing_key_id,
             # First provisioning mints the node's ONE identity. persist warns

--- a/ciris_engine/logic/persistence/models/tasks.py
+++ b/ciris_engine/logic/persistence/models/tasks.py
@@ -849,6 +849,35 @@ def set_task_updated_info_flag(
 # ==================== Multi-Occurrence Shared Task Functions ====================
 
 
+
+class SharedTaskClaimNotPersisted(RuntimeError):
+    """A shared-task claim reported success but the row is not in the store.
+
+    Raised rather than returned so the caller cannot accidentally continue as if
+    it held the task — the failure mode in #1057 was precisely an agent
+    proceeding on a claim it did not have.
+    """
+
+
+#: Claim verifications that failed this process. Surfaced by /v1/system/health
+#: so CIRISManager can see it without shelling into the container — the whole
+#: reason #1057 took a fleet-wide inspection to find.
+_SHARED_CLAIM_FAILURES: List[dict] = []
+
+
+def record_shared_claim_failure(task_id: str, outcome: str) -> None:
+    """Remember a claim that did not persist (bounded; newest kept)."""
+    _SHARED_CLAIM_FAILURES.append(
+        {"task_id": task_id, "outcome": outcome, "at": datetime.now(timezone.utc).isoformat()}
+    )
+    del _SHARED_CLAIM_FAILURES[:-20]
+
+
+def get_shared_claim_failures() -> List[dict]:
+    """Claim verifications that failed in this process, for health reporting."""
+    return list(_SHARED_CLAIM_FAILURES)
+
+
 def try_claim_shared_task(
     task_type: str,
     channel_id: str,
@@ -923,8 +952,35 @@ def try_claim_shared_task(
         raise RuntimeError(f"Shared task {task_id} claim returned no task row")
 
     task = _persist_row_to_task(task_row)
+
+    # READ BACK BEFORE DECLARING SUCCESS (CIRISAgent#1057).
+    #
+    # This used to return on the substrate's word alone. datum logged
+    # "This occurrence claimed shared ..." on every boot while its store held NO
+    # wakeup task for that day — and no row of any kind for 17 days. The agent
+    # then found 0 PENDING thoughts and span in WAKEUP to round 66, reporting
+    # healthy the whole time, because nothing ever checked that the row it
+    # believed it had written was actually there.
+    #
+    # A claim whose row cannot be read back is not a claim. We cannot fix the
+    # write from here — we do not know yet why it fails — but an agent must not
+    # proceed believing it holds a task it does not hold.
+    readback = get_task_by_id(task_id, "__shared__")
+    if readback is None:
+        record_shared_claim_failure(task_id, outcome or "unknown")
+        logger.critical(
+            "SHARED TASK CLAIM DID NOT PERSIST: %s reported outcome=%r but the row cannot be read back "
+            "from the store. The agent has NOT claimed this task and will find no work. "
+            "This is CIRISAgent#1057 — check that the process is reading the same database it wrote to.",
+            task_id,
+            outcome,
+        )
+        raise SharedTaskClaimNotPersisted(
+            f"Shared task {task_id} reported outcome={outcome!r} but is absent from the store"
+        )
+
     if outcome == "stored":
-        logger.info(f"Successfully claimed shared task {task_id}")
+        logger.info(f"Successfully claimed shared task {task_id} (verified present in store)")
         return (task, True)
     logger.info(f"Another occurrence claimed shared task {task_id} during race")
     return (task, False)

--- a/ciris_engine/logic/persistence/models/tasks.py
+++ b/ciris_engine/logic/persistence/models/tasks.py
@@ -862,7 +862,7 @@ class SharedTaskClaimNotPersisted(RuntimeError):
 #: Claim verifications that failed this process. Surfaced by /v1/system/health
 #: so CIRISManager can see it without shelling into the container — the whole
 #: reason #1057 took a fleet-wide inspection to find.
-_SHARED_CLAIM_FAILURES: List[dict] = []
+_SHARED_CLAIM_FAILURES: List[Dict[str, str]] = []
 
 
 def record_shared_claim_failure(task_id: str, outcome: str) -> None:
@@ -873,7 +873,7 @@ def record_shared_claim_failure(task_id: str, outcome: str) -> None:
     del _SHARED_CLAIM_FAILURES[:-20]
 
 
-def get_shared_claim_failures() -> List[dict]:
+def get_shared_claim_failures() -> List[Dict[str, str]]:
     """Claim verifications that failed in this process, for health reporting."""
     return list(_SHARED_CLAIM_FAILURES)
 

--- a/ciris_engine/logic/runtime/bootstrap_helpers.py
+++ b/ciris_engine/logic/runtime/bootstrap_helpers.py
@@ -122,6 +122,34 @@ def check_mock_llm(runtime: Any) -> None:
             logger.info("Added mock_llm to modules to load")
 
 
+
+def _record_adapter_failure(runtime: Any, adapter_type: str, adapter_id: str, exc: Exception) -> None:
+    """Remember a configured adapter that did not load.
+
+    #1057: these were logged once and forgotten, so a fleet ran for several
+    releases with adapters failing to import on every agent while health stayed
+    green. A log line nobody greps is not a signal.
+    """
+    from ciris_engine.schemas.runtime.adapter_management import AdapterLoadFailure
+
+    # "Could not import adapter module" is raised by load_adapter() when neither
+    # ciris_engine.logic.adapters.<mode> nor ciris_adapters.<mode> exists — a
+    # STALE CONFIG NAME, not a broken adapter, and it needs a different fix
+    # (rename/remove the entry) so it is worth distinguishing.
+    missing = isinstance(exc, ValueError) and "Could not import adapter module" in str(exc)
+    if not hasattr(runtime, "adapter_load_failures"):
+        runtime.adapter_load_failures = []
+    runtime.adapter_load_failures.append(
+        AdapterLoadFailure(
+            adapter_type=adapter_type,
+            adapter_id=adapter_id,
+            error=str(exc),
+            error_type=type(exc).__name__,
+            is_missing_module=missing,
+        )
+    )
+
+
 def _load_single_adapter(runtime: Any, adapter_type: str, adapter_id: str) -> bool:
     """Load a single adapter by type and id.
 
@@ -159,6 +187,7 @@ def _load_single_adapter(runtime: Any, adapter_type: str, adapter_id: str) -> bo
         return True
     except Exception as e:
         logger.error(f"Failed to load adapter '{adapter_id}': {e}", exc_info=True)
+        _record_adapter_failure(runtime, adapter_type, adapter_id, e)
         return False
 
 
@@ -223,3 +252,4 @@ def load_adapters_from_bootstrap(runtime: Any) -> None:
             logger.info(f"Successfully loaded adapter: {load_request.adapter_id}")
         except Exception as e:
             logger.error(f"Failed to load adapter '{load_request.adapter_id}': {e}", exc_info=True)
+            _record_adapter_failure(runtime, load_request.adapter_type, load_request.adapter_id, e)

--- a/ciris_engine/logic/utils/occurrence_utils.py
+++ b/ciris_engine/logic/utils/occurrence_utils.py
@@ -112,21 +112,56 @@ def discover_active_occurrences(within_minutes: int = 10) -> List[str]:
         return []
 
 
+#: The occurrence id an agent has when nobody assigned it one.
+DEFAULT_OCCURRENCE_ID = "default"
+
+
 def get_current_occurrence_id() -> str:
     """Get the current occurrence ID from environment or default.
+
+    Both spellings are accepted, matching EssentialConfig (essential.py:239):
+    CIRIS_OCCURRENCE_ID is the current standard, AGENT_OCCURRENCE_ID the legacy
+    name. This used to read only AGENT_OCCURRENCE_ID, so an operator who set the
+    documented CIRIS_OCCURRENCE_ID got "default" here while EssentialConfig
+    correctly saw their value — the two halves of the system disagreeing about
+    which occurrence this process is.
 
     Returns:
         Occurrence ID string (default: "default")
     """
-    return os.getenv("AGENT_OCCURRENCE_ID", "default")
+    return os.getenv("CIRIS_OCCURRENCE_ID") or os.getenv("AGENT_OCCURRENCE_ID") or DEFAULT_OCCURRENCE_ID
 
 
 def is_multi_occurrence_deployment() -> bool:
     """Check if this is a multi-occurrence deployment.
 
+    CIRISAgent#1048: this read ONLY AGENT_OCCURRENCE_COUNT, so scout2 — running
+    with AGENT_OCCURRENCE_ID=002 and no COUNT set — fell through to database
+    discovery, found itself alone in the activity window, and declared
+
+        "Single-occurrence agent claiming existing wakeup task ..."
+
+    while being occurrence 002 of a shared-Postgres pair. It then took the
+    single-occurrence claiming branch, which is not the branch a non-default
+    occurrence should take.
+
+    A NON-DEFAULT OCCURRENCE ID IS ITSELF PROOF. "002" cannot exist in a
+    single-occurrence deployment — somebody assigned it, and they only do that
+    when there is more than one. Treating the id as evidence removes the
+    dependence on a second variable that nothing forces an operator to set, and
+    on database discovery, which cannot see a sibling that is merely idle
+    (discover_active_occurrences only looks back 30 minutes).
+
     Returns:
         True if running with multiple occurrences, False if single occurrence
     """
+    if get_current_occurrence_id() != DEFAULT_OCCURRENCE_ID:
+        logger.debug(
+            "Multi-occurrence inferred from occurrence id %r (a non-default id implies siblings)",
+            get_current_occurrence_id(),
+        )
+        return True
+
     count = get_occurrence_count()
     return count > 1
 

--- a/ciris_engine/logic/utils/substrate_caps.py
+++ b/ciris_engine/logic/utils/substrate_caps.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 #: `NullScrubber`. Change that construction and change this together — they are
 #: the same fact stated twice, and the whole point of the constant is that there
 #: is exactly one of them.
-_AGENT_INSTALLS_SCRUBBER = True
+_AGENT_INSTALLS_SCRUBBER = False
 
 
 def substrate_can_scrub() -> bool:
@@ -37,7 +37,11 @@ def substrate_can_scrub() -> bool:
     substrate capability would have re-enabled it the moment we bumped the pin —
     a guard silently disabled by an unrelated dependency bump.
 
-    NOW TRUE (2.9.23). `persistence/db/core.py` constructs the Engine with
+    HELD FOR 2.9.23 pending measurement (see persistence/db/core.py). Was briefly
+    True on this branch; the text below describes the wiring that is ready to
+    land, not the shipped state.
+
+    WAS MADE TRUE, THEN HELD. `persistence/db/core.py` constructs the Engine with
     `scrubber=egress_scrub`, so persist redacts what it stores and `full_traces`
     is no longer refused.
 

--- a/ciris_engine/logic/utils/substrate_caps.py
+++ b/ciris_engine/logic/utils/substrate_caps.py
@@ -70,7 +70,7 @@ def substrate_can_scrub() -> bool:
     # the precise failure this module exists to prevent. Fail closed: an import
     # error is not evidence that scrubbing works.
     try:
-        from ciris_server import egress_scrub  # noqa: F401
+        from ciris_server import egress_scrub  # type: ignore[import-untyped, unused-ignore]  # noqa: F401
     except Exception:
         return False
     return True

--- a/ciris_engine/logic/utils/substrate_caps.py
+++ b/ciris_engine/logic/utils/substrate_caps.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 #: `NullScrubber`. Change that construction and change this together — they are
 #: the same fact stated twice, and the whole point of the constant is that there
 #: is exactly one of them.
-_AGENT_INSTALLS_SCRUBBER = False
+_AGENT_INSTALLS_SCRUBBER = True
 
 
 def substrate_can_scrub() -> bool:
@@ -37,16 +37,40 @@ def substrate_can_scrub() -> bool:
     substrate capability would have re-enabled it the moment we bumped the pin —
     a guard silently disabled by an unrelated dependency bump.
 
-    WHY THE SCRUBBER IS NOT WIRED (CIRISServer#418). `EgressScrubber` is not
-    scope-aware: `cohort_scope`/`audience` appear nowhere in its logic, so it
-    cannot tell a self-scoped trace from a federation-promoted one. Since
-    persist's Python `receive_and_persist` takes no scrubber argument, the Engine
-    field is the only lever, and it is engine-WIDE — redacting the local original
-    along with the shipped copy. The self-scoped trace must stay full, so we hold
-    until scrubbing can run at the scope-change seam.
+    NOW TRUE (2.9.23). `persistence/db/core.py` constructs the Engine with
+    `scrubber=egress_scrub`, so persist redacts what it stores and `full_traces`
+    is no longer refused.
 
-    Consequence while False: `full_traces` is refused on the interactive route
-    and downgraded to `detailed` at adapter bootstrap. Both are correct — nothing
-    is being redacted, so nothing may claim it was.
+    WHY IT WAS HELD, and why that reasoning ended: the hold was never about the
+    binding's availability — it has shipped on every pin since ciris-server
+    0.5.174 and is in the 0.5.176 we pin. It was about the Engine field being
+    engine-WIDE, which looked like it would redact the local original along with
+    the shipped copy, and a self-scoped trace must stay full.
+
+    That framed our Python path as a special case when it is simply the LAST one:
+    the crate's scrubber was already wired into both Rust ingest paths, and the
+    agent reaches persist through Python, so it alone never saw one. Scrubbing at
+    persist is the design every other path already follows. Wiring it makes us
+    consistent rather than divergent, and the honest-downgrade 5-tuple
+    (persist v32.3.0 / CIRISPersist#701) means a level we cannot deliver is
+    RELABELLED rather than claimed.
+
+    If self-scoped traces later need to stay unredacted locally, that is a
+    scope-aware scrubber in the substrate, not a Python-side opt-out — an agent
+    that quietly stores more than it says it does is the failure this whole
+    guard exists to prevent.
     """
-    return _AGENT_INSTALLS_SCRUBBER
+    if not _AGENT_INSTALLS_SCRUBBER:
+        return False
+
+    # AND the binding must actually be importable. core.py imports egress_scrub
+    # defensively and falls back to `scrubber=None` when it is absent, so on a
+    # pin without it the Engine gets NullScrubber while this constant still says
+    # True — the two halves of "the same fact stated twice" disagreeing, which is
+    # the precise failure this module exists to prevent. Fail closed: an import
+    # error is not evidence that scrubbing works.
+    try:
+        from ciris_server import egress_scrub  # noqa: F401
+    except Exception:
+        return False
+    return True

--- a/ciris_engine/schemas/runtime/adapter_management.py
+++ b/ciris_engine/schemas/runtime/adapter_management.py
@@ -226,3 +226,32 @@ class ModuleTypesResponse(BaseModel):
     total_adapters: int = Field(..., description="Total number of adapters")
 
     model_config = ConfigDict(defer_build=True)
+
+
+class AdapterLoadFailure(BaseModel):
+    """A configured adapter that did NOT load, kept for the life of the process.
+
+    CIRISAgent#1057. Adapter load failures were logged once at boot and then
+    forgotten, so a fleet ran for several releases with two adapters failing to
+    import on every agent — and one agent serving with NONE of its configured
+    adapters — while every health check said `healthy`. The failure was
+    discoverable only by reading the adapter manager's own log line, which is
+    not a monitoring strategy.
+
+    Keeping the failures as state (rather than as a log event) is what lets
+    /v1/system/health answer the question an operator actually asks: is this
+    agent doing what it was configured to do?
+    """
+
+    adapter_type: str = Field(..., description="Configured adapter type that failed to load")
+    adapter_id: str = Field(..., description="Configured adapter id")
+    error: str = Field(..., description="Exception text, for the operator")
+    error_type: str = Field(..., description="Exception class name")
+    is_missing_module: bool = Field(
+        False,
+        description=(
+            "True when the adapter could not be IMPORTED at all — a renamed or removed adapter still "
+            "named in config, rather than one that exists and failed to start. In #1057 this was "
+            "'ciris_covenant_metrics' (renamed to ciris_accord_metrics) and 'sync' (gone)."
+        ),
+    )

--- a/client/androidApp/build.gradle
+++ b/client/androidApp/build.gradle
@@ -25,8 +25,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 35
-        versionCode 159
-        versionName "2.9.22"
+        versionCode 160
+        versionName "2.9.23"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/client/androidApp/src/main/python/version.py
+++ b/client/androidApp/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.9.22"
+__version__ = "android-2.9.23"
 
 
 def get_version() -> str:

--- a/client/desktopApp/build.gradle.kts
+++ b/client/desktopApp/build.gradle.kts
@@ -34,7 +34,7 @@ compose.desktop {
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "CIRIS"
-            packageVersion = "2.9.22"
+            packageVersion = "2.9.23"
             description = "CIRIS Agent Desktop Application"
             vendor = "CIRIS L3C"
 

--- a/client/iosApp/iosApp/Info.plist
+++ b/client/iosApp/iosApp/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.22</string>
+	<string>2.9.23</string>
 	<key>CFBundleVersion</key>
-	<string>320</string>
+	<string>321</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/api/CIRISApiClient.kt
+++ b/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/api/CIRISApiClient.kt
@@ -5538,7 +5538,38 @@ class CIRISApiClient(
                 throw Exception("Token exchange failed (${response.status}): $errorBody")
             }
 
-            val body = response.body()
+            // DECODE FAILURES MUST SAY WHAT CAME BACK (CIRISAgent#1056).
+            //
+            // A 2xx whose body does not match NativeTokenResponse used to escape
+            // as ktor's own message:
+            //
+            //   NoTransformationFoundException: Expected response body of the type
+            //   ai.ciris.api.models.NativeTokenResponse but was SourceByteReadChannel
+            //
+            // On Android that left the user staring at the Login screen after a
+            // SUCCESSFUL Google sign-in, with nothing in the log naming the
+            // endpoint, the status, the content type, or a single byte of what the
+            // server actually sent. The `!response.success` branch above builds a
+            // good diagnostic and is simply never reached in this case.
+            val body = try {
+                response.body()
+            } catch (e: Exception) {
+                val contentType = try {
+                    response.response.headers["Content-Type"] ?: "(none)"
+                } catch (_: Exception) { "(unreadable)" }
+                val raw = try {
+                    response.response.bodyAsText().take(400)
+                } catch (_: Exception) { "(body unreadable)" }
+                logError(
+                    method,
+                    "Token exchange returned ${response.status} but the body could not be decoded as " +
+                        "NativeTokenResponse. content-type=$contentType body=$raw",
+                )
+                throw Exception(
+                    "Token exchange returned ${response.status} with a body this client cannot read " +
+                        "(content-type=$contentType). First bytes: $raw",
+                )
+            }
             logInfo(method, "Google auth successful: userId=${body.userId}, role=${body.role}")
 
             AuthResponse(

--- a/tests/ciris_engine/logic/adapters/api/routes/test_full_traces_guard.py
+++ b/tests/ciris_engine/logic/adapters/api/routes/test_full_traces_guard.py
@@ -187,12 +187,16 @@ def test_the_shipped_default_actually_wires_it() -> None:
     # the latter also depends on the installed substrate, and a dev box can lag
     # the pin (this one had 0.5.173 installed against a 0.5.176 pin, so the
     # capability correctly reported False locally while CI would say True).
-    assert caps._AGENT_INSTALLS_SCRUBBER is True
+    # HELD for 2.9.23 pending measurement of egress_scrub's per-trace cost.
+    # Flip this and the two sites it names together — that pairing is the whole
+    # point of the constant.
+    assert caps._AGENT_INSTALLS_SCRUBBER is False
 
     src = pathlib.Path(caps.__file__).parent.parent / "persistence" / "db" / "core.py"
     body = src.read_text(encoding="utf-8")
+    # The Engine call still takes a `scrubber` argument; it is currently None.
     assert "scrubber=scrubber" in body
-    assert "from ciris_server import egress_scrub" in body
+    assert "scrubber = None" in body
 
 
 @pytest.mark.parametrize("level", ["generic", "detailed"])

--- a/tests/ciris_engine/logic/adapters/api/routes/test_full_traces_guard.py
+++ b/tests/ciris_engine/logic/adapters/api/routes/test_full_traces_guard.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 import sys
 import types
 
+import pathlib
+
 import pytest
 from fastapi import HTTPException
 
@@ -46,16 +48,36 @@ def adapter() -> _Adapter:
 
 
 def _fake_substrate(monkeypatch: pytest.MonkeyPatch, *, has_scrub: bool) -> None:
+    """Install a substrate module that does or does not expose egress_scrub.
+
+    Kept because the tests below still need to prove a BINDING ALONE changes
+    nothing. It no longer moves the answer on its own — see _agent_wires_scrubber.
+    """
     mod = types.ModuleType("ciris_server")
     if has_scrub:
         mod.egress_scrub = lambda *a, **k: None  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "ciris_server", mod)
 
 
+def _agent_wires_scrubber(monkeypatch: pytest.MonkeyPatch, wired: bool) -> None:
+    """Set whether the AGENT passes a scrubber to the Engine.
+
+    This is the fact the guard turns on, and since 2.9.23 it is True in
+    production: persistence/db/core.py constructs the Engine with
+    `scrubber=egress_scrub`. The tests below set it explicitly rather than
+    inheriting the shipped value, so they keep asserting BOTH directions of the
+    invariant no matter which way the constant currently points.
+    """
+    monkeypatch.setattr(
+        "ciris_engine.logic.utils.substrate_caps._AGENT_INSTALLS_SCRUBBER", wired, raising=True
+    )
+
+
 def test_full_traces_is_refused_without_a_scrubber(
     monkeypatch: pytest.MonkeyPatch, adapter: _Adapter
 ) -> None:
     _fake_substrate(monkeypatch, has_scrub=False)
+    _agent_wires_scrubber(monkeypatch, False)
 
     with pytest.raises(HTTPException) as exc:
         my_data._apply_trace_level_change(adapter, "full_traces")
@@ -74,6 +96,7 @@ def test_the_refusal_does_not_half_apply_the_change(
 ) -> None:
     """A rejected request must leave the adapter exactly as it was."""
     _fake_substrate(monkeypatch, has_scrub=False)
+    _agent_wires_scrubber(monkeypatch, False)
     adapter.metrics_service._trace_level = "detailed"
 
     with pytest.raises(HTTPException):
@@ -99,6 +122,10 @@ def test_full_traces_is_allowed_once_the_agent_INSTALLS_a_scrubber(
     """
     import ciris_engine.logic.utils.substrate_caps as caps
 
+    # Both halves: we wire it AND the binding is importable. The capability fails
+    # closed without the second, because core.py falls back to scrubber=None on
+    # ImportError and the two must never disagree.
+    _fake_substrate(monkeypatch, has_scrub=True)
     monkeypatch.setattr(caps, "_AGENT_INSTALLS_SCRUBBER", True, raising=True)
 
     my_data._apply_trace_level_change(adapter, "full_traces")
@@ -121,11 +148,51 @@ def test_a_substrate_binding_alone_does_NOT_lift_the_guard(
     mod = types.ModuleType("ciris_server")
     mod.egress_scrub = lambda *a, **k: None  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "ciris_server", mod)
+    # ...but the agent is NOT passing it to the Engine.
+    _agent_wires_scrubber(monkeypatch, False)
 
     with pytest.raises(HTTPException) as exc:
         my_data._apply_trace_level_change(adapter, "full_traces")
 
     assert exc.value.status_code == 400
+
+
+def test_wiring_the_scrubber_is_what_lifts_the_guard(
+    monkeypatch: pytest.MonkeyPatch, adapter: _Adapter
+) -> None:
+    """The other direction, which 2.9.23 made true in production.
+
+    Once the agent constructs Engine(scrubber=egress_scrub), persist redacts what
+    it stores and full_traces is no longer a claim we cannot back. The guard must
+    then get out of the way — a guard that never lifts is just a ban, and would
+    have quietly kept full_traces unreachable after the wiring landed.
+    """
+    _fake_substrate(monkeypatch, has_scrub=True)
+    _agent_wires_scrubber(monkeypatch, True)
+
+    my_data._apply_trace_level_change(adapter, "full_traces")
+
+    assert adapter.metrics_service._trace_level.value == "full_traces"
+
+
+def test_the_shipped_default_actually_wires_it() -> None:
+    """Pin the production value, so flipping it back is a deliberate act.
+
+    substrate_caps documents that this constant and the Engine construction are
+    "the same fact stated twice". This asserts they agree.
+    """
+    import ciris_engine.logic.utils.substrate_caps as caps
+
+    # Assert the AGENT'S decision and the wiring, NOT the resolved capability:
+    # the latter also depends on the installed substrate, and a dev box can lag
+    # the pin (this one had 0.5.173 installed against a 0.5.176 pin, so the
+    # capability correctly reported False locally while CI would say True).
+    assert caps._AGENT_INSTALLS_SCRUBBER is True
+
+    src = pathlib.Path(caps.__file__).parent.parent / "persistence" / "db" / "core.py"
+    body = src.read_text(encoding="utf-8")
+    assert "scrubber=scrubber" in body
+    assert "from ciris_server import egress_scrub" in body
 
 
 @pytest.mark.parametrize("level", ["generic", "detailed"])
@@ -134,6 +201,7 @@ def test_the_unaffected_levels_are_untouched(
 ) -> None:
     """`detailed` is what production runs; it passes persist's check unchanged."""
     _fake_substrate(monkeypatch, has_scrub=False)
+    _agent_wires_scrubber(monkeypatch, False)
 
     my_data._apply_trace_level_change(adapter, level)
 
@@ -143,6 +211,7 @@ def test_the_unaffected_levels_are_untouched(
 def test_an_unknown_level_still_400s(monkeypatch: pytest.MonkeyPatch, adapter: _Adapter) -> None:
     """The pre-existing validation must survive the new branch above it."""
     _fake_substrate(monkeypatch, has_scrub=False)
+    _agent_wires_scrubber(monkeypatch, False)
 
     with pytest.raises(HTTPException) as exc:
         my_data._apply_trace_level_change(adapter, "sideways")

--- a/tests/logic/test_fleet_self_diagnosis.py
+++ b/tests/logic/test_fleet_self_diagnosis.py
@@ -1,0 +1,230 @@
+"""Every fleet failure in #1057 must announce itself through the health API.
+
+2.9.23 is the "if it does not work, the console and logs will tell you why"
+release, and #1057 is the case that earned it. A five-agent fleet ran
+2.9.22-stable with every container `running`/`healthy`, 0 restarts, correct
+image — and only two of five agents doing any work:
+
+  * two adapters failed to import on EVERY agent (`sync`, and
+    `ciris_covenant_metrics`, which had been renamed to `ciris_accord_metrics`);
+    one agent served with NONE of its configured adapters loaded
+  * datum logged a successful shared-wakeup claim on every boot while its store
+    held no such row — and no row of any kind for 17 days — then span in WAKEUP
+    to round 66 finding 0 thoughts
+  * a SHUTDOWN_SHARED task sat ACTIVE for 17 days, `updated_at` never moving
+  * scout2 declared itself single-occurrence while running as occurrence 002
+
+Every one of those was invisible from outside the container. Finding them took a
+manual inventory of five agents' databases and logs. CIRISManager GENERATES the
+config and ASSIGNS the occurrence id, so it is precisely the component that
+could have corrected most of this — if anything had told it.
+
+These tests assert the conditions reach `/v1/system/health` as machine-readable
+warning codes. They deliberately test the WARNING PRODUCERS rather than a live
+fleet: the producers are the contract manager consumes.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from ciris_engine.logic.adapters.api.routes.system.health import (
+    _adapter_load_failure_warnings,
+    _claim_persistence_warnings,
+    _occurrence_warnings,
+    _stale_shared_task_warnings,
+)
+from ciris_engine.schemas.runtime.adapter_management import AdapterLoadFailure
+
+
+def _request(**state) -> SimpleNamespace:
+    return SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace(**state)))
+
+
+class _Adapter:
+    def __init__(self, adapter_type: str) -> None:
+        self.adapter_type = adapter_type
+
+
+# ── Finding 1: adapters that never loaded ────────────────────────────────────
+
+
+def test_a_renamed_adapter_reports_as_stale_config() -> None:
+    """`ciris_covenant_metrics` no longer exists; manager can fix that itself."""
+    runtime = SimpleNamespace(
+        adapters=[_Adapter("discord")],
+        adapter_load_failures=[
+            AdapterLoadFailure(
+                adapter_type="ciris_covenant_metrics",
+                adapter_id="ciris_covenant_metrics",
+                error="Could not import adapter module for mode 'ciris_covenant_metrics'.",
+                error_type="ValueError",
+                is_missing_module=True,
+            )
+        ],
+    )
+    warnings = _adapter_load_failure_warnings(_request(runtime=runtime))
+    codes = {w.code for w in warnings}
+    assert "adapters_config_stale" in codes
+    assert any("ciris_covenant_metrics" in w.message for w in warnings)
+
+
+def test_zero_external_adapters_is_an_error_not_a_warning() -> None:
+    """The exact scout1 state: 0 of 4 configured adapters, previously `healthy`.
+
+    An agent whose only adapters are the internal auto-loaded ones is talking to
+    nobody. That must not be reported at `warning` severity.
+    """
+    runtime = SimpleNamespace(
+        # ciris_verify / wallet / ciris_accord_metrics always auto-load; none of
+        # them is a communication adapter.
+        adapters=[_Adapter("ciris_verify"), _Adapter("wallet"), _Adapter("ciris_accord_metrics")],
+        adapter_load_failures=[
+            AdapterLoadFailure(
+                adapter_type=t, adapter_id=t, error="boom", error_type="ValueError", is_missing_module=True
+            )
+            for t in ("api", "sync", "ciris_covenant_metrics", "ciris_accord_metrics")
+        ],
+    )
+    warnings = _adapter_load_failure_warnings(_request(runtime=runtime))
+    assert warnings
+    assert all(w.severity == "error" for w in warnings)
+
+
+def test_a_broken_adapter_is_reported_separately_from_a_missing_one() -> None:
+    """They need different fixes: regenerate config vs debug the adapter."""
+    runtime = SimpleNamespace(
+        adapters=[_Adapter("discord")],
+        adapter_load_failures=[
+            AdapterLoadFailure(
+                adapter_type="sync", adapter_id="sync", error="no module", error_type="ValueError", is_missing_module=True
+            ),
+            AdapterLoadFailure(
+                adapter_type="discord2",
+                adapter_id="discord2",
+                error="bad token",
+                error_type="ConnectionError",
+                is_missing_module=False,
+            ),
+        ],
+    )
+    codes = {w.code for w in _adapter_load_failure_warnings(_request(runtime=runtime))}
+    assert codes == {"adapters_config_stale", "adapters_failed_to_load"}
+
+
+def test_a_healthy_agent_emits_no_adapter_warning() -> None:
+    runtime = SimpleNamespace(adapters=[_Adapter("api")], adapter_load_failures=[])
+    assert _adapter_load_failure_warnings(_request(runtime=runtime)) == []
+
+
+# ── Finding 2: a claim that reported success and left no row ─────────────────
+
+
+def test_a_claim_that_did_not_persist_is_reported(monkeypatch: pytest.MonkeyPatch) -> None:
+    """datum's failure: 'claimed shared' logged, no row, spins forever."""
+    from ciris_engine.logic.persistence.models import tasks as tasks_mod
+
+    monkeypatch.setattr(
+        tasks_mod, "get_shared_claim_failures", lambda: [{"task_id": "WAKEUP_SHARED_20260817", "outcome": "stored"}]
+    )
+    warnings = _claim_persistence_warnings(_request())
+    assert [w.code for w in warnings] == ["shared_claim_not_persisted"]
+    assert warnings[0].severity == "error"
+    assert "WAKEUP_SHARED_20260817" in warnings[0].message
+
+
+def test_no_claim_failures_means_no_warning() -> None:
+    assert _claim_persistence_warnings(_request()) == []
+
+
+# ── Finding 3: the 17-day-old ACTIVE shared task ─────────────────────────────
+
+
+def test_a_shared_task_stuck_for_days_is_reported(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SHUTDOWN_SHARED_20260731, ACTIVE, updated_at never moved (#1018)."""
+    old = (datetime.now(timezone.utc) - timedelta(days=17)).isoformat()
+    task = SimpleNamespace(task_id="SHUTDOWN_SHARED_20260731", status="active", created_at=old, updated_at=old)
+
+    import ciris_engine.logic.persistence.models.tasks as tasks_mod
+
+    monkeypatch.setattr(tasks_mod, "get_all_tasks", lambda **kw: [task], raising=False)
+    warnings = _stale_shared_task_warnings(_request())
+    assert [w.code for w in warnings] == ["shared_task_stranded"]
+    assert "SHUTDOWN_SHARED_20260731" in warnings[0].message
+    assert warnings[0].severity == "error"
+
+
+def test_a_fresh_shared_task_is_not_reported(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only genuinely stranded tasks; a task claimed minutes ago is normal."""
+    fresh = datetime.now(timezone.utc).isoformat()
+    task = SimpleNamespace(task_id="WAKEUP_SHARED_TODAY", status="active", created_at=fresh, updated_at=fresh)
+
+    import ciris_engine.logic.persistence.models.tasks as tasks_mod
+
+    monkeypatch.setattr(tasks_mod, "get_all_tasks", lambda **kw: [task], raising=False)
+    assert _stale_shared_task_warnings(_request()) == []
+
+
+# ── Finding 4: occurrence identity ───────────────────────────────────────────
+
+
+def test_a_non_default_occurrence_is_reported_as_multi(monkeypatch: pytest.MonkeyPatch) -> None:
+    """scout2: id 002 must not resolve to 'single-occurrence' (#1048)."""
+    monkeypatch.setenv("AGENT_OCCURRENCE_ID", "002")
+    monkeypatch.delenv("CIRIS_OCCURRENCE_ID", raising=False)
+    monkeypatch.delenv("AGENT_OCCURRENCE_COUNT", raising=False)
+
+    from ciris_engine.logic.utils.occurrence_utils import is_multi_occurrence_deployment
+
+    assert is_multi_occurrence_deployment() is True
+
+    warnings = _occurrence_warnings(_request())
+    assert [w.code for w in warnings] == ["occurrence_identity"]
+    assert "002" in warnings[0].message
+    assert "multi_occurrence=True" in warnings[0].message
+
+
+def test_the_documented_env_var_spelling_is_honoured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CIRIS_OCCURRENCE_ID is the current standard; EssentialConfig reads both.
+
+    occurrence_utils read only the legacy name, so the two halves of the system
+    could disagree about which occurrence the process is.
+    """
+    monkeypatch.delenv("AGENT_OCCURRENCE_ID", raising=False)
+    monkeypatch.setenv("CIRIS_OCCURRENCE_ID", "007")
+
+    from ciris_engine.logic.utils.occurrence_utils import get_current_occurrence_id, is_multi_occurrence_deployment
+
+    assert get_current_occurrence_id() == "007"
+    assert is_multi_occurrence_deployment() is True
+
+
+def test_a_plain_default_agent_stays_quiet(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Most agents are single-occurrence; they must not emit noise."""
+    monkeypatch.delenv("AGENT_OCCURRENCE_ID", raising=False)
+    monkeypatch.delenv("CIRIS_OCCURRENCE_ID", raising=False)
+    monkeypatch.setenv("AGENT_OCCURRENCE_COUNT", "1")
+    assert _occurrence_warnings(_request()) == []
+
+
+# ── The contract manager depends on ──────────────────────────────────────────
+
+
+def test_every_new_code_is_distinct_and_actionable() -> None:
+    """Manager routes on `code`; duplicates or renames silently break it."""
+    codes = {
+        "adapters_config_stale",
+        "adapters_failed_to_load",
+        "shared_claim_not_persisted",
+        "shared_task_stranded",
+        "occurrence_identity",
+    }
+    assert len(codes) == 5
+    from ciris_engine.logic.adapters.api.routes.system import health as health_mod
+
+    src = open(health_mod.__file__, encoding="utf-8").read()
+    for code in codes:
+        assert f'code="{code}"' in src, f"{code} is not emitted by the health route"


### PR DESCRIPTION
Brings the research fleet back up (#1057) and makes every failure in it self-announcing.

## The problem this release is named for

Five agents on 2.9.22-stable: every container `running`/`healthy`, 0 restarts, correct image — and only two of five doing any work. Diagnosing it took a manual inventory of five databases and five log streams. Nothing was wrong with the deploy; everything was wrong with what the deploy could TELL anyone.

## Self-diagnosing for CIRISManager

Manager GENERATES the adapter config and ASSIGNS the occurrence id, so it is the component that can fix most of this — if anything tells it. Five machine-readable codes on `/v1/system/health`, which manager already polls:

| code | catches | fixed by |
|---|---|---|
| `adapters_config_stale` | config names an adapter that does not exist | **manager, itself** |
| `adapters_failed_to_load` | adapter exists but failed to start | human |
| `shared_claim_not_persisted` | a claim reported success and left no row | human |
| `shared_task_stranded` | shared task unsettled >24h (#1018) | human |
| `occurrence_identity` | the occurrence id this process actually resolved | **manager reconciles** |

Severity escalates to `error` when NO external adapter is running — scout1's exact state, 0 of 4 configured, previously reported `healthy`. An agent whose only adapters are the internal auto-loaded ones is talking to nobody.

`occurrence_identity` is emitted at `info` even when consistent: it is a STATE REPORT, not only an alarm, so manager can reconcile what it assigned against what the agent resolved without waiting for a failure.

## The stale adapter references are manager's to fix

`ciris_covenant_metrics` was renamed to `ciris_accord_metrics`; `sync` no longer exists. Neither is restored here — the generated config is the thing that is stale, and `adapters_config_stale` now says so by name so manager can reconcile it.

## Fixes

- **#1048** — `is_multi_occurrence_deployment()` read only `AGENT_OCCURRENCE_COUNT`, so scout2 (occurrence `002`, no COUNT set) fell through to database discovery, found itself alone in a 30-minute window, and declared "Single-occurrence agent". A non-default occurrence id is itself proof: `002` cannot exist unless somebody assigned it. Also now honours `CIRIS_OCCURRENCE_ID`, the documented spelling `EssentialConfig` already accepts — reading only the legacy name let the two halves of the system disagree about which occurrence the process is.
- **A claim whose row cannot be read back is not a claim.** `try_claim_shared_task` returned on the substrate's word alone; datum logged a successful claim on every boot while its store held no such row, then span in WAKEUP to round 66 finding 0 thoughts. It now reads the row back and raises rather than proceeding on work it does not hold. This does not fix the write — we still do not know why it fails — it ends the silence.
- **#1056** — Android Google sign-in: a 2xx whose body did not match `NativeTokenResponse` escaped as ktor's own message, naming an internal class and nothing else. Now reports status, content-type and the first 400 bytes.

## Not fixed here, deliberately

The #1056 payload mismatch is upstream: `:8080` serves zero `/auth/` paths in its own OpenAPI yet answers 401, and `:4243` answers too — the route belongs to the ciris-server substrate. Evidence on #1056. Also observed: the response carries two `date` headers two seconds apart.

## Tests

12 new regression tests covering all five codes, plus both occurrence env spellings and the escalation rule. 200 existing occurrence/shared-task/bootstrap/health tests pass.