### PR TITLE
2.9.31 — BYOK setup wizard: reachable Test Connection + break the model chicken-and-egg

### DIFF
--- a/BUILD_INFO.txt
+++ b/BUILD_INFO.txt
@@ -1,8 +1,8 @@
 # Build Information
-Code Hash: 5870b556d0ca
-Build Time: 2026-08-21T10:11:03.202518
-Git Commit: 65a0f925534add5d4f6822a93e549cbbd16edb12
-Git Branch: fix/2.9.29-nullworks-rc3-findings
+Code Hash: 8f5bf9d8bcf7
+Build Time: 2026-08-21T19:11:19.704386
+Git Commit: c26cb366a61849e98ceffa973bbdf2c47e2fb0fc
+Git Branch: fix/byok-wizard-automation
 
 This hash is a SHA-256 of all Python source files in the repository.
 It provides a deterministic version identifier based on the actual code content.

--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -6,11 +6,11 @@ from typing import List
 from ciris_engine.schemas.runtime.canonical_peer import CanonicalBootstrapPeer
 
 # Version information
-CIRIS_VERSION = "2.9.30-stable"
+CIRIS_VERSION = "2.9.31-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
 CIRIS_VERSION_MINOR = 9
-CIRIS_VERSION_PATCH = 30
+CIRIS_VERSION_PATCH = 31
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/client/androidApp/build.gradle
+++ b/client/androidApp/build.gradle
@@ -25,8 +25,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 35
-        versionCode 167
-        versionName "2.9.30"
+        versionCode 168
+        versionName "2.9.31"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/client/androidApp/src/main/python/version.py
+++ b/client/androidApp/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.9.30"
+__version__ = "android-2.9.31"
 
 
 def get_version() -> str:

--- a/client/desktopApp/build.gradle.kts
+++ b/client/desktopApp/build.gradle.kts
@@ -34,7 +34,7 @@ compose.desktop {
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "CIRIS"
-            packageVersion = "2.9.30"
+            packageVersion = "2.9.31"
             description = "CIRIS Agent Desktop Application"
             vendor = "CIRIS L3C"
 

--- a/client/iosApp/iosApp/Info.plist
+++ b/client/iosApp/iosApp/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.30</string>
+	<string>2.9.31</string>
 	<key>CFBundleVersion</key>
-	<string>328</string>
+	<string>329</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/api/LlmConfigCheck.kt
+++ b/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/api/LlmConfigCheck.kt
@@ -98,9 +98,26 @@ data class LlmConfigCheck(
  * Run the whole check against a provider's real endpoint.
  *
  * Both the wizard and LLM settings call THIS, so they cannot drift apart again.
- * Ordered deliberately: the key is checked first, and a rejected key
- * short-circuits, because "list models" against a bad credential returns a
- * confusing secondary error that buries the real one.
+ *
+ * ORDERING — and why it is not simply "validate then list":
+ *
+ * `validateLlmConfiguration` (POST /v1/setup/validate-llm) REFUSES a probe that
+ * names no model: since CIRISAgent#1078 ("a credential probe must not assume a
+ * model") it returns `valid=false, "No model selected"` when `model` is empty.
+ * That is correct for the pipeline probe, but it means validate cannot be the
+ * key gate on a FRESH setup — no model is chosen until the dropdown loads, and
+ * the dropdown loads from `listModels`, so gating listing behind a validate that
+ * demands a model is an unbreakable chicken-and-egg (CIRISAgent#1062 follow-up:
+ * the wizard showed "No model selected" and never populated the dropdown).
+ *
+ * So the gate depends on whether we already have a model to name:
+ *   - model in hand  -> validate it first (it may be a model the provider does
+ *     not serve, and validate surfaces that precisely); a rejected key still
+ *     short-circuits so its error is not buried by a secondary listing error.
+ *   - no model yet   -> SKIP validate and let `listModels` be the credential
+ *     check. Listing hits the same provider with the same key, so a live list is
+ *     itself proof the key authenticates; a thrown error is the real key/reach
+ *     failure, reported as such.
  */
 suspend fun CIRISApiClient.checkLlmConfig(
     provider: String,
@@ -118,32 +135,42 @@ suspend fun CIRISApiClient.checkLlmConfig(
         )
     }
 
-    val validation = try {
-        validateLlmConfiguration(provider = provider, apiKey = apiKey, baseUrl = baseUrl, model = selectedModel)
-    } catch (e: Exception) {
-        return LlmConfigCheck(
-            key = CheckState.FAILED,
-            keyMessage = e.message ?: "Could not reach the provider.",
-        )
-    }
+    val hasModel = !selectedModel.isNullOrBlank()
 
-    if (!validation.valid) {
-        // Stop here on purpose. Listing models with a rejected credential
-        // produces a second, less informative error that hides the first.
-        return LlmConfigCheck(
-            key = CheckState.FAILED,
-            keyMessage = validation.error ?: validation.message,
-        )
+    // Explicit credential probe ONLY when a model is already named — otherwise
+    // #1078 refuses it and we would report a false key failure (see above).
+    var validationMessage: String? = null
+    if (hasModel) {
+        val validation = try {
+            validateLlmConfiguration(provider = provider, apiKey = apiKey, baseUrl = baseUrl, model = selectedModel)
+        } catch (e: Exception) {
+            return LlmConfigCheck(
+                key = CheckState.FAILED,
+                keyMessage = e.message ?: "Could not reach the provider.",
+            )
+        }
+        if (!validation.valid) {
+            // Stop here on purpose. Listing models with a rejected credential
+            // produces a second, less informative error that hides the first.
+            return LlmConfigCheck(
+                key = CheckState.FAILED,
+                keyMessage = validation.error ?: validation.message,
+            )
+        }
+        validationMessage = validation.message
     }
 
     val listed = try {
         listModels(provider = provider, apiKey = apiKey, baseUrl = baseUrl)
     } catch (e: Exception) {
+        // With a model already validated the key is known good, so a listing
+        // error is purely a models failure. Without one, listing WAS the key
+        // check, so its failure is the key's.
         return LlmConfigCheck(
-            key = CheckState.OK,
-            keyMessage = validation.message,
-            models = CheckState.FAILED,
-            modelsMessage = e.message ?: "Could not list models.",
+            key = if (hasModel) CheckState.OK else CheckState.FAILED,
+            keyMessage = if (hasModel) validationMessage else (e.message ?: "The API key was rejected or the provider is unreachable."),
+            models = if (hasModel) CheckState.FAILED else CheckState.UNKNOWN,
+            modelsMessage = if (hasModel) (e.message ?: "Could not list models.") else null,
         )
     }
 
@@ -151,6 +178,15 @@ suspend fun CIRISApiClient.checkLlmConfig(
         listed.isLive && listed.models.isNotEmpty() -> CheckState.OK
         listed.models.isEmpty() -> CheckState.FAILED
         else -> CheckState.DEGRADED
+    }
+
+    // On the no-model path a LIVE list is proof the key authenticates; a
+    // non-live/empty list can't distinguish a bad key from a provider hiccup, so
+    // leave the key UNKNOWN and let the models row carry the detail.
+    val keyState = when {
+        hasModel -> CheckState.OK
+        modelsState == CheckState.OK -> CheckState.OK
+        else -> CheckState.UNKNOWN
     }
 
     // Only judge the selected model against a LIVE list. Marking it missing
@@ -163,8 +199,8 @@ suspend fun CIRISApiClient.checkLlmConfig(
     }
 
     return LlmConfigCheck(
-        key = CheckState.OK,
-        keyMessage = validation.message,
+        key = keyState,
+        keyMessage = validationMessage,
         models = modelsState,
         modelsMessage = listed.error,
         selectedModel = selectedState,

--- a/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/screens/SetupScreen.kt
+++ b/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/screens/SetupScreen.kt
@@ -1609,13 +1609,19 @@ private fun AiStep(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            // Test Connection button
-            OutlinedButton(
-                onClick = {
-                    if (!isTesting) {
-                        isTesting = true
-                        testResult = null
-                        coroutineScope.launch(Dispatchers.Default) {
+            // Test Connection action.
+            //
+            // Bound to BOTH the real tap (onClick) and the UI-automation click
+            // path (testableClickable on the button below). This button used to
+            // carry `testable(...)` — position only, NOT reachable via the test
+            // server's /click — so automation could never trigger it and the
+            // live BYOK model dropdown (#1062) never populated under test.
+            // Extracting the action lets both the human and the harness run it.
+            val runTestConnection: () -> Unit = {
+                if (!isTesting) {
+                    isTesting = true
+                    testResult = null
+                    coroutineScope.launch(Dispatchers.Default) {
                             try {
                                 // Provider is now stored as key directly (e.g., "openai", "local")
                                 val providerId = state.llmProvider
@@ -1673,8 +1679,13 @@ private fun AiStep(
                             }
                         }
                     }
-                },
-                modifier = Modifier.fillMaxWidth().testable("btn_test_connection"),
+                }
+
+            OutlinedButton(
+                onClick = runTestConnection,
+                // testableClickable (not testable): the /click endpoint must be
+                // able to fire this so UI automation can list BYOK models.
+                modifier = Modifier.fillMaxWidth().testableClickable("btn_test_connection") { runTestConnection() },
                 enabled = !isTesting && (isLocalProvider || isMobileLocalProvider || state.llmApiKey.isNotEmpty()),
                 colors = ButtonDefaults.outlinedButtonColors(
                     contentColor = SetupColors.Primary

--- a/tools/qa_runner/modules/mobile/ios_physical_test_cases.py
+++ b/tools/qa_runner/modules/mobile/ios_physical_test_cases.py
@@ -823,6 +823,102 @@ def _resolve_udid(helper: IDeviceHelper) -> Optional[str]:
     return None
 
 
+def _sanitize_model_tag(model_id: str) -> str:
+    """Mirror SetupScreen.kt's ``menu_model_${model.id.replace("/","_").replace(":","_")}``.
+
+    The live-model dropdown item testTags are derived from the provider's model
+    id with ``/`` and ``:`` swapped for ``_``. Keep this in lockstep with the
+    Kotlin composable or the automation clicks a tag that doesn't exist.
+    """
+    return model_id.replace("/", "_").replace(":", "_")
+
+
+def _select_from_model_dropdown(client: "TestAutomationClient", model_tag: str, llm_model: str) -> Tuple[bool, str]:
+    """Open the live-model dropdown and pick a model.
+
+    The ``ExposedDropdownMenu`` composes its ``menu_model_*`` items only while
+    expanded, so we click the ``input_llm_model`` anchor first, THEN read the
+    tree for the option tags. Prefer the requested model; otherwise take the
+    first offered option (the provider list is CIRIS-sorted, recommended-first,
+    and the app auto-selects the recommended one — clicking the first option
+    just makes that explicit so Finish is never blocked on an empty selection).
+    """
+    client.click("input_llm_model")
+    time.sleep(1)
+    menu_tags = [t for t in client.tree() if t.startswith("menu_model_")]
+    if model_tag and f"menu_model_{model_tag}" in menu_tags:
+        client.click(f"menu_model_{model_tag}")
+        return True, f"selected requested model {llm_model!r} from live dropdown"
+    if menu_tags:
+        client.click(menu_tags[0])
+        return True, f"selected {menu_tags[0]} (first of {len(menu_tags)} live models)"
+    return True, "model dropdown present but empty; provider default stands"
+
+
+def _drive_llm_wizard_step(
+    client: "TestAutomationClient",
+    llm_provider: str,
+    llm_api_key: str,
+    llm_model: str,
+) -> Tuple[bool, str]:
+    """Drive the wizard's 'AI' step (LLM provider / key / model).
+
+    Since 2.9.30 (#1062) the model field is *adaptive*. Once a valid BYOK key
+    yields a live model list from the provider, the free-text
+    ``input_llm_model_text`` field is replaced by a read-only dropdown
+    (``input_llm_model`` anchor + one ``menu_model_<sanitized-id>`` per listed
+    model). Before validation — or with no key at all (mock path) — the text
+    field remains. This helper accommodates BOTH shapes: it waits out the
+    provider round-trip for a BYOK key and selects from the dropdown, and falls
+    back to typing into the text field when no live list appears.
+    """
+    # 1. Provider selection (dropdown toggled by input_llm_provider).
+    if client.click("input_llm_provider"):
+        time.sleep(1)
+        client.click(f"menu_provider_{llm_provider}")
+        time.sleep(1)
+
+    # 2. API key.
+    if llm_api_key:
+        client.input("input_api_key", llm_api_key)
+        time.sleep(1)
+
+    model_tag = _sanitize_model_tag(llm_model) if llm_model else ""
+
+    # 3. Model. Entering a key does NOT list models on its own — the wizard
+    #    runs the shared checkLlmConfig probe only when "Test Connection" is
+    #    tapped (SetupScreen.kt), which then populates the live-model dropdown
+    #    and auto-selects a recommended model. So for a BYOK key we tap
+    #    btn_test_connection, then give the provider round-trip a generous
+    #    window before deciding it's a text-only step.
+    if llm_api_key:
+        client.click("btn_test_connection")
+        time.sleep(2)
+        deadline = time.time() + 25.0
+        while time.time() < deadline:
+            tags = set(client.tree())
+            if "input_llm_model" in tags:
+                return _select_from_model_dropdown(client, model_tag, llm_model)
+            if "input_llm_model_text" not in tags:
+                # Step still rendering — neither widget yet.
+                time.sleep(1)
+                continue
+            # Text field present but the model list may still be loading.
+            time.sleep(1.5)
+        # Live list never arrived; fall through to the text fallback below.
+
+    tags = set(client.tree())
+    if "input_llm_model_text" in tags:
+        if llm_model:
+            client.input("input_llm_model_text", llm_model)
+            return True, f"typed model {llm_model!r} into text field (no live list)"
+        return True, "no model specified; using provider/mock default"
+    if "input_llm_model" in tags:
+        # Dropdown appeared late (e.g. after the wait window); use it.
+        return _select_from_model_dropdown(client, model_tag, llm_model)
+    return True, "no model widget present; leaving provider default"
+
+
 def test_physical_ui_login(helper: IDeviceHelper, ui: PhysicalDeviceUIHelper, config: dict) -> TestReport:
     """Drive a real UI login on the device via the in-app test-automation server.
 
@@ -973,17 +1069,12 @@ def test_physical_ui_login(helper: IDeviceHelper, ui: PhysicalDeviceUIHelper, co
         time.sleep(3)
 
         # ── Step 3 "AI": LLM provider / key / model ──
+        # Adaptive model widget since 2.9.30 (#1062): a valid BYOK key + Test
+        # Connection yields a live-model dropdown; otherwise a free-text field.
+        # _drive_llm_wizard_step accommodates both.
         print(f"  [5e] 'AI' step: LLM provider={llm_provider} model={llm_model or '(default)'}...")
-        if client.click("input_llm_provider"):
-            time.sleep(1)
-            client.click(f"menu_provider_{llm_provider}")
-            time.sleep(1)
-        if llm_api_key:
-            client.input("input_api_key", llm_api_key)
-            time.sleep(1)
-        if llm_model:
-            client.input("input_llm_model_text", llm_model)
-            time.sleep(1)
+        ai_ok, ai_msg = _drive_llm_wizard_step(client, llm_provider, llm_api_key, llm_model)
+        print(f"       LLM step: {ai_msg}")
 
         # ── Finish → "CLAIM then COMPLETE" (exercises the claim_pin file read) ──
         print("  [5f] Finishing setup — self-claim + complete...")

--- a/tools/qa_runner/modules/web_ui/__main__.py
+++ b/tools/qa_runner/modules/web_ui/__main__.py
@@ -329,6 +329,91 @@ class DesktopAppTestRunner:
 
         return all(r.success for r in self.results)
 
+    async def _drive_llm_step_byok(
+        self,
+        provider: str,
+        api_key: str,
+        model: Optional[str],
+    ) -> None:
+        """Drive the AI step's BYOK path: provider → key → Test Connection → model.
+
+        Since 2.9.30 (#1062) the model field is adaptive. Once a valid key +
+        Test Connection yields a live model list, the free-text
+        ``input_llm_model_text`` is replaced by a dropdown (``input_llm_model``
+        anchor + one ``menu_model_<sanitized-id>`` per model). The live list
+        only appears AFTER btn_test_connection runs the shared checkLlmConfig
+        probe, so we must click it (it is now testableClickable, the fix under
+        test) before waiting for the dropdown. Falls back to the text field
+        when no live list appears.
+        """
+        assert self.helper is not None
+
+        def _model_tag(model_id: str) -> str:
+            # Mirror SetupScreen.kt: menu_model_${id.replace("/","_").replace(":","_")}
+            return model_id.replace("/", "_").replace(":", "_")
+
+        async def _tags() -> set:
+            return {e.test_tag for e in await self.helper.get_elements()}
+
+        self._log(f"AI (BYOK): provider={provider} model={model or '(auto)'}")
+
+        # 1. Provider.
+        if not await self.helper.click("input_llm_provider"):
+            raise RuntimeError("Failed to open LLM provider dropdown")
+        if not await self.helper.wait_for_element(f"menu_provider_{provider}", timeout=4000):
+            raise RuntimeError(f"menu_provider_{provider} not found in provider dropdown")
+        await self.helper.click(f"menu_provider_{provider}")
+        await asyncio.sleep(0.3)
+
+        # 2. API key.
+        if not await self.helper.input_text("input_api_key", api_key):
+            raise RuntimeError("Failed to enter API key (input_api_key)")
+        await asyncio.sleep(0.3)
+
+        # 3. Test Connection — populates the live-model dropdown (the fix: this
+        #    button is now testableClickable, so /click can fire it). Retry it a
+        #    few times: on a freshly-wiped node the backend/node can still be
+        #    warming when the first probe fires, so listModels throws and no
+        #    dropdown appears. Each attempt re-runs the whole checkLlmConfig.
+        model_tag = _model_tag(model) if model else ""
+        for attempt in range(1, 6):
+            if not await self.helper.click("btn_test_connection"):
+                raise RuntimeError(
+                    "Failed to click btn_test_connection — is the app built with the "
+                    "testableClickable fix? (#1062)"
+                )
+            self._log(f"AI (BYOK): Test Connection attempt {attempt}/5")
+            # One checkLlmConfig cycle (validate + listModels) is a few seconds;
+            # give it up to 18s to surface the dropdown before retrying.
+            inner_deadline = time.time() + 18
+            while time.time() < inner_deadline:
+                tags = await _tags()
+                if "input_llm_model" in tags:
+                    await self.helper.click("input_llm_model")
+                    await asyncio.sleep(0.6)
+                    menu = sorted(t for t in await _tags() if t.startswith("menu_model_"))
+                    if model_tag and f"menu_model_{model_tag}" in menu:
+                        await self.helper.click(f"menu_model_{model_tag}")
+                        self._log(f"AI (BYOK): selected requested model {model!r} from live dropdown")
+                    elif menu:
+                        await self.helper.click(menu[0])
+                        self._log(f"AI (BYOK): selected {menu[0]} (first of {len(menu)} live models)")
+                    else:
+                        self._log("AI (BYOK): model dropdown present but empty; provider default stands")
+                    return
+                await asyncio.sleep(1)
+            # No dropdown this cycle. Let the node warm before the next attempt.
+            self._log(f"AI (BYOK): no live list on attempt {attempt}; node may be warming, retrying")
+            await asyncio.sleep(4)
+
+        # 4. Still no live list after retries → text fallback so setup can finish.
+        tags = await _tags()
+        if "input_llm_model_text" in tags and model:
+            await self.helper.input_text("input_llm_model_text", model)
+            self._log(f"AI (BYOK): typed model {model!r} into text field (no live list appeared)")
+        else:
+            self._log("AI (BYOK): no live model list appeared after retries; leaving provider/text default")
+
     async def test_setup_wizard_flow(
         self,
         username: str = "admin",
@@ -337,6 +422,9 @@ class DesktopAppTestRunner:
         announce: bool = True,
         trace_opt_in: bool = True,
         age_band: str = "adult",
+        llm_provider: Optional[str] = None,
+        llm_api_key: Optional[str] = None,
+        llm_model: Optional[str] = None,
     ) -> bool:
         """Drive the first-run setup wizard via the test server.
 
@@ -517,7 +605,12 @@ class DesktopAppTestRunner:
             if not await self.helper.wait_for_element("input_llm_provider", timeout=6000):
                 self._log("No AI screen (node-client build) — the wizard is finishing")
                 return
-            if await self.helper.is_element_visible("btn_use_free_ai"):
+            if llm_api_key:
+                # BYOK path (#1062): real provider + key + Test Connection +
+                # live-model dropdown. This exercises the accommodation that
+                # made btn_test_connection reachable by automation.
+                await self._drive_llm_step_byok(llm_provider or "openrouter", llm_api_key, llm_model)
+            elif await self.helper.is_element_visible("btn_use_free_ai"):
                 # CIRIS-hosted proxy option (OAuth path) — no key entry needed.
                 self._log("AI: choosing CIRIS-hosted option (btn_use_free_ai)")
                 if not await self.helper.click("btn_use_free_ai"):
@@ -864,6 +957,32 @@ Examples:
         "--no-trace-opt-in",
         action="store_true",
         help="For desktop-setup/desktop-catchup: announce but don't opt into reasoning traces",
+    )
+    # BYOK LLM options for the desktop-setup AI step. Without a key the AI step
+    # takes the keyless 'local' provider (works with --mock-llm). With a key it
+    # drives the real BYOK path: provider + key + Test Connection + live-model
+    # dropdown (#1062).
+    parser.add_argument(
+        "--llm-provider",
+        default=None,
+        help="For desktop-setup: BYOK provider id (e.g. openrouter, groq, together). "
+        "Omit for the keyless 'local' provider.",
+    )
+    parser.add_argument(
+        "--llm-key",
+        default=None,
+        help="For desktop-setup: BYOK API key literal (prefer --llm-key-file).",
+    )
+    parser.add_argument(
+        "--llm-key-file",
+        default=None,
+        help="For desktop-setup: file holding the BYOK API key (e.g. ~/.openrouter_key).",
+    )
+    parser.add_argument(
+        "--llm-model",
+        default=None,
+        help="For desktop-setup: exact model id to select from the live dropdown "
+        "(default: whatever the wizard auto-selects as recommended).",
     )
 
     # Browser options
@@ -2249,12 +2368,22 @@ async def run_desktop_tests(args: argparse.Namespace) -> int:
             # First-run wizard (2.9.14, three screens):
             #   YOU (fed-ID + account + age) → JOIN_FEDERATION (consent)
             #   → [AI] → COMPLETE
+            _byok_key = args.llm_key
+            if not _byok_key and args.llm_key_file:
+                _key_path = Path(args.llm_key_file).expanduser()
+                if _key_path.is_file():
+                    _byok_key = _key_path.read_text().strip()
+                else:
+                    print(f" [WARN] --llm-key-file not found: {_key_path} — falling back to keyless local")
             success = await runner.test_setup_wizard_flow(
                 username=args.username or TEST_ADMIN_USERNAME,
                 password=args.password or TEST_ADMIN_PASSWORD,
                 fed_label=args.fed_label,
                 announce=not args.no_announce,
                 trace_opt_in=not args.no_trace_opt_in,
+                llm_provider=args.llm_provider,
+                llm_api_key=_byok_key,
+                llm_model=args.llm_model,
             )
             runner.print_summary()
             return 0 if success else 1


### PR DESCRIPTION
## Summary

Fixes the **BYOK (bring-your-own-key) path** of the 2.9.30 setup wizard so a user can actually reach and pick a live model, plus the UI-automation that exercises it on desktop and iOS. Validated **end-to-end on macOS**: setup (OpenRouter + Llama-4-Maverick) → login → agent in WORK on the real model → real chat reply.

### The three fixes

1. **`btn_test_connection` was unreachable by automation** (`SetupScreen.kt`). The live-model dropdown only populates after the shared `checkLlmConfig` probe runs, triggered by "Test Connection" — but that button carried `testable(...)` (position only), so the test server's `/click` could never fire it. Extracted the action into a lambda bound to **both** `onClick` and `testableClickable("btn_test_connection")`.

2. **checkLlmConfig chicken-and-egg** (`LlmConfigCheck.kt`). On a fresh BYOK setup, the check validated the credential first, passing the *empty* selected model to validate-llm. Since #1078 ("a credential probe must not assume a model") the backend refuses that with `valid=false, "No model selected"`, and the check treated any `!valid` as a **key failure**, short-circuiting before it ever listed models — so the dropdown never populated and the wizard showed "No model selected" as if the key were bad. Now: when no model is selected yet, **skip validate and let `listModels` be the credential check** (a live list is itself proof the key authenticates). When a model is in hand, validate it first (unchanged). Both the wizard and LLM Settings call this, so both are fixed.

3. **UI automation accommodation** (`ios_physical_test_cases.py`, `web_ui/__main__.py`). Both platforms now drive the adaptive model widget: tap Test Connection (retried while a fresh node warms), select from the live `menu_model_<id>` dropdown, fall back to `input_llm_model_text` when no live list appears. `desktop-setup` gains `--llm-provider/--llm-key(-file)/--llm-model`.

## Testing

- **macOS desktop BYOK: E2E green.** Automated wizard (OpenRouter, live 421-model dropdown) → login → `AgentState.WORK` on the real model → interact returned a real Llama-4-Maverick answer.
- iOS framework builds with both commonMain fixes.

## Not in this PR (tracked separately)

- **Google/OAuth setup loops** on a `WACertificate` `wa_id` pattern mismatch — the OAuth WA is minted as `wa_id='oauth-google-<sub>'`, which fails `^wa-\d{4}-\d{2}-\d{2}-[A-Z0-9]{6}$`. Likely a substrate-side write bug; BYOK is unaffected. (The local substrate wheel was also stale at 0.5.181 vs the repo's 0.5.184 pin, which fired the non-blocking node/client banner — an env issue, not code.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)