### PR TITLE
fix(desktop): stale click closure ate the typed API key + CI BYOK gate (2.9.32)

### DIFF
--- a/.github/workflows/windows-desktop-ui.yml
+++ b/.github/workflows/windows-desktop-ui.yml
@@ -155,6 +155,57 @@ jobs:
         shell: pwsh
         run: python tools/dev/assert_no_control_chars_in_env.py --home "$env:CIRIS_HOME" --label boot1
 
+      # ── BYOK regression boot — the stale-click-closure gate ───────────────
+      # A SYNTHETIC key drives the real BYOK path: provider dropdown, key entry,
+      # Test Connection. The PASS is the provider REFUSING the credential —
+      # proof the key the automation typed actually reached the wire. The
+      # regression this guards (rememberUpdatedState in
+      # TestAutomation.desktop.kt): the click registry served a closure captured
+      # before the key existed, so Test Connection read an EMPTY key while the
+      # field held one, rendered "Enter an API key", and the old runner fell
+      # back to the text field and PASSED. Humans were immune (.clickable reads
+      # the live lambda), which is why only THIS runner can catch it — and
+      # before this step, no CI run ever supplied a key, so the guarded path
+      # never executed at all.
+      #
+      # Own CIRIS_HOME: this boot must not disturb the boot-1/boot-2 env-sync
+      # assertions that follow.
+      - name: BYOK boot — a typed key must reach the wire
+        shell: pwsh
+        run: |
+          # REAL key (repo secret): the gate is the FULL happy path — Test
+          # Connection populates the live model dropdown, and the text-field
+          # fallback is a FAILURE (--llm-require-live-models), because with a
+          # working key that fallback is indistinguishable from the
+          # stale-closure bug this step exists to catch.
+          #
+          # Fork PRs get no secrets, so the key is empty there: fall back to a
+          # SYNTHETIC key where the pass is the provider REFUSING it — weaker,
+          # but still proof the key the automation typed reached the wire.
+          if ($env:OPENROUTER_API_KEY) {
+            Write-Host "BYOK gate: REAL key (strict live-models mode)"
+            python -m tools.qa_runner.modules.web_ui desktop-setup `
+              --launch --headless --mock-llm `
+              --username qabyok --password "qa_test_password_12345" `
+              --llm-provider openrouter `
+              --llm-key "$env:OPENROUTER_API_KEY" `
+              --llm-require-live-models `
+              --json-report byok_regression.json -v
+          } else {
+            Write-Host "BYOK gate: no secret (fork PR?) — synthetic key, expect-rejected mode"
+            python -m tools.qa_runner.modules.web_ui desktop-setup `
+              --launch --headless --mock-llm `
+              --username qabyok --password "qa_test_password_12345" `
+              --llm-provider openrouter `
+              --llm-key "sk-or-v1-cirisci-synthetic-not-a-real-credential-000000000000" `
+              --llm-key-expect-rejected `
+              --json-report byok_regression.json -v
+          }
+        env:
+          CIRIS_FORCE_FIRST_RUN: "1"
+          CIRIS_HOME: ${{ runner.temp }}\ciris-byok-regression
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+
       # ── BOOT 2 — THE ONE THAT CATCHES IT ─────────────────────────────────
       # The env sync rewrites .env on every start. In 2.9.19 it un-escaped what
       # the wizard had just written correctly, so boot 1 was always clean and

--- a/.github/workflows/windows-desktop-ui.yml
+++ b/.github/workflows/windows-desktop-ui.yml
@@ -170,6 +170,35 @@ jobs:
       #
       # Own CIRIS_HOME: this boot must not disturb the boot-1/boot-2 env-sync
       # assertions that follow.
+      - name: Boot 2 — restart and log in again, via the UI
+        shell: pwsh
+        run: |
+          python -m tools.qa_runner.modules.web_ui desktop-login `
+            --launch --headless `
+            --username qaadmin --password "qa_test_password_12345" `
+            --json-report boot2.json -v
+
+      - name: Boot 2 — assert no control character reached any path
+        shell: pwsh
+        run: python tools/dev/assert_no_control_chars_in_env.py --home "$env:CIRIS_HOME" --label boot2
+
+      # ── OAUTH ────────────────────────────────────────────────────────────
+      # Deliberately NOT a real Google sign-in: that needs interactive consent
+      # and account credentials, which do not belong in CI. What broke hosted
+      # OAuth was never the consent screen — it was the redirect_uri we SEND
+      # (CIRISServer#421: the agent-id segment was dropped, and the base fell
+      # back to loopback). That is fully observable from the authorize redirect,
+      # so this asserts the URL the UI's sign-in button actually produces.
+      - name: OAuth — the sign-in button must emit a usable redirect_uri
+        shell: pwsh
+        run: |
+          python -m tools.qa_runner.modules.web_ui desktop-up --launch --headless --json-report oauth_up.json -v
+          python tools/dev/assert_oauth_redirect_uri.py --agent-port 8080 --provider google
+
+      # LAST UI step on purpose: desktop-login --launch (Boot 2) reuses any
+      # healthy running app, so this step's own stack (different CIRIS_HOME,
+      # different user) must not be the one it finds. Sequencing this after
+      # Boot 2 keeps the Boot 1 -> Boot 2 handoff exactly as it always was.
       - name: BYOK boot — a typed key must reach the wire
         shell: pwsh
         run: |
@@ -210,31 +239,6 @@ jobs:
       # The env sync rewrites .env on every start. In 2.9.19 it un-escaped what
       # the wizard had just written correctly, so boot 1 was always clean and
       # boot 2 was broken. Restarting is the entire value of this step.
-      - name: Boot 2 — restart and log in again, via the UI
-        shell: pwsh
-        run: |
-          python -m tools.qa_runner.modules.web_ui desktop-login `
-            --launch --headless `
-            --username qaadmin --password "qa_test_password_12345" `
-            --json-report boot2.json -v
-
-      - name: Boot 2 — assert no control character reached any path
-        shell: pwsh
-        run: python tools/dev/assert_no_control_chars_in_env.py --home "$env:CIRIS_HOME" --label boot2
-
-      # ── OAUTH ────────────────────────────────────────────────────────────
-      # Deliberately NOT a real Google sign-in: that needs interactive consent
-      # and account credentials, which do not belong in CI. What broke hosted
-      # OAuth was never the consent screen — it was the redirect_uri we SEND
-      # (CIRISServer#421: the agent-id segment was dropped, and the base fell
-      # back to loopback). That is fully observable from the authorize redirect,
-      # so this asserts the URL the UI's sign-in button actually produces.
-      - name: OAuth — the sign-in button must emit a usable redirect_uri
-        shell: pwsh
-        run: |
-          python -m tools.qa_runner.modules.web_ui desktop-up --launch --headless --json-report oauth_up.json -v
-          python tools/dev/assert_oauth_redirect_uri.py --agent-port 8080 --provider google
-
       - name: Collect artifacts
         if: always()
         shell: pwsh

--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -6,11 +6,11 @@ from typing import List
 from ciris_engine.schemas.runtime.canonical_peer import CanonicalBootstrapPeer
 
 # Version information
-CIRIS_VERSION = "2.9.31-stable"
+CIRIS_VERSION = "2.9.32-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
 CIRIS_VERSION_MINOR = 9
-CIRIS_VERSION_PATCH = 31
+CIRIS_VERSION_PATCH = 32
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/client/androidApp/build.gradle
+++ b/client/androidApp/build.gradle
@@ -25,8 +25,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 35
-        versionCode 168
-        versionName "2.9.31"
+        versionCode 169
+        versionName "2.9.32"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/client/androidApp/src/main/python/version.py
+++ b/client/androidApp/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.9.31"
+__version__ = "android-2.9.32"
 
 
 def get_version() -> str:

--- a/client/desktopApp/build.gradle.kts
+++ b/client/desktopApp/build.gradle.kts
@@ -34,7 +34,7 @@ compose.desktop {
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "CIRIS"
-            packageVersion = "2.9.31"
+            packageVersion = "2.9.32"
             description = "CIRIS Agent Desktop Application"
             vendor = "CIRIS L3C"
 

--- a/client/iosApp/iosApp/Info.plist
+++ b/client/iosApp/iosApp/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.31</string>
+	<string>2.9.32</string>
 	<key>CFBundleVersion</key>
-	<string>329</string>
+	<string>330</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/screens/SetupScreen.kt
+++ b/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/ui/screens/SetupScreen.kt
@@ -1713,14 +1713,25 @@ private fun AiStep(
             // then fails every request. Break them out.
             configCheck?.let { c ->
                 Spacer(modifier = Modifier.height(12.dp))
+                // The verdict TEXT is exposed to the test server (testable carries
+                // `text` into /tree). Without this, CI could see THAT a check row
+                // rendered but never WHAT it said — which is how the stale-closure
+                // regression hid: the row said "Enter an API key" while the field
+                // held one, and no automation could read the words.
                 if (c.key != CheckState.UNKNOWN) {
-                    LlmCheckRow(state = c.key, message = c.keyMessage)
+                    Box(Modifier.testable("txt_llm_check_key", text = c.keyMessage)) {
+                        LlmCheckRow(state = c.key, message = c.keyMessage)
+                    }
                 }
                 if (c.models != CheckState.UNKNOWN) {
-                    LlmCheckRow(state = c.models, message = c.modelsMessage)
+                    Box(Modifier.testable("txt_llm_check_models", text = c.modelsMessage)) {
+                        LlmCheckRow(state = c.models, message = c.modelsMessage)
+                    }
                 }
                 if (c.selectedModel != CheckState.UNKNOWN) {
-                    LlmCheckRow(state = c.selectedModel, message = c.selectedModelMessage)
+                    Box(Modifier.testable("txt_llm_check_selected_model", text = c.selectedModelMessage)) {
+                        LlmCheckRow(state = c.selectedModel, message = c.selectedModelMessage)
+                    }
                 }
             }
 
@@ -1730,6 +1741,7 @@ private fun AiStep(
                     shape = RoundedCornerShape(8.dp),
                     color = if (result.valid) SetupColors.SuccessLight else SetupColors.ErrorLight,
                     modifier = Modifier.fillMaxWidth()
+                        .testable("txt_llm_test_result", text = listOfNotNull(result.message, result.error).joinToString(" — "))
                 ) {
                     Row(
                         modifier = Modifier.padding(12.dp),

--- a/client/shared/src/desktopMain/kotlin/ai/ciris/mobile/shared/platform/TestAutomation.desktop.kt
+++ b/client/shared/src/desktopMain/kotlin/ai/ciris/mobile/shared/platform/TestAutomation.desktop.kt
@@ -2,6 +2,8 @@ package ai.ciris.mobile.shared.platform
 
 import androidx.compose.foundation.clickable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -170,8 +172,21 @@ actual fun Modifier.testable(tag: String, text: String?): Modifier = composed {
  */
 actual fun Modifier.testableClickable(tag: String, text: String?, onClick: () -> Unit): Modifier = composed {
     if (TestAutomation.isEnabled()) {
+        // THE REGISTERED HANDLER MUST TRACK RECOMPOSITION. DisposableEffect is
+        // keyed on `tag`, so it runs once — and the registry kept the FIRST
+        // composition's `onClick`, whose closure had captured the screen state
+        // of that moment. Every automation /click then replayed that snapshot:
+        // in the setup wizard, Test Connection read an EMPTY api key while the
+        // field visibly held one, returned "Enter an API key" before any HTTP,
+        // and only a Back→Next (dispose + re-register) unwedged it. Real mouse
+        // clicks were immune because `.clickable { onClick() }` reads the
+        // current lambda — precisely the split that made this invisible to
+        // manual testing. rememberUpdatedState keeps single registration (the
+        // dispose-time cleanup the comment above documents still holds) while
+        // the registered thunk always calls the LATEST lambda.
+        val currentOnClick by rememberUpdatedState(onClick)
         DisposableEffect(tag) {
-            TestAutomation.registerClickHandler(tag, onClick)
+            TestAutomation.registerClickHandler(tag) { currentOnClick() }
             onDispose {
                 TestAutomation.unregisterClickHandler(tag)
                 TestAutomation.unregisterElement(tag)
@@ -210,8 +225,10 @@ actual fun Modifier.testableClickable(tag: String, text: String?, onClick: () ->
  */
 actual fun Modifier.testableWithHandler(tag: String, onClick: () -> Unit): Modifier = composed {
     if (TestAutomation.isEnabled()) {
+        // Same stale-closure hazard as testableClickable — see the comment there.
+        val currentOnClick by rememberUpdatedState(onClick)
         DisposableEffect(tag) {
-            TestAutomation.registerClickHandler(tag, onClick)
+            TestAutomation.registerClickHandler(tag) { currentOnClick() }
             onDispose {
                 TestAutomation.unregisterClickHandler(tag)
                 TestAutomation.unregisterElement(tag)

--- a/tools/qa_runner/modules/web_ui/__main__.py
+++ b/tools/qa_runner/modules/web_ui/__main__.py
@@ -329,11 +329,29 @@ class DesktopAppTestRunner:
 
         return all(r.success for r in self.results)
 
+    # The message checkLlmConfig returns when state.llmApiKey is BLANK — the
+    # signature of the stale-click-closure regression: the field visibly holds a
+    # key, the automation clicked Test Connection, and the handler read a frozen
+    # snapshot from before the key existed. If this text appears while we KNOW
+    # we entered a key, the registered handler is stale, full stop.
+    _BLANK_KEY_MESSAGE = "Enter an API key"
+
+    async def _llm_verdict_texts(self) -> dict:
+        """testTag -> text for the AI step's verdict surfaces (txt_llm_*)."""
+        assert self.helper is not None
+        out = {}
+        for e in await self.helper.get_elements():
+            if e.test_tag.startswith("txt_llm_") and e.text:
+                out[e.test_tag] = e.text
+        return out
+
     async def _drive_llm_step_byok(
         self,
         provider: str,
         api_key: str,
         model: Optional[str],
+        expect_key_rejected: bool = False,
+        require_live_models: bool = False,
     ) -> None:
         """Drive the AI step's BYOK path: provider → key → Test Connection → model.
 
@@ -383,6 +401,31 @@ class DesktopAppTestRunner:
                     "testableClickable fix? (#1062)"
                 )
             self._log(f"AI (BYOK): Test Connection attempt {attempt}/5")
+            await asyncio.sleep(3)  # let one checkLlmConfig produce its verdict rows
+
+            verdicts = await self._llm_verdict_texts()
+            blob = " | ".join(verdicts.values())
+            if self._BLANK_KEY_MESSAGE in blob:
+                # We ENTERED a key; the handler saw none. Do not retry — every
+                # retry replays the same frozen closure and the old runner
+                # "fell back to the text field" and PASSED, which is exactly how
+                # this shipped. Fail loudly with the mechanism named.
+                raise RuntimeError(
+                    "STALE CLICK CLOSURE regression: Test Connection ran with an EMPTY api key while "
+                    f"input_api_key holds one (verdict: {blob!r}). The automation registry is serving a "
+                    "handler captured before the key was typed — see "
+                    "TestAutomation.desktop.kt testableClickable/rememberUpdatedState."
+                )
+            if expect_key_rejected:
+                # Synthetic-key CI mode: the PASS is the provider refusing the
+                # credential — proof the key REACHED the wire. No dropdown will
+                # ever appear, so return on the auth-class verdict.
+                lowered = blob.lower()
+                if any(w in lowered for w in ("rejected", "auth", "invalid", "key", "credit", "unauthorized")):
+                    self._log(f"AI (BYOK): synthetic key correctly refused by the provider ({blob!r})")
+                    return
+                self._log(f"AI (BYOK): no auth verdict yet (attempt {attempt}): {blob!r}")
+
             # One checkLlmConfig cycle (validate + listModels) is a few seconds;
             # give it up to 18s to surface the dropdown before retrying.
             inner_deadline = time.time() + 18
@@ -406,6 +449,25 @@ class DesktopAppTestRunner:
             self._log(f"AI (BYOK): no live list on attempt {attempt}; node may be warming, retrying")
             await asyncio.sleep(4)
 
+        if expect_key_rejected:
+            raise RuntimeError(
+                "expected the provider to REJECT the synthetic key, but no auth-class verdict ever "
+                "rendered — either the request never reached the provider or the verdict surfaces "
+                "(txt_llm_*) are missing from this build."
+            )
+        if require_live_models:
+            # A REAL key was supplied, so the live dropdown is the contract.
+            # The permissive text-fallback below is what let the stale-closure
+            # regression pass CI-shaped runs silently: no dropdown, type the
+            # model by hand, setup "succeeds". With a working key that fallback
+            # is indistinguishable from the bug, so in strict mode it is one.
+            verdicts = await self._llm_verdict_texts()
+            raise RuntimeError(
+                "live model dropdown never appeared with a REAL key after 5 Test Connection "
+                f"attempts (verdicts: {verdicts!r}) — the BYOK path is broken; refusing the "
+                "text-field fallback because it would report this as a pass."
+            )
+
         # 4. Still no live list after retries → text fallback so setup can finish.
         tags = await _tags()
         if "input_llm_model_text" in tags and model:
@@ -425,6 +487,8 @@ class DesktopAppTestRunner:
         llm_provider: Optional[str] = None,
         llm_api_key: Optional[str] = None,
         llm_model: Optional[str] = None,
+        llm_key_expect_rejected: bool = False,
+        llm_require_live_models: bool = False,
     ) -> bool:
         """Drive the first-run setup wizard via the test server.
 
@@ -609,7 +673,11 @@ class DesktopAppTestRunner:
                 # BYOK path (#1062): real provider + key + Test Connection +
                 # live-model dropdown. This exercises the accommodation that
                 # made btn_test_connection reachable by automation.
-                await self._drive_llm_step_byok(llm_provider or "openrouter", llm_api_key, llm_model)
+                await self._drive_llm_step_byok(
+                    llm_provider or "openrouter", llm_api_key, llm_model,
+                    expect_key_rejected=llm_key_expect_rejected,
+                    require_live_models=llm_require_live_models,
+                )
             elif await self.helper.is_element_visible("btn_use_free_ai"):
                 # CIRIS-hosted proxy option (OAuth path) — no key entry needed.
                 self._log("AI: choosing CIRIS-hosted option (btn_use_free_ai)")
@@ -972,6 +1040,23 @@ Examples:
         "--llm-key",
         default=None,
         help="For desktop-setup: BYOK API key literal (prefer --llm-key-file).",
+    )
+    parser.add_argument(
+        "--llm-require-live-models",
+        action="store_true",
+        help=(
+            "Strict BYOK: a real key was supplied, so the live model dropdown MUST populate — "
+            "the text-field fallback becomes a failure instead of a silent pass."
+        ),
+    )
+    parser.add_argument(
+        "--llm-key-expect-rejected",
+        action="store_true",
+        help=(
+            "CI mode: the supplied key is SYNTHETIC and the pass is the provider refusing it — "
+            "proof the key reached the wire. Guards the stale-click-closure regression without "
+            "a real secret."
+        ),
     )
     parser.add_argument(
         "--llm-key-file",
@@ -2381,6 +2466,8 @@ async def run_desktop_tests(args: argparse.Namespace) -> int:
                 fed_label=args.fed_label,
                 announce=not args.no_announce,
                 trace_opt_in=not args.no_trace_opt_in,
+                llm_key_expect_rejected=getattr(args, "llm_key_expect_rejected", False),
+                llm_require_live_models=getattr(args, "llm_require_live_models", False),
                 llm_provider=args.llm_provider,
                 llm_api_key=_byok_key,
                 llm_model=args.llm_model,

--- a/tools/qa_runner/modules/web_ui/__main__.py
+++ b/tools/qa_runner/modules/web_ui/__main__.py
@@ -630,13 +630,19 @@ class DesktopAppTestRunner:
             # run broken -- the same lesson as the .env assertion that passed
             # while asserting nothing. If YOU is unsatisfied, say so here, where
             # the cause is, instead of two steps downstream.
-            await asyncio.sleep(0.5)
-            if await self.helper.is_element_visible(band_tag):
-                await self._dump_tree("you_step:did-not-advance")
-                raise RuntimeError(
-                    "still on the YOU step after btn_next — a required field is unsatisfied "
-                    "(age band, account, or fed-ID label)"
-                )
+            #
+            # POLL, don't one-shot: on the Windows CI runner the transition
+            # takes ~1s, and a fixed 0.5s sleep flagged a wizard that advanced
+            # 300ms after the check (join_federation then passed immediately).
+            deadline = asyncio.get_event_loop().time() + 10.0
+            while await self.helper.is_element_visible(band_tag):
+                if asyncio.get_event_loop().time() > deadline:
+                    await self._dump_tree("you_step:did-not-advance")
+                    raise RuntimeError(
+                        "still on the YOU step 10s after btn_next — a required field is "
+                        "unsatisfied (age band, account, or fed-ID label)"
+                    )
+                await asyncio.sleep(0.5)
 
         await self.run_test("you_step", you_step)
 


### PR DESCRIPTION
## The bug

`testableClickable` / `testableWithHandler` registered their `/click` handler in a `DisposableEffect(tag)` keyed **on the tag only** — the registry kept the FIRST composition's closure forever. Automation clicks on `btn_test_connection` therefore ran with the initial empty `llmApiKey`, producing "Enter an API key to check this provider." while the field visibly held the key. Real mouse clicks were immune (`.clickable { onClick() }` reads the live lambda), which is why manual testing never saw it — and CI never exercised BYOK at all (`--mock-llm`, no key), so the bug was invisible by construction.

## The fix

`rememberUpdatedState(onClick)` + register `{ currentOnClick() }` in both modifiers (`TestAutomation.desktop.kt`).

## Never again (test hooks + CI gate)

- **SetupScreen**: `txt_llm_check_key` / `txt_llm_check_models` / `txt_llm_check_selected_model` / `txt_llm_test_result` expose the verdict text via `/tree`.
- **web_ui runner**: tripwire raises `STALE CLICK CLOSURE regression` if the blank-key message appears after a typed key. Two new modes:
  - `--llm-key-expect-rejected` — synthetic key; the pass is the provider **refusing** it (proves the typed key reached the wire; works with no secrets).
  - `--llm-require-live-models` — real key; the live model dropdown **must** populate, and the text-field fallback becomes a failure (with a working key that fallback is indistinguishable from this bug).
- **windows-desktop-ui.yml**: new *BYOK boot* step — uses the real `OPENROUTER_API_KEY` repo secret in strict live-models mode; fork PRs (no secrets) fall back to the synthetic expect-rejected mode.

## Verified live (Linux desktop, Xephyr :99, 2.9.31 wheel + this JAR)

- First click on Test Connection with the typed key → **"Connection verified"** (no blank-key message)
- `txt_llm_*` hooks render in `/tree`
- Model dropdown populates with **421 live OpenRouter models** (the exact strict-mode CI path)
- Full E2E on the fixed build earlier: wizard → `.env` persisted → restart → login → `POST /v1/agent/interact` → 200 ("Hello! The pipeline is working as expected.", llama-4-maverick)

Bumps version to **2.9.32**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVMJwukQjscjwLQz9NZktK