### PR TITLE
2.9.33 — desktop Google OAuth + iOS Apple auth: setup, billing, and native-auth fixes

### DIFF
--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -6,11 +6,11 @@ from typing import List
 from ciris_engine.schemas.runtime.canonical_peer import CanonicalBootstrapPeer
 
 # Version information
-CIRIS_VERSION = "2.9.32-stable"
+CIRIS_VERSION = "2.9.33-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
 CIRIS_VERSION_MINOR = 9
-CIRIS_VERSION_PATCH = 32
+CIRIS_VERSION_PATCH = 33
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/ciris_engine/logic/adapters/api/routes/setup/complete.py
+++ b/ciris_engine/logic/adapters/api/routes/setup/complete.py
@@ -632,6 +632,19 @@ async def _create_setup_users(
     await auth_service.start()
 
     try:
+        from ciris_engine.logic.persistence.stores import authentication_store
+
+        # WORKAROUND (#1098 — drop once ciris-server mints OAuth WA ids as proper
+        # `wa-…`): the OAuth browser-handoff parks the session as a live wa_cert
+        # whose id is the placeholder `oauth-<provider>-<sub>`. Capture it BEFORE
+        # we mint+link (linking can repoint the primary oauth index) so we can
+        # retire it afterwards and leave exactly one live cert for the identity.
+        provisional_oauth_wa_id: Optional[str] = None
+        if setup.oauth_provider and setup.oauth_external_id:
+            provisional_oauth_wa_id = authentication_store.provisional_oauth_cert_id(
+                setup.oauth_provider, setup.oauth_external_id
+            )
+
         # Check if OAuth user already exists and update to ROOT if found
         existing_wa, _ = await _check_existing_oauth_wa(auth_service, setup)
 
@@ -676,6 +689,18 @@ async def _create_setup_users(
             wa_cert = await _link_oauth_identity_to_wa(auth_service, setup, wa_cert)
         else:
             _log_oauth_linking_skip(setup)
+
+        # Retire the substrate's provisional OAuth cert so it does not duplicate
+        # the WA we just minted+linked (#1098 workaround — drop once ciris-server
+        # mints OAuth WA ids correctly). Raw set_active, so the placeholder id is
+        # never materialized into a WACertificate.
+        if provisional_oauth_wa_id and provisional_oauth_wa_id != wa_cert.wa_id:
+            authentication_store.update_wa_certificate(provisional_oauth_wa_id, {"active": False})
+            logger.info(
+                "CIRIS_USER_CREATE: retired provisional OAuth cert %s (kept minted %s)",
+                provisional_oauth_wa_id,
+                wa_cert.wa_id,
+            )
 
         # Update default admin password if specified
         assert wa_cert is not None, "wa_cert should be set by create_wa or existing WA lookup"

--- a/ciris_engine/logic/persistence/stores/authentication_store.py
+++ b/ciris_engine/logic/persistence/stores/authentication_store.py
@@ -509,13 +509,40 @@ def _list_active_by_role(role: str, limit: int = 1000) -> List[Dict[str, Any]]:
     return [r for r in obj if isinstance(r, dict)]
 
 
+#: A minted WA id — ``wa-YYYY-MM-DD-XXXXXX``. Mirrors WACertificate.wa_id's
+#: own pattern (schemas/services/authority_core.py). The OAuth browser-handoff
+#: flow can leave a PROVISIONAL wa_cert row keyed by (provider, external_id)
+#: whose wa_id is the OAuth placeholder ``oauth-<provider>-<sub>`` — which is not
+#: a minted certificate and does NOT satisfy this pattern (#1098).
+_MINTED_WA_ID = re.compile(r"^wa-\d{4}-\d{2}-\d{2}-[A-Z0-9]{6}$")
+
+
+def _row_to_wa_or_none(row: Dict[str, Any]) -> Optional[WACertificate]:
+    """Materialize a row into a WACertificate, or None if it is not a minted WA.
+
+    A provisional OAuth-placeholder row (``wa_id='oauth-<provider>-<sub>'``) is
+    not a certificate; constructing a WACertificate from it raises on the
+    wa_id pattern and 500s completeSetup, looping the wizard (#1098). Treat such
+    a row as absent so callers fall through to the real linked WA — or create
+    and link one — instead of crashing.
+    """
+    wa_id = row.get("wa_id")
+    if not isinstance(wa_id, str) or not _MINTED_WA_ID.match(wa_id):
+        return None
+    return _row_to_wa(row)
+
+
 def get_wa_by_oauth(provider: str, external_id: str) -> Optional[WACertificate]:
     """Get an active WA certificate by OAuth identity (primary + linked fallback)."""
     engine = _get_engine()
     raw = engine.wa_cert_get_by_oauth(provider, external_id)
     row = _active_or_none(_parse_persist_payload(raw))
     if row is not None:
-        return _row_to_wa(row)
+        wa = _row_to_wa_or_none(row)
+        if wa is not None:
+            return wa
+        # Provisional OAuth-placeholder row — not a minted WA. Fall through to
+        # the linked-identity search below (and, ultimately, None → mint one).
 
     # Fallback: search linked OAuth identities across all active certs.
     for role in ("root", "authority", "observer"):

--- a/ciris_engine/logic/persistence/stores/authentication_store.py
+++ b/ciris_engine/logic/persistence/stores/authentication_store.py
@@ -556,6 +556,31 @@ def get_wa_by_oauth(provider: str, external_id: str) -> Optional[WACertificate]:
     return None
 
 
+def provisional_oauth_cert_id(provider: str, external_id: str) -> Optional[str]:
+    """Return the id of the substrate's PROVISIONAL OAuth cert, or None.
+
+    WORKAROUND for #1098 — drop once ciris-server mints OAuth WA ids as proper
+    ``wa-…`` (server issue). The OAuth browser-handoff parks the session as a
+    live wa_cert keyed by (provider, external_id) whose wa_id is the placeholder
+    ``oauth-<provider>-<sub>``. Once setup mints+links a real WA for the same
+    identity, that placeholder becomes a DUPLICATE and the node refuses the
+    ambiguous account. Callers capture this id BEFORE linking (linking can
+    repoint the primary oauth index) and deactivate it afterwards via
+    ``update_wa_certificate(id, {"active": False})`` — the raw set_active path,
+    since materializing the placeholder id would fail the wa_id pattern.
+    Returns None when the primary row is already a minted WA or absent.
+    """
+    engine = _get_engine()
+    raw = engine.wa_cert_get_by_oauth(provider, external_id)
+    row = _parse_persist_payload(raw)
+    if not isinstance(row, dict):
+        return None
+    wa_id = row.get("wa_id")
+    if isinstance(wa_id, str) and wa_id and not _MINTED_WA_ID.match(wa_id):
+        return wa_id
+    return None
+
+
 def get_wa_by_adapter(adapter_id: str) -> Optional[WACertificate]:
     """Get an active WA certificate by adapter_id.
 

--- a/ciris_engine/logic/runtime/billing_helpers.py
+++ b/ciris_engine/logic/runtime/billing_helpers.py
@@ -141,16 +141,21 @@ async def reinitialize_billing_provider(runtime: Any) -> None:
     is_mobile = "ANDROID_DATA" in os.environ or os.environ.get("CIRIS_IOS_FRAMEWORK_PATH", "")
     using_ciris_proxy = is_using_ciris_proxy()
 
-    logger.info(f"Billing provider check: is_mobile={is_mobile}, using_ciris_proxy={using_ciris_proxy}")
+    logger.info(f"Billing provider check: platform_mobile={bool(is_mobile)}, using_ciris_proxy={using_ciris_proxy}")
     logger.info(f"  OPENAI_API_BASE={os.getenv('OPENAI_API_BASE', '')}")
 
-    if not (is_mobile and using_ciris_proxy):
-        logger.info("Billing provider not needed (not using CIRIS proxy or not mobile)")
+    # Billing is required for ANY client on the CIRIS LLM proxy — desktop
+    # Google-OAuth included, not just mobile (#1098 follow-up). The OAuth ID
+    # token below is the real gate: no token, no billing provider. The old
+    # `is_mobile` requirement silently disabled billing on desktop CIRISProxy,
+    # so those LLM calls went out with no billing identity.
+    if not using_ciris_proxy:
+        logger.info("Billing provider not needed (not using CIRIS proxy)")
         return
 
     google_id_token = os.getenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", "") or os.getenv("CIRIS_BILLING_APPLE_ID_TOKEN", "")
     if not google_id_token:
-        logger.warning("Mobile using CIRIS LLM proxy without OAuth ID token - billing provider not configured")
+        logger.warning("Using CIRIS LLM proxy without OAuth ID token - billing provider not configured")
         return
 
     credit_provider = create_billing_provider(google_id_token)

--- a/ciris_engine/logic/runtime/node_fold.py
+++ b/ciris_engine/logic/runtime/node_fold.py
@@ -522,9 +522,16 @@ def start_node_fold(brain_port: int, *, home: Optional[str] = None, key_id: Opti
     # sign-in fell back to the node's loopback callback and Google rejected it.
     # Best-effort and idempotent: a desktop install has no oauth.json and needs none.
     try:
-        from ciris_engine.logic.runtime.oauth_provider_sync import sync_oauth_providers_to_node
+        from ciris_engine.logic.runtime.oauth_provider_sync import (
+            ensure_native_apple_provider,
+            sync_oauth_providers_to_node,
+        )
 
         sync_oauth_providers_to_node()
+        # The substrate defaults a Google provider but no Apple one, so native
+        # "Sign in with Apple" is refused "not configured" until we register the
+        # app's bundle id (the 2.9.14 fold did not carry it across). Idempotent.
+        ensure_native_apple_provider()
     except Exception:  # pragma: no cover - never block the boot on OAuth config
         logger.exception("Node fold: OAuth provider sync failed (agent continues)")
     _reprime_federation_delivery("post-bind")

--- a/ciris_engine/logic/runtime/oauth_provider_sync.py
+++ b/ciris_engine/logic/runtime/oauth_provider_sync.py
@@ -238,3 +238,57 @@ def sync_oauth_providers_to_node(node_url: str = "http://127.0.0.1:4243") -> Non
             logger.warning("[OAUTH_SYNC] registering provider %r returned %s", name, status)
 
     _sync_callback_base(node_url)
+
+
+#: The CIRIS mobile app's Apple audience. Native "Sign in with Apple" mints an
+#: ID token whose `aud` is the app's bundle id; the node validates the token
+#: against a configured provider's client_id. Public identifier, NOT a secret.
+_APPLE_NATIVE_CLIENT_ID = "ai.ciris.mobile"
+
+
+def ensure_native_apple_provider(node_url: str = "http://127.0.0.1:4243") -> None:
+    """Register the app's native Apple audience with the node.
+
+    2.9.14 folded /v1/auth/* onto the node. The substrate ships a default Google
+    provider (the browser-handoff client) but NO Apple provider, so native
+    "Sign in with Apple" (POST /v1/auth/native/apple) is refused
+    "Apple native auth is not configured for this application"
+    (reason_id=auth.oauth.native_token_invalid) — the bundle id it checks the
+    token `aud` against was never carried across the fold, and setup completes
+    (via claim-remote) but the FIRST real Apple login afterwards 401s.
+
+    Registering the provider makes native validation pass (verified: signature +
+    aud + exp are checked against Apple's live keys). Native auth performs no
+    code exchange, so no client_secret is meaningful — the config endpoint
+    requires the field, so a non-secret placeholder is sent. Skipped when a
+    hosted Apple provider is already configured (a server deployment owns that
+    via oauth.json). Idempotent upsert; never raises — auth being unconfigured
+    must not stop an agent from starting.
+    """
+    try:
+        # A hosted Apple provider (real client_id + secret from oauth.json) owns
+        # this config on a server deployment — do not clobber it.
+        existing = _read_provider_config() or {}
+        if "apple" in existing:
+            logger.debug("[OAUTH_SYNC] hosted Apple provider present — skipping native registration")
+            return
+
+        payload: Dict[str, Any] = {
+            "provider": "apple",
+            "client_id": _APPLE_NATIVE_CLIENT_ID,
+            # Native token validation does no code exchange, so there is no
+            # secret; the endpoint requires the field, so send a placeholder
+            # that can never authenticate a hosted flow.
+            "client_secret": "native-apple-no-hosted-flow",
+            "metadata": {
+                "ios_client_id": _APPLE_NATIVE_CLIENT_ID,
+                "bundle_id": _APPLE_NATIVE_CLIENT_ID,
+            },
+        }
+        status, _ = _call("POST", f"{node_url}/v1/auth/oauth/providers", payload)
+        if status == 200:
+            logger.info("[OAUTH_SYNC] native Apple provider registered (aud=%s)", _APPLE_NATIVE_CLIENT_ID)
+        else:
+            logger.warning("[OAUTH_SYNC] native Apple provider registration returned %s", status)
+    except Exception:  # pragma: no cover - never block boot on OAuth config
+        logger.exception("[OAUTH_SYNC] native Apple provider registration failed (agent continues)")

--- a/client/androidApp/build.gradle
+++ b/client/androidApp/build.gradle
@@ -25,8 +25,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 35
-        versionCode 169
-        versionName "2.9.32"
+        versionCode 170
+        versionName "2.9.33"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/client/androidApp/src/main/python/version.py
+++ b/client/androidApp/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.9.32"
+__version__ = "android-2.9.33"
 
 
 def get_version() -> str:

--- a/client/desktopApp/build.gradle.kts
+++ b/client/desktopApp/build.gradle.kts
@@ -34,7 +34,7 @@ compose.desktop {
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "CIRIS"
-            packageVersion = "2.9.32"
+            packageVersion = "2.9.33"
             description = "CIRIS Agent Desktop Application"
             vendor = "CIRIS L3C"
 

--- a/client/iosApp/Resources/app/ciris_adapters/ciris_verify/__init__.py
+++ b/client/iosApp/Resources/app/ciris_adapters/ciris_verify/__init__.py
@@ -38,6 +38,7 @@ from .ffi_bindings import (  # noqa: F401
     ValidationStatus,
     VerificationFailedError,
     get_library_version,
+    jcs_canonicalize,
     setup_logging,
 )
 from .service import CIRISVerifyService, VerificationConfig  # noqa: F401

--- a/client/iosApp/Resources/app/ciris_adapters/ciris_verify/ffi_bindings/__init__.py
+++ b/client/iosApp/Resources/app/ciris_adapters/ciris_verify/ffi_bindings/__init__.py
@@ -4,7 +4,7 @@ Hardware-rooted license verification for the CIRIS ecosystem.
 Provides cryptographic proof of license status to prevent capability spoofing.
 
 Usage:
-    from ciris_verify import CIRISVerify, LicenseStatus
+    from ciris_adapters.ciris_verify.ffi_bindings import CIRISVerify, LicenseStatus
 
     verifier = CIRISVerify()
     status = verifier.get_license_status(challenge_nonce=os.urandom(32))
@@ -22,12 +22,17 @@ Logging:
     verifier.set_log_callback(lambda lvl, target, msg: print(f"[{lvl}] {msg}"))
 
     # Or integrate with Python logging
-    from ciris_verify import setup_logging
+    from ciris_adapters.ciris_verify.ffi_bindings import setup_logging
     setup_logging(verifier, level="DEBUG")
 """
 
 import logging as _logging
 
+# jcs_canonicalize IS re-exported (unlike verify_tree below): it binds the
+# substrate's ciris_verify_jcs_canonicalize through ciris_server.verify_ffi_path(),
+# so it carries no standalone-wheel dependency. This is the import the 2.9.29
+# ciris-verify pin removal (#917) rewired the producer call sites onto.
+from ._jcs import jcs_canonicalize
 from .client import CIRISVerify, MockCIRISVerify
 from .exceptions import (
     AttestationInProgressError,
@@ -43,7 +48,10 @@ from .exceptions import (
 # vendored ffi_bindings layer — it carries CIRISAgent-local FFI-loader
 # patches (commit 03f5e958d) that the upstream client.py doesn't have.
 # Consumers needing the runtime tree verifier import directly:
-#     from ciris_verify import verify_tree, TreeVerifyRequest
+#     from ciris_engine.logic.services.infrastructure.authentication\
+#             .attestation.tree_verify import verify_tree, TreeVerifyRequest
+# which ctypes-binds ciris_verify_tree through ciris_server.verify_ffi_path()
+# (the 2.9.7 DRY purge) — no standalone ciris-verify wheel involved.
 # This file is in `update_ciris_verify.py::AGENT_MANAGED` to prevent
 # upstream `__init__.py` from re-introducing the broken import on each
 # `ciris-verify` bump (Codex P0 on PR #741, fix tracked in fe14c6c94).
@@ -131,6 +139,7 @@ __version__ = "10.3.0"
 __all__ = [
     "CIRISVerify",
     "MockCIRISVerify",
+    "jcs_canonicalize",  # substrate-bound (#917)
     # verify_tree / DEFAULT_REGISTRY_URL not re-exported — see comment above.
     "TreeVerifyRequest",
     "TreeVerifyResult",

--- a/client/iosApp/Resources/app/ciris_adapters/ciris_verify/ffi_bindings/client.py
+++ b/client/iosApp/Resources/app/ciris_adapters/ciris_verify/ffi_bindings/client.py
@@ -4,42 +4,47 @@ This module provides a high-level Python interface to the CIRISVerify
 Rust binary via C FFI. It handles JSON encoding/decoding and type conversion.
 """
 
-import asyncio
-import ctypes
-import hashlib
-import json
 import os
+import json
+import ctypes
+import asyncio
+import hashlib
 import platform
 import socket
-from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional, Set
+from datetime import datetime, timezone
+from concurrent.futures import ThreadPoolExecutor
 
-from .exceptions import AttestationInProgressError, BinaryNotFoundError, BinaryTamperedError, CommunicationError
-from .exceptions import TimeoutError as CIRISTimeoutError
-from .exceptions import VerificationFailedError
 from .types import (
-    AttestationData,
-    CapabilityCheckResult,
-    DisclosureSeverity,
-    FileIntegrityResult,
-    HardwareInfo,
-    HardwareLimitation,
-    HardwareType,
-    KeyringScope,
-    LicenseDetails,
     LicenseStatus,
-    LicenseStatusResponse,
     LicenseTier,
+    LicenseDetails,
     MandatoryDisclosure,
-    PythonIntegrityResult,
-    PythonModuleHashes,
-    SecurityAdvisory,
+    DisclosureSeverity,
+    LicenseStatusResponse,
+    CapabilityCheckResult,
+    FileIntegrityResult,
+    HardwareType,
+    ValidationStatus,
     SourceDetails,
+    AttestationData,
+    PythonModuleHashes,
+    PythonIntegrityResult,
+    SecurityAdvisory,
+    HardwareLimitation,
+    HardwareInfo,
     StorageDescriptor,
     StorageKind,
-    ValidationStatus,
+    KeyringScope,
+)
+from .exceptions import (
+    BinaryNotFoundError,
+    BinaryTamperedError,
+    VerificationFailedError,
+    TimeoutError as CIRISTimeoutError,
+    CommunicationError,
+    AttestationInProgressError,
 )
 
 # FFI error codes
@@ -66,7 +71,6 @@ DEFAULT_BINARY_PATHS = {
         # The actual path is resolved at runtime via _find_ios_framework()
     ],
 }
-
 
 def _resolve_ciris_server_ffi_path() -> Optional[Path]:
     """Resolve the CIRISVerify FFI library bundled in the ciris-server wheel.
@@ -232,7 +236,6 @@ class CIRISVerify:
         # Check for Chaquopy-specific marker
         try:
             import java  # noqa: F401
-
             return True
         except ImportError:
             pass
@@ -277,13 +280,11 @@ class CIRISVerify:
         Java context to get nativeLibraryDir.
         """
         import logging
-
         logger = logging.getLogger(__name__)
 
         # Use Chaquopy's Java context to get nativeLibraryDir
         try:
             from java import jclass
-
             context = jclass("com.chaquo.python.Python").getPlatform().getApplication()
             native_lib_dir = context.getApplicationInfo().nativeLibraryDir
             logger.info(f"[CIRISVerify] Android nativeLibraryDir: {native_lib_dir}")
@@ -320,7 +321,8 @@ class CIRISVerify:
             if ios_path:
                 return ios_path
             raise BinaryNotFoundError(
-                "CIRISVerify.framework not found in app bundle. " "Ensure CIRISVerify.xcframework is linked in Xcode."
+                "CIRISVerify.framework not found in app bundle. "
+                "Ensure CIRISVerify.xcframework is linked in Xcode."
             )
 
         # Android-specific library search (Chaquopy)
@@ -329,7 +331,8 @@ class CIRISVerify:
             if android_path:
                 return android_path
             raise BinaryNotFoundError(
-                "libciris_verify_ffi.so not found on Android. " "Ensure the native library is included in jniLibs."
+                "libciris_verify_ffi.so not found on Android. "
+                "Ensure the native library is included in jniLibs."
             )
 
         # Search default paths
@@ -460,18 +463,18 @@ class CIRISVerify:
                     raise BinaryTamperedError("Empty binary file")
 
                 valid_magic = [
-                    b"\x7fELF",  # ELF
+                    b"\x7fELF",           # ELF
                     b"\xfe\xed\xfa\xce",  # Mach-O 32 BE
                     b"\xfe\xed\xfa\xcf",  # Mach-O 64 BE
                     b"\xce\xfa\xed\xfe",  # Mach-O 32 LE
                     b"\xcf\xfa\xed\xfe",  # Mach-O 64 LE (macOS/iOS arm64)
                     b"\xca\xfe\xba\xbe",  # Mach-O Universal
-                    b"!\x0a<arch>",  # Static library (ar archive)
-                    b"MZ\x90\x00",  # PE
-                    b"MZ\x00\x00",  # PE variant
+                    b"!\x0a<arch>",       # Static library (ar archive)
+                    b"MZ\x90\x00",        # PE
+                    b"MZ\x00\x00",        # PE variant
                 ]
 
-                if not any(magic.startswith(m[: len(magic)]) for m in valid_magic):
+                if not any(magic.startswith(m[:len(magic)]) for m in valid_magic):
                     raise BinaryTamperedError(f"Invalid binary magic: {magic.hex()}")
 
         except (OSError, IOError) as e:
@@ -492,45 +495,45 @@ class CIRISVerify:
         # NOTE: response_data is JSON text (no null bytes), but use c_void_p for
         # consistency with other output pointer patterns.
         self._lib.ciris_verify_get_status.argtypes = [
-            ctypes.c_void_p,  # handle
-            ctypes.c_char_p,  # request_data (JSON bytes, input)
-            ctypes.c_size_t,  # request_len
-            ctypes.POINTER(ctypes.c_void_p),  # response_data (out)
-            ctypes.POINTER(ctypes.c_size_t),  # response_len (out)
+            ctypes.c_void_p,                    # handle
+            ctypes.c_char_p,                    # request_data (JSON bytes, input)
+            ctypes.c_size_t,                    # request_len
+            ctypes.POINTER(ctypes.c_void_p),    # response_data (out)
+            ctypes.POINTER(ctypes.c_size_t),    # response_len (out)
         ]
         self._lib.ciris_verify_get_status.restype = ctypes.c_int
 
         # ciris_verify_check_capability(handle, capability, action, required_tier, allowed) -> i32
         self._lib.ciris_verify_check_capability.argtypes = [
-            ctypes.c_void_p,  # handle
-            ctypes.c_char_p,  # capability
-            ctypes.c_char_p,  # action
-            ctypes.c_int,  # required_tier
-            ctypes.POINTER(ctypes.c_int),  # allowed (out)
+            ctypes.c_void_p,                    # handle
+            ctypes.c_char_p,                    # capability
+            ctypes.c_char_p,                    # action
+            ctypes.c_int,                       # required_tier
+            ctypes.POINTER(ctypes.c_int),       # allowed (out)
         ]
         self._lib.ciris_verify_check_capability.restype = ctypes.c_int
 
         # ciris_verify_check_agent_integrity(handle, manifest_data, manifest_len,
         #   agent_root, spot_check_count, response_data, response_len) -> i32
         self._lib.ciris_verify_check_agent_integrity.argtypes = [
-            ctypes.c_void_p,  # handle
-            ctypes.c_char_p,  # manifest_data (JSON bytes, input)
-            ctypes.c_size_t,  # manifest_len
-            ctypes.c_char_p,  # agent_root (null-terminated path, input)
-            ctypes.c_uint32,  # spot_check_count (0 = full)
-            ctypes.POINTER(ctypes.c_void_p),  # response_data (out)
-            ctypes.POINTER(ctypes.c_size_t),  # response_len (out)
+            ctypes.c_void_p,                    # handle
+            ctypes.c_char_p,                    # manifest_data (JSON bytes, input)
+            ctypes.c_size_t,                    # manifest_len
+            ctypes.c_char_p,                    # agent_root (null-terminated path, input)
+            ctypes.c_uint32,                    # spot_check_count (0 = full)
+            ctypes.POINTER(ctypes.c_void_p),    # response_data (out)
+            ctypes.POINTER(ctypes.c_size_t),    # response_len (out)
         ]
         self._lib.ciris_verify_check_agent_integrity.restype = ctypes.c_int
 
         # ciris_verify_sign(handle, data, data_len, sig_data, sig_len) -> i32
         # NOTE: Use c_void_p for output sig_data — c_char_p truncates at null bytes.
         self._lib.ciris_verify_sign.argtypes = [
-            ctypes.c_void_p,  # handle
-            ctypes.c_char_p,  # data (input, null-terminated OK)
-            ctypes.c_size_t,  # data_len
-            ctypes.POINTER(ctypes.c_void_p),  # signature_data (out)
-            ctypes.POINTER(ctypes.c_size_t),  # signature_len (out)
+            ctypes.c_void_p,                    # handle
+            ctypes.c_char_p,                    # data (input, null-terminated OK)
+            ctypes.c_size_t,                    # data_len
+            ctypes.POINTER(ctypes.c_void_p),    # signature_data (out)
+            ctypes.POINTER(ctypes.c_size_t),    # signature_len (out)
         ]
         self._lib.ciris_verify_sign.restype = ctypes.c_int
 
@@ -538,21 +541,21 @@ class CIRISVerify:
         # NOTE: Use c_void_p (not c_char_p) for output data pointers because
         # c_char_p truncates at null bytes, and public keys contain 0x00 bytes.
         self._lib.ciris_verify_get_public_key.argtypes = [
-            ctypes.c_void_p,  # handle
-            ctypes.POINTER(ctypes.c_void_p),  # key_data (out)
-            ctypes.POINTER(ctypes.c_size_t),  # key_len (out)
-            ctypes.POINTER(ctypes.c_void_p),  # algorithm (out)
-            ctypes.POINTER(ctypes.c_size_t),  # algorithm_len (out)
+            ctypes.c_void_p,                    # handle
+            ctypes.POINTER(ctypes.c_void_p),    # key_data (out)
+            ctypes.POINTER(ctypes.c_size_t),    # key_len (out)
+            ctypes.POINTER(ctypes.c_void_p),    # algorithm (out)
+            ctypes.POINTER(ctypes.c_size_t),    # algorithm_len (out)
         ]
         self._lib.ciris_verify_get_public_key.restype = ctypes.c_int
 
         # ciris_verify_export_attestation(handle, challenge, challenge_len, proof_data, proof_len) -> i32
         self._lib.ciris_verify_export_attestation.argtypes = [
-            ctypes.c_void_p,  # handle
-            ctypes.c_char_p,  # challenge (input)
-            ctypes.c_size_t,  # challenge_len
-            ctypes.POINTER(ctypes.c_void_p),  # proof_data (out)
-            ctypes.POINTER(ctypes.c_size_t),  # proof_len (out)
+            ctypes.c_void_p,                    # handle
+            ctypes.c_char_p,                    # challenge (input)
+            ctypes.c_size_t,                    # challenge_len
+            ctypes.POINTER(ctypes.c_void_p),    # proof_data (out)
+            ctypes.POINTER(ctypes.c_size_t),    # proof_len (out)
         ]
         self._lib.ciris_verify_export_attestation.restype = ctypes.c_int
 
@@ -561,9 +564,9 @@ class CIRISVerify:
         self._has_storage_descriptor = False
         if hasattr(self._lib, "ciris_verify_signer_storage_descriptor"):
             self._lib.ciris_verify_signer_storage_descriptor.argtypes = [
-                ctypes.c_void_p,  # handle
-                ctypes.POINTER(ctypes.c_void_p),  # descriptor_data (out)
-                ctypes.POINTER(ctypes.c_size_t),  # descriptor_len (out)
+                ctypes.c_void_p,                    # handle
+                ctypes.POINTER(ctypes.c_void_p),    # descriptor_data (out)
+                ctypes.POINTER(ctypes.c_size_t),    # descriptor_len (out)
             ]
             self._lib.ciris_verify_signer_storage_descriptor.restype = ctypes.c_int
             self._has_storage_descriptor = True
@@ -605,26 +608,25 @@ class CIRISVerify:
 
             # ciris_verify_sign_ed25519(handle, data, data_len, sig_data, sig_len) -> i32
             self._lib.ciris_verify_sign_ed25519.argtypes = [
-                ctypes.c_void_p,  # handle
-                ctypes.c_char_p,  # data
-                ctypes.c_size_t,  # data_len
-                ctypes.POINTER(ctypes.c_void_p),  # signature_data (out)
-                ctypes.POINTER(ctypes.c_size_t),  # signature_len (out)
+                ctypes.c_void_p,                    # handle
+                ctypes.c_char_p,                    # data
+                ctypes.c_size_t,                    # data_len
+                ctypes.POINTER(ctypes.c_void_p),    # signature_data (out)
+                ctypes.POINTER(ctypes.c_size_t),    # signature_len (out)
             ]
             self._lib.ciris_verify_sign_ed25519.restype = ctypes.c_int
 
             # ciris_verify_get_ed25519_public_key(handle, key_data, key_len) -> i32
             self._lib.ciris_verify_get_ed25519_public_key.argtypes = [
-                ctypes.c_void_p,  # handle
-                ctypes.POINTER(ctypes.c_void_p),  # key_data (out)
-                ctypes.POINTER(ctypes.c_size_t),  # key_len (out)
+                ctypes.c_void_p,                    # handle
+                ctypes.POINTER(ctypes.c_void_p),    # key_data (out)
+                ctypes.POINTER(ctypes.c_size_t),    # key_len (out)
             ]
             self._lib.ciris_verify_get_ed25519_public_key.restype = ctypes.c_int
 
             self._has_ed25519_support = True
         except AttributeError:
             import logging
-
             logging.getLogger(__name__).info(
                 "[CIRISVerify] Ed25519 key functions not available in this library version"
             )
@@ -632,9 +634,9 @@ class CIRISVerify:
         # ciris_verify_get_diagnostics (optional - added in 0.4.3)
         try:
             self._lib.ciris_verify_get_diagnostics.argtypes = [
-                ctypes.c_void_p,  # handle
-                ctypes.POINTER(ctypes.c_void_p),  # diag_data (out)
-                ctypes.POINTER(ctypes.c_size_t),  # diag_len (out)
+                ctypes.c_void_p,                    # handle
+                ctypes.POINTER(ctypes.c_void_p),    # diag_data (out)
+                ctypes.POINTER(ctypes.c_size_t),    # diag_len (out)
             ]
             self._lib.ciris_verify_get_diagnostics.restype = ctypes.c_int
         except AttributeError:
@@ -643,12 +645,12 @@ class CIRISVerify:
         # ciris_verify_audit_trail (optional - added in 0.6.16)
         try:
             self._lib.ciris_verify_audit_trail.argtypes = [
-                ctypes.c_void_p,  # handle (can be null)
-                ctypes.c_char_p,  # db_path
-                ctypes.c_char_p,  # jsonl_path (optional)
-                ctypes.c_char_p,  # portal_key_id (optional)
-                ctypes.POINTER(ctypes.c_void_p),  # result_json (out)
-                ctypes.POINTER(ctypes.c_size_t),  # result_len (out)
+                ctypes.c_void_p,                    # handle (can be null)
+                ctypes.c_char_p,                    # db_path
+                ctypes.c_char_p,                    # jsonl_path (optional)
+                ctypes.c_char_p,                    # portal_key_id (optional)
+                ctypes.POINTER(ctypes.c_void_p),    # result_json (out)
+                ctypes.POINTER(ctypes.c_size_t),    # result_len (out)
             ]
             self._lib.ciris_verify_audit_trail.restype = ctypes.c_int
             self._has_audit_trail_support = True
@@ -659,11 +661,11 @@ class CIRISVerify:
         # Full unified attestation running all 5 levels
         try:
             self._lib.ciris_verify_run_attestation.argtypes = [
-                ctypes.c_void_p,  # handle
-                ctypes.c_char_p,  # request_json (input)
-                ctypes.c_size_t,  # request_len
-                ctypes.POINTER(ctypes.c_void_p),  # result_json (out)
-                ctypes.POINTER(ctypes.c_size_t),  # result_len (out)
+                ctypes.c_void_p,                    # handle
+                ctypes.c_char_p,                    # request_json (input)
+                ctypes.c_size_t,                    # request_len
+                ctypes.POINTER(ctypes.c_void_p),    # result_json (out)
+                ctypes.POINTER(ctypes.c_size_t),    # result_len (out)
             ]
             self._lib.ciris_verify_run_attestation.restype = ctypes.c_int
             self._has_run_attestation_support = True
@@ -674,10 +676,10 @@ class CIRISVerify:
         # Report device attestation failure (Play Integrity / App Attest token acquisition failed)
         try:
             self._lib.ciris_verify_device_attestation_failed.argtypes = [
-                ctypes.c_void_p,  # handle
-                ctypes.c_char_p,  # platform ("android" or "ios")
-                ctypes.c_int,  # error_code
-                ctypes.c_char_p,  # error_message (nullable)
+                ctypes.c_void_p,                    # handle
+                ctypes.c_char_p,                    # platform ("android" or "ios")
+                ctypes.c_int,                       # error_code
+                ctypes.c_char_p,                    # error_message (nullable)
             ]
             self._lib.ciris_verify_device_attestation_failed.restype = ctypes.c_int
             self._has_device_attestation_failed_support = True
@@ -688,25 +690,25 @@ class CIRISVerify:
         # Save manifests with hardware signature for offline L1
         try:
             self._lib.ciris_verify_save_manifest_cache.argtypes = [
-                ctypes.c_void_p,  # handle
-                ctypes.c_char_p,  # binary_manifest_json
-                ctypes.c_size_t,  # binary_manifest_len
-                ctypes.c_char_p,  # function_manifest_json (nullable)
-                ctypes.c_size_t,  # function_manifest_len
-                ctypes.c_char_p,  # build_record_json (nullable)
-                ctypes.c_size_t,  # build_record_len
+                ctypes.c_void_p,                    # handle
+                ctypes.c_char_p,                    # binary_manifest_json
+                ctypes.c_size_t,                    # binary_manifest_len
+                ctypes.c_char_p,                    # function_manifest_json (nullable)
+                ctypes.c_size_t,                    # function_manifest_len
+                ctypes.c_char_p,                    # build_record_json (nullable)
+                ctypes.c_size_t,                    # build_record_len
             ]
             self._lib.ciris_verify_save_manifest_cache.restype = ctypes.c_int
 
             self._lib.ciris_verify_load_manifest_cache.argtypes = [
-                ctypes.c_void_p,  # handle
-                ctypes.POINTER(ctypes.c_void_p),  # result_json (out)
-                ctypes.POINTER(ctypes.c_size_t),  # result_len (out)
+                ctypes.c_void_p,                    # handle
+                ctypes.POINTER(ctypes.c_void_p),    # result_json (out)
+                ctypes.POINTER(ctypes.c_size_t),    # result_len (out)
             ]
             self._lib.ciris_verify_load_manifest_cache.restype = ctypes.c_int
 
             self._lib.ciris_verify_manifest_cache_exists.argtypes = [
-                ctypes.c_void_p,  # handle (can be null)
+                ctypes.c_void_p,                    # handle (can be null)
             ]
             self._lib.ciris_verify_manifest_cache_exists.restype = ctypes.c_int
             self._has_manifest_cache_support = True
@@ -717,22 +719,22 @@ class CIRISVerify:
         # Get hardware information and security limitations
         try:
             self._lib.ciris_verify_get_hardware_info.argtypes = [
-                ctypes.c_void_p,  # handle (can be null)
+                ctypes.c_void_p,                    # handle (can be null)
                 ctypes.POINTER(ctypes.POINTER(ctypes.c_uint8)),  # result_json
-                ctypes.POINTER(ctypes.c_size_t),  # result_len
+                ctypes.POINTER(ctypes.c_size_t),   # result_len
             ]
             self._lib.ciris_verify_get_hardware_info.restype = ctypes.c_int
 
             self._lib.ciris_verify_get_hardware_info_android.argtypes = [
-                ctypes.c_void_p,  # handle (can be null)
-                ctypes.c_char_p,  # hardware
-                ctypes.c_char_p,  # board
-                ctypes.c_char_p,  # manufacturer
-                ctypes.c_char_p,  # model
-                ctypes.c_char_p,  # security_patch
-                ctypes.c_char_p,  # fingerprint
+                ctypes.c_void_p,                    # handle (can be null)
+                ctypes.c_char_p,                    # hardware
+                ctypes.c_char_p,                    # board
+                ctypes.c_char_p,                    # manufacturer
+                ctypes.c_char_p,                    # model
+                ctypes.c_char_p,                    # security_patch
+                ctypes.c_char_p,                    # fingerprint
                 ctypes.POINTER(ctypes.POINTER(ctypes.c_uint8)),  # result_json
-                ctypes.POINTER(ctypes.c_size_t),  # result_len
+                ctypes.POINTER(ctypes.c_size_t),   # result_len
             ]
             self._lib.ciris_verify_get_hardware_info_android.restype = ctypes.c_int
             self._has_hardware_info_support = True
@@ -745,8 +747,8 @@ class CIRISVerify:
             # Callback signature: void callback(int level, const char* target, const char* message)
             # Level: 1=ERROR, 2=WARN, 3=INFO, 4=DEBUG, 5=TRACE
             self._log_callback_type = ctypes.CFUNCTYPE(
-                None,  # return type (void)
-                ctypes.c_int,  # level
+                None,           # return type (void)
+                ctypes.c_int,   # level
                 ctypes.c_char_p,  # target
                 ctypes.c_char_p,  # message
             )
@@ -764,72 +766,72 @@ class CIRISVerify:
         # Derive secp256k1 public key for EVM wallet
         try:
             self._lib.ciris_verify_derive_secp256k1_pubkey.argtypes = [
-                ctypes.c_void_p,  # handle
+                ctypes.c_void_p,                    # handle
                 ctypes.POINTER(ctypes.POINTER(ctypes.c_uint8)),  # pubkey_data (out)
-                ctypes.POINTER(ctypes.c_size_t),  # pubkey_len (out)
+                ctypes.POINTER(ctypes.c_size_t),    # pubkey_len (out)
             ]
             self._lib.ciris_verify_derive_secp256k1_pubkey.restype = ctypes.c_int
 
             self._lib.ciris_verify_get_evm_address.argtypes = [
-                ctypes.POINTER(ctypes.c_uint8),  # pubkey
-                ctypes.c_size_t,  # pubkey_len
+                ctypes.POINTER(ctypes.c_uint8),     # pubkey
+                ctypes.c_size_t,                    # pubkey_len
                 ctypes.POINTER(ctypes.POINTER(ctypes.c_uint8)),  # address_data (out)
-                ctypes.POINTER(ctypes.c_size_t),  # address_len (out)
+                ctypes.POINTER(ctypes.c_size_t),    # address_len (out)
             ]
             self._lib.ciris_verify_get_evm_address.restype = ctypes.c_int
 
             self._lib.ciris_verify_get_evm_address_checksummed.argtypes = [
-                ctypes.POINTER(ctypes.c_uint8),  # pubkey
-                ctypes.c_size_t,  # pubkey_len
-                ctypes.POINTER(ctypes.c_char_p),  # address_str (out)
-                ctypes.POINTER(ctypes.c_size_t),  # address_str_len (out)
+                ctypes.POINTER(ctypes.c_uint8),     # pubkey
+                ctypes.c_size_t,                    # pubkey_len
+                ctypes.POINTER(ctypes.c_char_p),    # address_str (out)
+                ctypes.POINTER(ctypes.c_size_t),    # address_str_len (out)
             ]
             self._lib.ciris_verify_get_evm_address_checksummed.restype = ctypes.c_int
 
             self._lib.ciris_verify_sign_secp256k1.argtypes = [
-                ctypes.c_void_p,  # handle
-                ctypes.POINTER(ctypes.c_uint8),  # message_hash
-                ctypes.c_size_t,  # hash_len
+                ctypes.c_void_p,                    # handle
+                ctypes.POINTER(ctypes.c_uint8),     # message_hash
+                ctypes.c_size_t,                    # hash_len
                 ctypes.POINTER(ctypes.POINTER(ctypes.c_uint8)),  # signature_data (out)
-                ctypes.POINTER(ctypes.c_size_t),  # signature_len (out)
+                ctypes.POINTER(ctypes.c_size_t),    # signature_len (out)
             ]
             self._lib.ciris_verify_sign_secp256k1.restype = ctypes.c_int
 
             self._lib.ciris_verify_sign_evm_transaction.argtypes = [
-                ctypes.c_void_p,  # handle
-                ctypes.POINTER(ctypes.c_uint8),  # tx_hash
-                ctypes.c_size_t,  # hash_len
-                ctypes.c_uint64,  # chain_id
+                ctypes.c_void_p,                    # handle
+                ctypes.POINTER(ctypes.c_uint8),     # tx_hash
+                ctypes.c_size_t,                    # hash_len
+                ctypes.c_uint64,                    # chain_id
                 ctypes.POINTER(ctypes.POINTER(ctypes.c_uint8)),  # signature_data (out)
-                ctypes.POINTER(ctypes.c_size_t),  # signature_len (out)
+                ctypes.POINTER(ctypes.c_size_t),    # signature_len (out)
             ]
             self._lib.ciris_verify_sign_evm_transaction.restype = ctypes.c_int
 
             self._lib.ciris_verify_sign_typed_data.argtypes = [
-                ctypes.c_void_p,  # handle
-                ctypes.POINTER(ctypes.c_uint8),  # domain_hash
-                ctypes.c_size_t,  # domain_len
-                ctypes.POINTER(ctypes.c_uint8),  # message_hash
-                ctypes.c_size_t,  # message_len
+                ctypes.c_void_p,                    # handle
+                ctypes.POINTER(ctypes.c_uint8),     # domain_hash
+                ctypes.c_size_t,                    # domain_len
+                ctypes.POINTER(ctypes.c_uint8),     # message_hash
+                ctypes.c_size_t,                    # message_len
                 ctypes.POINTER(ctypes.POINTER(ctypes.c_uint8)),  # signature_data (out)
-                ctypes.POINTER(ctypes.c_size_t),  # signature_len (out)
+                ctypes.POINTER(ctypes.c_size_t),    # signature_len (out)
             ]
             self._lib.ciris_verify_sign_typed_data.restype = ctypes.c_int
 
             self._lib.ciris_verify_recover_evm_address.argtypes = [
-                ctypes.POINTER(ctypes.c_uint8),  # message_hash
-                ctypes.c_size_t,  # hash_len
-                ctypes.POINTER(ctypes.c_uint8),  # signature
-                ctypes.c_size_t,  # signature_len
+                ctypes.POINTER(ctypes.c_uint8),     # message_hash
+                ctypes.c_size_t,                    # hash_len
+                ctypes.POINTER(ctypes.c_uint8),     # signature
+                ctypes.c_size_t,                    # signature_len
                 ctypes.POINTER(ctypes.POINTER(ctypes.c_uint8)),  # address_data (out)
-                ctypes.POINTER(ctypes.c_size_t),  # address_len (out)
+                ctypes.POINTER(ctypes.c_size_t),    # address_len (out)
             ]
             self._lib.ciris_verify_recover_evm_address.restype = ctypes.c_int
 
             self._lib.ciris_verify_get_wallet_info.argtypes = [
-                ctypes.c_void_p,  # handle
+                ctypes.c_void_p,                    # handle
                 ctypes.POINTER(ctypes.POINTER(ctypes.c_uint8)),  # result_json (out)
-                ctypes.POINTER(ctypes.c_size_t),  # result_len (out)
+                ctypes.POINTER(ctypes.c_size_t),    # result_len (out)
             ]
             self._lib.ciris_verify_get_wallet_info.restype = ctypes.c_int
 
@@ -907,24 +909,24 @@ class CIRISVerify:
         """Clean up resources."""
         # Clear log callback first to prevent calls during destruction
         # Use getattr to handle partial initialization
-        if getattr(self, "_has_log_callback_support", False) and getattr(self, "_lib", None):
+        if getattr(self, '_has_log_callback_support', False) and getattr(self, '_lib', None):
             try:
                 # Pass null function pointer to disable callback
-                log_cb_type = getattr(self, "_log_callback_type", None)
+                log_cb_type = getattr(self, '_log_callback_type', None)
                 if log_cb_type:
                     null_callback = ctypes.cast(None, log_cb_type)
                     self._lib.ciris_verify_set_log_callback(null_callback)
             except Exception:
                 pass
         # Clear the reference after FFI call
-        if hasattr(self, "_active_log_callback"):
+        if hasattr(self, '_active_log_callback'):
             self._active_log_callback = None
-        if getattr(self, "_handle", None) and getattr(self, "_lib", None):
+        if getattr(self, '_handle', None) and getattr(self, '_lib', None):
             try:
                 self._lib.ciris_verify_destroy(self._handle)
             except Exception:
                 pass
-        if getattr(self, "_executor", None):
+        if getattr(self, '_executor', None):
             self._executor.shutdown(wait=False)
 
     def set_log_callback(self, callback=None, level: int = 3):
@@ -948,7 +950,6 @@ class CIRISVerify:
         """
         if not self._has_log_callback_support:
             import warnings
-
             warnings.warn("Log callback not supported in this library version (requires 0.9.1+)")
             return
 
@@ -1055,14 +1056,14 @@ class CIRISVerify:
             dns_us_reachable=dns_us.get("reachable", False),
             dns_eu_reachable=dns_eu.get("reachable", False),
             https_reachable=https_src.get("reachable", False),
-            validation_status=_RUST_VALIDATION_MAP.get(overall_str, ValidationStatus.VALIDATION_ERROR),
-            sources_agreeing=sum(
-                [
-                    dns_us.get("valid", False),
-                    dns_eu.get("valid", False),
-                    https_src.get("valid", False),
-                ]
+            validation_status=_RUST_VALIDATION_MAP.get(
+                overall_str, ValidationStatus.VALIDATION_ERROR
             ),
+            sources_agreeing=sum([
+                dns_us.get("valid", False),
+                dns_eu.get("valid", False),
+                https_src.get("valid", False),
+            ]),
             # Error details (added in v0.6.6)
             dns_us_error=dns_us.get("error_details") or dns_us.get("error"),
             dns_us_error_category=dns_us.get("error_category"),
@@ -1144,7 +1145,10 @@ class CIRISVerify:
             )
         else:
             reason_text = f"Reason: {reason} " if reason else ""
-            return f"CRITICAL: License verification failed. {reason_text}" "Agent capabilities are severely restricted."
+            return (
+                f"CRITICAL: License verification failed. {reason_text}"
+                "Agent capabilities are severely restricted."
+            )
 
     async def get_license_status(
         self,
@@ -1206,7 +1210,7 @@ class CIRISVerify:
                 self._handle,
                 capability.encode("utf-8"),
                 b"",  # action (default empty)
-                0,  # required_tier (default 0)
+                0,    # required_tier (default 0)
                 ctypes.byref(result),
             )
 
@@ -1563,7 +1567,9 @@ class CIRISVerify:
         )
 
         if ret != 0:
-            raise VerificationFailedError(ret, f"storage_descriptor failed with code {ret}")
+            raise VerificationFailedError(
+                ret, f"storage_descriptor failed with code {ret}"
+            )
 
         try:
             payload = ctypes.string_at(descriptor_data.value, descriptor_len.value)
@@ -1636,9 +1642,9 @@ class CIRISVerify:
             result_len = ctypes.c_size_t()
 
             # Encode paths as C strings
-            db_path_bytes = db_path.encode("utf-8")
-            jsonl_path_bytes = jsonl_path.encode("utf-8") if jsonl_path else None
-            portal_key_bytes = portal_key_id.encode("utf-8") if portal_key_id else None
+            db_path_bytes = db_path.encode('utf-8')
+            jsonl_path_bytes = jsonl_path.encode('utf-8') if jsonl_path else None
+            portal_key_bytes = portal_key_id.encode('utf-8') if portal_key_id else None
 
             ret = self._lib.ciris_verify_audit_trail(
                 self._handle,
@@ -1695,9 +1701,9 @@ class CIRISVerify:
         result_len = ctypes.c_size_t()
 
         # Encode paths as C strings
-        db_path_bytes = db_path.encode("utf-8")
-        jsonl_path_bytes = jsonl_path.encode("utf-8") if jsonl_path else None
-        portal_key_bytes = portal_key_id.encode("utf-8") if portal_key_id else None
+        db_path_bytes = db_path.encode('utf-8')
+        jsonl_path_bytes = jsonl_path.encode('utf-8') if jsonl_path else None
+        portal_key_bytes = portal_key_id.encode('utf-8') if portal_key_id else None
 
         ret = self._lib.ciris_verify_audit_trail(
             self._handle,
@@ -2008,7 +2014,9 @@ class CIRISVerify:
             VerificationFailedError: If the call fails.
         """
         if not self.has_device_attestation_failed_support:
-            raise RuntimeError("device_attestation_failed not available in this library version (requires >= 1.5.3)")
+            raise RuntimeError(
+                "device_attestation_failed not available in this library version (requires >= 1.5.3)"
+            )
 
         if platform not in ("android", "ios"):
             raise ValueError("platform must be 'android' or 'ios'")
@@ -2024,7 +2032,9 @@ class CIRISVerify:
         )
 
         if ret != 0:
-            raise VerificationFailedError(ret, f"device_attestation_failed failed with code {ret}")
+            raise VerificationFailedError(
+                ret, f"device_attestation_failed failed with code {ret}"
+            )
 
     async def device_attestation_failed(
         self,
@@ -2310,35 +2320,29 @@ class CIRISVerify:
                 elif "VulnerableSoC" in lim:
                     vuln = lim["VulnerableSoC"]
                     advisory = vuln.get("advisory", {})
-                    limitations.append(
-                        HardwareLimitation(
-                            limitation_type="VulnerableSoC",
-                            manufacturer=vuln.get("manufacturer"),
-                            advisory=SecurityAdvisory(
-                                cve=advisory.get("cve", ""),
-                                title=advisory.get("title", ""),
-                                impact=advisory.get("impact", ""),
-                                software_patchable=advisory.get("software_patchable", False),
-                                min_patch_level=advisory.get("min_patch_level"),
-                            ),
-                        )
-                    )
+                    limitations.append(HardwareLimitation(
+                        limitation_type="VulnerableSoC",
+                        manufacturer=vuln.get("manufacturer"),
+                        advisory=SecurityAdvisory(
+                            cve=advisory.get("cve", ""),
+                            title=advisory.get("title", ""),
+                            impact=advisory.get("impact", ""),
+                            software_patchable=advisory.get("software_patchable", False),
+                            min_patch_level=advisory.get("min_patch_level"),
+                        ),
+                    ))
                 elif "WeakTEE" in lim:
-                    limitations.append(
-                        HardwareLimitation(
-                            limitation_type="WeakTEE",
-                            reason=lim["WeakTEE"].get("reason"),
-                        )
-                    )
+                    limitations.append(HardwareLimitation(
+                        limitation_type="WeakTEE",
+                        reason=lim["WeakTEE"].get("reason"),
+                    ))
                 elif "OutdatedPatchLevel" in lim:
                     patch = lim["OutdatedPatchLevel"]
-                    limitations.append(
-                        HardwareLimitation(
-                            limitation_type="OutdatedPatchLevel",
-                            current_patch=patch.get("current"),
-                            minimum_patch=patch.get("minimum_required"),
-                        )
-                    )
+                    limitations.append(HardwareLimitation(
+                        limitation_type="OutdatedPatchLevel",
+                        current_patch=patch.get("current"),
+                        minimum_patch=patch.get("minimum_required"),
+                    ))
 
         return HardwareInfo(
             platform=data.get("platform", "unknown"),
@@ -2455,7 +2459,9 @@ class CIRISVerify:
                 attestation = verifier.attestation_with_challenge(challenge)
         """
         if not self._has_ed25519_support:
-            raise NotImplementedError("Ed25519 key functions not available in this library version.")
+            raise NotImplementedError(
+                "Ed25519 key functions not available in this library version."
+            )
 
         # Check if the FFI function exists
         if not hasattr(self._lib, "ciris_verify_await_key_registration"):
@@ -2485,7 +2491,6 @@ class CIRISVerify:
 
         if result_ptr.value:
             import json
-
             result_json = result_ptr.value.decode("utf-8")
             self._lib.ciris_verify_free_string(result_ptr)
             return json.loads(result_json)
@@ -2509,7 +2514,9 @@ class CIRISVerify:
             AttestationInProgressError: If attestation is currently running.
         """
         if not self._has_ed25519_support:
-            raise NotImplementedError("Ed25519 key functions not available in this library version.")
+            raise NotImplementedError(
+                "Ed25519 key functions not available in this library version."
+            )
         ret = self._lib.ciris_verify_has_key(self._handle)
         if ret == CIRIS_ERROR_ATTESTATION_IN_PROGRESS:
             raise AttestationInProgressError("has_key")
@@ -2526,7 +2533,9 @@ class CIRISVerify:
             AttestationInProgressError: If attestation is currently running.
         """
         if not self._has_ed25519_support:
-            raise NotImplementedError("Ed25519 key functions not available in this library version.")
+            raise NotImplementedError(
+                "Ed25519 key functions not available in this library version."
+            )
         ret = self._lib.ciris_verify_delete_key(self._handle)
         if ret == CIRIS_ERROR_ATTESTATION_IN_PROGRESS:
             raise AttestationInProgressError("delete_key")
@@ -2562,12 +2571,15 @@ class CIRISVerify:
             # attestation["key_attestation"]["key_type"] == "ephemeral"
         """
         if not self._has_ed25519_support:
-            raise NotImplementedError("Ed25519 key functions not available in this library version.")
+            raise NotImplementedError(
+                "Ed25519 key functions not available in this library version."
+            )
 
         # Check if the FFI function exists
         if not hasattr(self._lib, "ciris_verify_generate_key"):
             raise NotImplementedError(
-                "generate_key not available in this library version. " "Update to ciris-verify >= 1.1.16."
+                "generate_key not available in this library version. "
+                "Update to ciris-verify >= 1.1.16."
             )
 
         ret = self._lib.ciris_verify_generate_key(self._handle)
@@ -2593,7 +2605,9 @@ class CIRISVerify:
             AttestationInProgressError: If attestation is currently running.
         """
         if not self._has_ed25519_support:
-            raise NotImplementedError("Ed25519 key functions not available in this library version.")
+            raise NotImplementedError(
+                "Ed25519 key functions not available in this library version."
+            )
         sig_data = ctypes.c_void_p()
         sig_len = ctypes.c_size_t()
 
@@ -2628,7 +2642,9 @@ class CIRISVerify:
             AttestationInProgressError: If attestation is currently running.
         """
         if not self._has_ed25519_support:
-            raise NotImplementedError("Ed25519 key functions not available in this library version.")
+            raise NotImplementedError(
+                "Ed25519 key functions not available in this library version."
+            )
         key_data = ctypes.c_void_p()
         key_len = ctypes.c_size_t()
 
@@ -2706,7 +2722,7 @@ class CIRISVerify:
             CommunicationError: If wallet info retrieval fails.
             VerificationFailedError: If no Ed25519 key is loaded.
         """
-        if not getattr(self, "_has_wallet_support", False):
+        if not getattr(self, '_has_wallet_support', False):
             raise CommunicationError("Wallet support not available (library version < 1.3.0)")
 
         result_json = ctypes.POINTER(ctypes.c_uint8)()
@@ -2743,7 +2759,7 @@ class CIRISVerify:
             CommunicationError: If derivation fails.
             VerificationFailedError: If no Ed25519 key is loaded.
         """
-        if not getattr(self, "_has_wallet_support", False):
+        if not getattr(self, '_has_wallet_support', False):
             raise CommunicationError("Wallet support not available (library version < 1.3.0)")
 
         pubkey_data = ctypes.POINTER(ctypes.c_uint8)()
@@ -2783,7 +2799,7 @@ class CIRISVerify:
             CommunicationError: If address derivation fails.
             ValueError: If pubkey is not 65 bytes.
         """
-        if not getattr(self, "_has_wallet_support", False):
+        if not getattr(self, '_has_wallet_support', False):
             raise CommunicationError("Wallet support not available (library version < 1.3.0)")
 
         if pubkey is None:
@@ -2828,7 +2844,7 @@ class CIRISVerify:
             CommunicationError: If address derivation fails.
             ValueError: If pubkey is not 65 bytes.
         """
-        if not getattr(self, "_has_wallet_support", False):
+        if not getattr(self, '_has_wallet_support', False):
             raise CommunicationError("Wallet support not available (library version < 1.3.0)")
 
         if pubkey is None:
@@ -2871,7 +2887,7 @@ class CIRISVerify:
             VerificationFailedError: If no Ed25519 key is loaded.
             ValueError: If message_hash is not 32 bytes.
         """
-        if not getattr(self, "_has_wallet_support", False):
+        if not getattr(self, '_has_wallet_support', False):
             raise CommunicationError("Wallet support not available (library version < 1.3.0)")
 
         if len(message_hash) != 32:
@@ -2915,7 +2931,7 @@ class CIRISVerify:
             VerificationFailedError: If no Ed25519 key is loaded.
             ValueError: If tx_hash is not 32 bytes.
         """
-        if not getattr(self, "_has_wallet_support", False):
+        if not getattr(self, '_has_wallet_support', False):
             raise CommunicationError("Wallet support not available (library version < 1.3.0)")
 
         if len(tx_hash) != 32:
@@ -2960,7 +2976,7 @@ class CIRISVerify:
             VerificationFailedError: If no Ed25519 key is loaded.
             ValueError: If hashes are not 32 bytes.
         """
-        if not getattr(self, "_has_wallet_support", False):
+        if not getattr(self, '_has_wallet_support', False):
             raise CommunicationError("Wallet support not available (library version < 1.3.0)")
 
         if len(domain_hash) != 32:
@@ -3008,7 +3024,7 @@ class CIRISVerify:
             CommunicationError: If recovery fails (invalid signature).
             ValueError: If arguments are wrong length.
         """
-        if not getattr(self, "_has_wallet_support", False):
+        if not getattr(self, '_has_wallet_support', False):
             raise CommunicationError("Wallet support not available (library version < 1.3.0)")
 
         if len(message_hash) != 32:
@@ -3062,12 +3078,16 @@ class CIRISVerify:
             AttestationInProgressError: If attestation is currently running.
         """
         if not self._has_named_key_support:
-            raise NotImplementedError("Named key functions not available (library version < 1.5.0)")
+            raise NotImplementedError(
+                "Named key functions not available (library version < 1.5.0)"
+            )
         if len(seed) != 32:
             raise ValueError(f"seed must be 32 bytes, got {len(seed)}")
 
         key_id_bytes = key_id.encode("utf-8")
-        ret = self._lib.ciris_verify_store_named_key(self._handle, key_id_bytes, seed, len(seed))
+        ret = self._lib.ciris_verify_store_named_key(
+            self._handle, key_id_bytes, seed, len(seed)
+        )
 
         if ret == CIRIS_ERROR_ATTESTATION_IN_PROGRESS:
             raise AttestationInProgressError("store_named_key")
@@ -3089,7 +3109,9 @@ class CIRISVerify:
             AttestationInProgressError: If attestation is currently running.
         """
         if not self._has_named_key_support:
-            raise NotImplementedError("Named key functions not available (library version < 1.5.0)")
+            raise NotImplementedError(
+                "Named key functions not available (library version < 1.5.0)"
+            )
 
         sig_data = ctypes.c_void_p()
         sig_len = ctypes.c_size_t()
@@ -3107,7 +3129,9 @@ class CIRISVerify:
         if ret == CIRIS_ERROR_ATTESTATION_IN_PROGRESS:
             raise AttestationInProgressError("sign_with_named_key")
         if ret != 0:
-            raise VerificationFailedError(ret, f"sign_with_named_key failed with code {ret}")
+            raise VerificationFailedError(
+                ret, f"sign_with_named_key failed with code {ret}"
+            )
 
         try:
             return ctypes.string_at(sig_data.value, sig_len.value)
@@ -3129,7 +3153,9 @@ class CIRISVerify:
             AttestationInProgressError: If attestation is currently running.
         """
         if not self._has_named_key_support:
-            raise NotImplementedError("Named key functions not available (library version < 1.5.0)")
+            raise NotImplementedError(
+                "Named key functions not available (library version < 1.5.0)"
+            )
 
         key_id_bytes = key_id.encode("utf-8")
         ret = self._lib.ciris_verify_has_named_key(self._handle, key_id_bytes)
@@ -3152,7 +3178,9 @@ class CIRISVerify:
             AttestationInProgressError: If attestation is currently running.
         """
         if not self._has_named_key_support:
-            raise NotImplementedError("Named key functions not available (library version < 1.5.0)")
+            raise NotImplementedError(
+                "Named key functions not available (library version < 1.5.0)"
+            )
 
         key_id_bytes = key_id.encode("utf-8")
         ret = self._lib.ciris_verify_delete_named_key(self._handle, key_id_bytes)
@@ -3176,7 +3204,9 @@ class CIRISVerify:
             AttestationInProgressError: If attestation is currently running.
         """
         if not self._has_named_key_support:
-            raise NotImplementedError("Named key functions not available (library version < 1.5.0)")
+            raise NotImplementedError(
+                "Named key functions not available (library version < 1.5.0)"
+            )
 
         pk_data = ctypes.c_void_p()
         pk_len = ctypes.c_size_t()
@@ -3192,7 +3222,9 @@ class CIRISVerify:
         if ret == CIRIS_ERROR_ATTESTATION_IN_PROGRESS:
             raise AttestationInProgressError("get_named_key_public")
         if ret != 0:
-            raise VerificationFailedError(ret, f"get_named_key_public failed with code {ret}")
+            raise VerificationFailedError(
+                ret, f"get_named_key_public failed with code {ret}"
+            )
 
         try:
             return ctypes.string_at(pk_data.value, pk_len.value)
@@ -3212,10 +3244,14 @@ class CIRISVerify:
             AttestationInProgressError: If attestation is currently running.
         """
         if not self._has_named_key_support:
-            raise NotImplementedError("Named key functions not available (library version < 1.5.0)")
+            raise NotImplementedError(
+                "Named key functions not available (library version < 1.5.0)"
+            )
 
         json_out = ctypes.c_char_p()
-        ret = self._lib.ciris_verify_list_named_keys(self._handle, ctypes.byref(json_out))
+        ret = self._lib.ciris_verify_list_named_keys(
+            self._handle, ctypes.byref(json_out)
+        )
 
         if ret == CIRIS_ERROR_ATTESTATION_IN_PROGRESS:
             raise AttestationInProgressError("list_named_keys")
@@ -3336,7 +3372,10 @@ class MockCIRISVerify(CIRISVerify):
         """
         # Standard operations are always allowed, even in community mode
         cap_lower = capability.lower()
-        is_standard = cap_lower.startswith("standard:") or cap_lower.startswith("tool:")
+        is_standard = (
+            cap_lower.startswith("standard:")
+            or cap_lower.startswith("tool:")
+        )
 
         if not self._mock_status.allows_licensed_operation():
             if is_standard:
@@ -3394,7 +3433,6 @@ class MockCIRISVerify(CIRISVerify):
         # Use a mock Ed25519 signing key
         if not hasattr(self, "_mock_private_key"):
             from cryptography.hazmat.primitives.asymmetric import ed25519
-
             self._mock_private_key = ed25519.Ed25519PrivateKey.generate()
             self._mock_public_key = self._mock_private_key.public_key()
 
@@ -3407,12 +3445,10 @@ class MockCIRISVerify(CIRISVerify):
         """Mock get_public_key — returns software Ed25519 key."""
         if not hasattr(self, "_mock_private_key"):
             from cryptography.hazmat.primitives.asymmetric import ed25519
-
             self._mock_private_key = ed25519.Ed25519PrivateKey.generate()
             self._mock_public_key = self._mock_private_key.public_key()
 
         from cryptography.hazmat.primitives import serialization
-
         key_bytes = self._mock_public_key.public_bytes(
             encoding=serialization.Encoding.Raw,
             format=serialization.PublicFormat.Raw,
@@ -3460,17 +3496,13 @@ class MockCIRISVerify(CIRISVerify):
                 "https": {"reachable": True, "valid": True},
             },
             "audit_trail": None,  # Skipped in mock
-            "python_integrity": (
-                {
-                    "valid": True,
-                    "modules_checked": python_hashes.module_count,
-                    "modules_passed": python_hashes.module_count,
-                    "modules_failed": 0,
-                    "total_hash_valid": True,
-                }
-                if python_hashes
-                else None
-            ),
+            "python_integrity": {
+                "valid": True,
+                "modules_checked": python_hashes.module_count,
+                "modules_passed": python_hashes.module_count,
+                "modules_failed": 0,
+                "total_hash_valid": True,
+            } if python_hashes else None,
             "registry_key_status": "active" if key_fingerprint else "not_checked",
             "checks_passed": 3,
             "checks_total": 3,
@@ -3514,17 +3546,13 @@ class MockCIRISVerify(CIRISVerify):
                 "https": {"reachable": True, "valid": True},
             },
             "audit_trail": None,
-            "python_integrity": (
-                {
-                    "valid": True,
-                    "modules_checked": python_hashes.module_count,
-                    "modules_passed": python_hashes.module_count,
-                    "modules_failed": 0,
-                    "total_hash_valid": True,
-                }
-                if python_hashes
-                else None
-            ),
+            "python_integrity": {
+                "valid": True,
+                "modules_checked": python_hashes.module_count,
+                "modules_passed": python_hashes.module_count,
+                "modules_failed": 0,
+                "total_hash_valid": True,
+            } if python_hashes else None,
             "registry_key_status": "active" if key_fingerprint else "not_checked",
             "checks_passed": 3,
             "checks_total": 3,

--- a/client/iosApp/Resources/app/ciris_adapters/ciris_verify/ffi_bindings/exceptions.py
+++ b/client/iosApp/Resources/app/ciris_adapters/ciris_verify/ffi_bindings/exceptions.py
@@ -3,11 +3,13 @@
 
 class CIRISVerifyError(Exception):
     """Base exception for all CIRISVerify errors."""
+
     pass
 
 
 class BinaryNotFoundError(CIRISVerifyError):
     """CIRISVerify binary not found at expected path."""
+
     def __init__(self, path: str):
         self.path = path
         super().__init__(f"CIRISVerify binary not found at: {path}")
@@ -19,12 +21,14 @@ class BinaryTamperedError(CIRISVerifyError):
     This is a CRITICAL security error. The binary may have been
     modified by an attacker. All operations should be halted.
     """
+
     def __init__(self, message: str = "Binary integrity check failed"):
         super().__init__(message)
 
 
 class VerificationFailedError(CIRISVerifyError):
     """License verification failed."""
+
     def __init__(self, status_code: int, message: str):
         self.status_code = status_code
         super().__init__(f"Verification failed ({status_code}): {message}")
@@ -32,6 +36,7 @@ class VerificationFailedError(CIRISVerifyError):
 
 class TimeoutError(CIRISVerifyError):
     """Operation timed out."""
+
     def __init__(self, operation: str, timeout_seconds: float):
         self.operation = operation
         self.timeout_seconds = timeout_seconds
@@ -40,6 +45,7 @@ class TimeoutError(CIRISVerifyError):
 
 class CommunicationError(CIRISVerifyError):
     """Error communicating with CIRISVerify binary."""
+
     def __init__(self, message: str, cause: Exception = None):
         self.cause = cause
         super().__init__(message)
@@ -54,7 +60,7 @@ class AttestationInProgressError(CIRISVerifyError):
     The caller should wait ~500ms and retry. Example:
 
         import time
-        from ciris_verify import CIRISVerify, AttestationInProgressError
+        from ciris_adapters.ciris_verify.ffi_bindings import CIRISVerify, AttestationInProgressError
 
         verifier = CIRISVerify()
         max_retries = 5
@@ -69,8 +75,7 @@ class AttestationInProgressError(CIRISVerifyError):
                 else:
                     raise
     """
+
     def __init__(self, operation: str = "key operation"):
         self.operation = operation
-        super().__init__(
-            f"Attestation in progress - {operation} blocked. Retry after ~500ms."
-        )
+        super().__init__(f"Attestation in progress - {operation} blocked. Retry after ~500ms.")

--- a/client/iosApp/iosApp/Info.plist
+++ b/client/iosApp/iosApp/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.32</string>
+	<string>2.9.33</string>
 	<key>CFBundleVersion</key>
-	<string>330</string>
+	<string>334</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/CIRISApp.kt
+++ b/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/CIRISApp.kt
@@ -1662,35 +1662,54 @@ fun CIRISApp(
                             // password manager and 2FA, short enough that an
                             // abandoned attempt does not spin forever.
                             var token: ai.ciris.mobile.shared.models.OAuthHandoff? = null
+                            var failure: ai.ciris.mobile.shared.models.OAuthHandoffPoll.Failed? = null
                             var attempts = 0
-                            while (token == null && attempts < 90) {
+                            while (token == null && failure == null && attempts < 90) {
                                 kotlinx.coroutines.delay(2000)
                                 attempts++
                                 // After ~20s our own tab has had its chance;
                                 // accept a sign-in that completed in a stray
                                 // tab rather than spin while the node holds a
                                 // perfectly good session.
-                                token = apiClient.collectOAuthHandoff(
+                                when (val poll = apiClient.pollOAuthHandoff(
                                     nonce,
                                     nodeBaseUrl,
                                     allowUnbound = attempts > 10,
-                                )
-                                // Heartbeat every ~20s: "still waiting" must be
-                                // visible, or a stalled flow looks like a crashed one.
-                                if (token == null && attempts % 10 == 0) {
-                                    platformLog(TAG, "[INFO][onGoogleSignIn] still waiting for the browser (${attempts * 2}s)")
+                                )) {
+                                    is ai.ciris.mobile.shared.models.OAuthHandoffPoll.Ready -> token = poll.handoff
+                                    // The node reported a TERMINAL failure — stop
+                                    // spinning and surface its reason (#1098). Without
+                                    // this, a failed sign-in spun the full ~3 minutes.
+                                    is ai.ciris.mobile.shared.models.OAuthHandoffPoll.Failed -> failure = poll
+                                    // Heartbeat every ~20s: "still waiting" must be
+                                    // visible, or a stalled flow looks like a crashed one.
+                                    ai.ciris.mobile.shared.models.OAuthHandoffPoll.Pending ->
+                                        if (attempts % 10 == 0) {
+                                            platformLog(TAG, "[INFO][onGoogleSignIn] still waiting for the browser (${attempts * 2}s)")
+                                        }
                                 }
                             }
                             isLoginLoading = false
                             loginStatusMessage = null
                             val collected = token
                             if (collected == null) {
-                                // Say WHICH failure this is. "Sign-in failed" would
-                                // cover both "you closed the tab" and "the node is
-                                // broken", and only one of those is the user's to fix.
-                                loginErrorMessage =
-                                    LocalizationHelper.getString("auth.browser_signin.timed_out")
-                                platformLog(TAG, "[WARN][onGoogleSignIn] no hand-off after ${attempts * 2}s. If you signed in successfully, the browser tab was probably an OLD one opened without ?app_nonce= — close stray CIRIS sign-in tabs and use the button again.")
+                                // Show the reason the browser tab showed, so a user
+                                // who saw the node's error on the web page sees the
+                                // same thing here — not a 3-minute spinner (#1098).
+                                loginErrorMessage = when (failure?.reasonId) {
+                                    "auth.oauth.store_unavailable" ->
+                                        "That account is linked to more than one certificate on this node, so it can't sign you in with it. Sign in with your local username and password, or retire the duplicate."
+                                    "auth.oauth.flow_expired", "auth.oauth.state_invalid" ->
+                                        "That sign-in expired before it completed. Please try again."
+                                    null ->
+                                        LocalizationHelper.getString("auth.browser_signin.timed_out")
+                                    else ->
+                                        "Google sign-in couldn't complete (${failure?.reasonId}). Try again, or sign in with your local username and password."
+                                }
+                                // Return to the Login chooser so the message is
+                                // actionable rather than stranded behind a spinner.
+                                currentScreen = Screen.Login
+                                platformLog(TAG, "[WARN][onGoogleSignIn] sign-in did not complete after ${attempts * 2}s (reason=${failure?.reasonId ?: "timeout"}).")
                             } else {
                                 platformLog(TAG, "[INFO][onGoogleSignIn] desktop browser sign-in collected a session")
                                 currentAccessToken = collected.accessToken

--- a/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/api/CIRISApiClient.kt
+++ b/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/api/CIRISApiClient.kt
@@ -1618,17 +1618,45 @@ class CIRISApiClient(
          * bound path always wins when it exists.
          */
         allowUnbound: Boolean = false,
-    ): OAuthHandoff? {
+    ): OAuthHandoff? = (pollOAuthHandoff(appNonce, localNodeUrl, allowUnbound) as? OAuthHandoffPoll.Ready)?.handoff
+
+    /**
+     * Poll the desktop OAuth hand-off, distinguishing a TERMINAL node failure
+     * from "still waiting" (#1098 follow-up).
+     *
+     * `collectOAuthHandoff` collapsed every non-204 to null, so a failed
+     * sign-in — the node already reporting e.g. `auth.oauth.store_unavailable`
+     * or `auth.oauth.flow_expired` — was indistinguishable from "the human is
+     * still in the browser", and the caller spun the full ~3-minute timeout
+     * instead of returning to Login with the reason. This surfaces the node's
+     * own `reason_id`. Only a node-reported terminal state (a body carrying a
+     * `reason_id`) stops the poll; an unrecognized non-success is treated as
+     * transient so a boot blip does not abort a live sign-in.
+     */
+    suspend fun pollOAuthHandoff(
+        appNonce: String,
+        localNodeUrl: String = LOCAL_NODE_URL,
+        allowUnbound: Boolean = false,
+    ): OAuthHandoffPoll {
         val client = federationHttpClient()
         return try {
             val response = client.get(
                 "$localNodeUrl/v1/auth/oauth/handoff?app_nonce=$appNonce&allow_unbound=$allowUnbound"
             )
-            if (response.status.value == 204) return null
-            if (!response.status.isSuccess()) return null
-            jsonConfig.decodeFromString(OAuthHandoff.serializer(), response.bodyAsText())
+            when {
+                response.status.value == 204 -> OAuthHandoffPoll.Pending
+                response.status.isSuccess() ->
+                    OAuthHandoffPoll.Ready(jsonConfig.decodeFromString(OAuthHandoff.serializer(), response.bodyAsText()))
+                else -> {
+                    val err = runCatching {
+                        jsonConfig.decodeFromString(OAuthHandoffError.serializer(), response.bodyAsText())
+                    }.getOrNull()
+                    if (err?.reasonId != null) OAuthHandoffPoll.Failed(err.reasonId, err.status)
+                    else OAuthHandoffPoll.Pending
+                }
+            }
         } catch (_: Exception) {
-            null
+            OAuthHandoffPoll.Pending
         } finally {
             client.close()
         }

--- a/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/models/OAuthHandoff.kt
+++ b/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/models/OAuthHandoff.kt
@@ -43,3 +43,33 @@ data class OAuthHandoff(
     @SerialName("id_token")
     val idToken: String? = null,
 )
+
+/**
+ * The node's terminal error body on the OAuth hand-off endpoint, e.g.
+ * `{"reason_id":"auth.oauth.store_unavailable","status":"..."}`. Human message
+ * is derived from [reasonId] client-side (the body carries no prose).
+ */
+@Serializable
+data class OAuthHandoffError(
+    @SerialName("reason_id")
+    val reasonId: String? = null,
+    val status: String? = null,
+)
+
+/**
+ * The outcome of one poll of the desktop OAuth hand-off (#1098 follow-up).
+ *
+ * Distinguishes a TERMINAL node failure from "still waiting", so a failed
+ * sign-in returns to Login with the node's reason instead of spinning to the
+ * ~3-minute timeout.
+ */
+sealed class OAuthHandoffPoll {
+    /** 204 — not yet; the human is still in the browser. Keep waiting. */
+    object Pending : OAuthHandoffPoll()
+
+    /** The node handed the session over. */
+    data class Ready(val handoff: OAuthHandoff) : OAuthHandoffPoll()
+
+    /** The node reported a terminal failure for this flow. Stop and show it. */
+    data class Failed(val reasonId: String?, val status: String?) : OAuthHandoffPoll()
+}

--- a/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/platform/Platform.kt
+++ b/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/platform/Platform.kt
@@ -47,7 +47,10 @@ fun isWeb(): Boolean = getPlatform() == Platform.WEB
 fun getOAuthProviderName(): String = when (getPlatform()) {
     Platform.IOS -> "Apple"
     Platform.ANDROID -> "Google"
-    Platform.DESKTOP -> "Desktop"
+    // Desktop signs in through the Google browser-handoff flow (there is no
+    // native SDK), so the provider the user sees is Google — not "Desktop".
+    // Real OAuth routing already uses "google" here (CIRISApp: `else "google"`).
+    Platform.DESKTOP -> "Google"
     Platform.WEB -> "Web"
 }
 
@@ -57,7 +60,7 @@ fun getOAuthProviderName(): String = when (getPlatform()) {
 fun getOAuthProviderId(): String = when (getPlatform()) {
     Platform.IOS -> "apple"
     Platform.ANDROID -> "google"
-    Platform.DESKTOP -> "desktop"
+    Platform.DESKTOP -> "google"
     Platform.WEB -> "web"
 }
 

--- a/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupState.kt
+++ b/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/viewmodels/SetupState.kt
@@ -881,15 +881,17 @@ data class SetupFormState(
             runWithoutAi -> null
             // "Google sign-in is required" told a SIGNED-IN user to sign in.
             //
-            // The desktop browser-handoff path calls setGoogleAuthState(isAuth =
-            // true, idToken = null) on purpose — it collects a BEARER, not the raw
-            // Google ID token — so isGoogleAuth is true while googleIdToken is
-            // null. The old single check read that as "not signed in".
+            // The desktop browser-handoff path forwards the provider's ID token
+            // when the node sends one (CIRISApp: idToken = collected.idToken,
+            // CIRISServer#434 / ciris-server 0.5.177+). An older node — or a
+            // provider that issues no ID token — leaves isGoogleAuth true while
+            // googleIdToken is null, and the old single check read that as
+            // "not signed in".
             //
             // The token still genuinely matters: CIRIS_PROXY sends it AS the LLM
             // api_key (SetupViewModel: llm_api_key = googleIdToken ?: ""), so
-            // waving this through would configure the proxy with an EMPTY key and
-            // fail later, further from the cause. Two states, two messages.
+            // waving a null through would configure the proxy with an EMPTY key
+            // and fail later, further from the cause. Two states, two messages.
             setupMode == SetupMode.CIRIS_PROXY && !isGoogleAuth ->
                 LocalizationHelper.getString("setup_validation_google_required")
             setupMode == SetupMode.CIRIS_PROXY && googleIdToken == null ->


### PR DESCRIPTION
## Summary

Fixes the desktop **Google-OAuth** setup/billing path and the iOS **Apple** sign-in path. Both flows now work end-to-end on their respective devices (Apple login + billing confirmed on-device); the remaining blockers are all server/infra config, tracked separately.

## Fixes (agent-side)

1. **Provider label "Desktop" → "Google"** (`Platform.kt`). Desktop signs in via the Google browser-handoff, but `getOAuthProviderName()/Id()` returned "Desktop"/"desktop". Real routing already used "google".

2. **Duplicate-cert loop on Google OAuth** (`setup/complete.py`, `authentication_store.py`). The browser-handoff parks the session as a live wa_cert with the placeholder id `oauth-<provider>-<sub>`. The prior crash-guard let completeSetup mint a *second* cert + link Google to it → two live certs → node refused (`auth.oauth.store_unavailable`). completeSetup now captures the provisional cert id *before* minting and **retires it** (raw `set_active`) after minting+linking → one live cert. **Workaround — drop once ciris-server mints OAuth `wa_id` properly (CIRISServer#475).**

3. **Client spun ~3 min on a failed sign-in** (`CIRISApiClient.kt`, `CIRISApp.kt`, `OAuthHandoff.kt`). `collectOAuthHandoff` collapsed every non-204 to null, so a terminal node error looked like "still waiting". New `pollOAuthHandoff` returns Pending/Ready/Failed; on Failed the app stops spinning and returns to Login with the node's reason.

4. **Desktop CIRISProxy billing was disabled** (`billing_helpers.py`). `reinitialize_billing_provider` gated on `is_mobile`, silently skipping desktop. Now gates on `using_ciris_proxy` + an OAuth ID token (the real gate), so desktop configures `CIRISBillingProvider` like mobile. Verified: `Reinitialized CIRISBillingProvider … platform_mobile=False, using_ciris_proxy=True`.

5. **Native "Sign in with Apple" refused "not configured"** (`node_fold.py`, `oauth_provider_sync.py`). The 2.9.14 auth-fold moved `/v1/auth/*` onto the node, which ships a default Google provider but no Apple one — so native Apple auth (`POST /v1/auth/native/apple`) 401'd `auth.oauth.native_token_invalid`, and login-back-in failed after setup. `node_fold` now calls `ensure_native_apple_provider()` to register the app's Apple audience (`ai.ciris.mobile`). Verified on-device: `Apple auth successful … role=OBSERVER`, billing `HAS_CREDIT`.

## Testing
- **macOS desktop BYOK**: E2E green (live model dropdown → real reply) in prior runs.
- **iOS Apple OAuth**: on-device — Apple login succeeds, session + billing + credits confirmed. (LLM turn currently blocked only by a proxy-origin 522 outage — CIRISBridge#6, infra.)
- Shared module + Python parse/compile clean.

## Not in this PR (server/infra, filed)
- **CIRISBridge#5** — add the desktop Google client_id to billing `GOOGLE_CLIENT_IDS` (desktop credits).
- **CIRISBridge#6** — LLM proxy origin (`llm01.ciris-services-1.ai`) returning Cloudflare 522.
- **CIRISServer#475** — mint OAuth `wa_id` as `wa-…` so the retire-provisional workaround (fix #2) can be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)