### PR TITLE
fix(desktop): the token-refresh handshake wrote a name the agent never read (2.9.36)

### DIFF
--- a/ciris_adapters/ciris_hosted_tools/services.py
+++ b/ciris_adapters/ciris_hosted_tools/services.py
@@ -173,10 +173,16 @@ class CIRISHostedToolService:
         Returns:
             Google ID token if available, None otherwise
         """
-        # First try environment (direct or loaded at startup)
-        token = os.environ.get("CIRIS_BILLING_GOOGLE_ID_TOKEN")
+        # Same selector as billing and the LLM services. Reading only the
+        # Google name here meant that after a desktop client refreshed under a
+        # different variable, hosted tools and tool-balance requests went on
+        # sending the stale setup token — or none — while the rest of the agent
+        # had already recovered.
+        from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+        token, source_var = read_proxy_token()
         if token:
-            logger.info(f"[HOSTED_TOOLS] Got token from env CIRIS_BILLING_GOOGLE_ID_TOKEN (len={len(token)})")
+            logger.info(f"[HOSTED_TOOLS] Got token from env {source_var} (len={len(token)})")
         else:
             token = os.environ.get("GOOGLE_ID_TOKEN")
             if token:

--- a/ciris_adapters/ciris_hosted_tools/services.py
+++ b/ciris_adapters/ciris_hosted_tools/services.py
@@ -216,9 +216,20 @@ class CIRISHostedToolService:
                     logger.info(f"[HOSTED_TOOLS] Checking {env_path} exists={env_path.exists()}")
                     if env_path.exists():
                         with open(env_path) as f:
+                            # SAME NAMES AS THE SELECTOR. Scanning only for
+                            # CIRIS_BILLING_GOOGLE_ID_TOKEN here is the same
+                            # drift one level deeper: a desktop client that
+                            # refreshed under a different variable wrote it
+                            # into this very file, and this loop would walk
+                            # straight past it.
+                            from ciris_engine.logic.utils.token_handshake import PROXY_TOKEN_VARS
+
+                            found: dict[str, str] = {}
                             for line in f:
                                 line = line.strip()
-                                if line.startswith("CIRIS_BILLING_GOOGLE_ID_TOKEN="):
+                                for var in PROXY_TOKEN_VARS:
+                                    if not line.startswith(f"{var}="):
+                                        continue
                                     # Handle quoted and unquoted values
                                     value = line.split("=", 1)[1].strip()
                                     if value.startswith('"') and value.endswith('"'):
@@ -226,11 +237,20 @@ class CIRISHostedToolService:
                                     elif value.startswith("'") and value.endswith("'"):
                                         value = value[1:-1]
                                     if value:
-                                        token = value
-                                        logger.info(
-                                            f"[HOSTED_TOOLS] ✓ Loaded fresh token from {env_path} (len={len(value)})"
-                                        )
-                                        break
+                                        found[var] = value
+                            if found:
+                                # Rank them the same way the selector does, so
+                                # the file path and the environment path cannot
+                                # disagree about which token is current.
+                                from ciris_engine.logic.utils.token_handshake import jwt_expiry_epoch
+
+                                var, value = max(
+                                    found.items(), key=lambda kv: (jwt_expiry_epoch(kv[1]) or 0.0)
+                                )
+                                token = value
+                                logger.info(
+                                    f"[HOSTED_TOOLS] Loaded fresh token from {env_path} under {var} (len={len(value)})"
+                                )
                         if token:
                             break
                         else:

--- a/ciris_adapters/ciris_hosted_tools/services.py
+++ b/ciris_adapters/ciris_hosted_tools/services.py
@@ -239,14 +239,19 @@ class CIRISHostedToolService:
                                     if value:
                                         found[var] = value
                             if found:
-                                # Rank them the same way the selector does, so
-                                # the file path and the environment path cannot
-                                # disagree about which token is current.
-                                from ciris_engine.logic.utils.token_handshake import jwt_expiry_epoch
+                                # THE SAME RANKING, not a second one that
+                                # happens to agree on the easy cases. Comparing
+                                # expiry alone here left the opaque tie to
+                                # dictionary insertion order — Google first —
+                                # while the shared selector resolves that same
+                                # tie toward the legacy-desktop name. The file
+                                # path and the environment path would then pick
+                                # different tokens from identical inputs, so
+                                # hosted tools sent the stale credential while
+                                # billing and the LLM used the refreshed one.
+                                from ciris_engine.logic.utils.token_handshake import rank_candidates
 
-                                var, value = max(
-                                    found.items(), key=lambda kv: (jwt_expiry_epoch(kv[1]) or 0.0)
-                                )
+                                var, value = rank_candidates(list(found.items()))[0]
                                 token = value
                                 logger.info(
                                     f"[HOSTED_TOOLS] Loaded fresh token from {env_path} under {var} (len={len(value)})"

--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -6,11 +6,11 @@ from typing import List
 from ciris_engine.schemas.runtime.canonical_peer import CanonicalBootstrapPeer
 
 # Version information
-CIRIS_VERSION = "2.9.35-stable"
+CIRIS_VERSION = "2.9.36-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
 CIRIS_VERSION_MINOR = 9
-CIRIS_VERSION_PATCH = 35
+CIRIS_VERSION_PATCH = 36
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/ciris_engine/logic/adapters/api/adapter.py
+++ b/ciris_engine/logic/adapters/api/adapter.py
@@ -748,7 +748,9 @@ class ApiPlatform(Service):
         """Check if OAuth authentication token is available (Google or Apple)."""
         import os
 
-        return bool(os.environ.get("CIRIS_BILLING_GOOGLE_ID_TOKEN") or os.environ.get("CIRIS_BILLING_APPLE_ID_TOKEN"))
+        from ciris_engine.logic.utils.token_handshake import has_proxy_token
+
+        return has_proxy_token()
 
     def _is_hosted_tools_loaded(self) -> bool:
         """Check if ciris_hosted_tools adapter is already loaded."""

--- a/ciris_engine/logic/adapters/api/routes/billing.py
+++ b/ciris_engine/logic/adapters/api/routes/billing.py
@@ -517,14 +517,19 @@ def _try_lazy_init_billing_provider(request: Request, resource_monitor: Any) -> 
             logger.debug("[BILLING_LAZY_INIT] Reloaded .env from %s", env_path)
 
     # Check for OAuth ID token (written by Kotlin when user logs in - Google on Android, Apple on iOS)
-    google_token = os.environ.get("CIRIS_BILLING_GOOGLE_ID_TOKEN", "") or os.environ.get(
-        "CIRIS_BILLING_APPLE_ID_TOKEN", ""
-    )
+    # The shared selector, because compatibility must not depend on a provider
+    # already existing. Reading only the Google/Apple names here meant that when
+    # Python started BEFORE an older desktop client signed in — and that client
+    # writes its own variable — this returned None, /credits answered with the
+    # unlimited-credit response, and the purchase routes reported no provider
+    # configured, all while a perfectly good token sat in the environment.
+    from ciris_engine.logic.utils.token_handshake import PROXY_TOKEN_VARS, read_proxy_token
+
+    google_token, token_var = read_proxy_token()
     if not google_token:
-        logger.debug(
-            "[BILLING_LAZY_INIT] No CIRIS_BILLING_GOOGLE_ID_TOKEN or CIRIS_BILLING_APPLE_ID_TOKEN in environment"
-        )
+        logger.debug("[BILLING_LAZY_INIT] no proxy token in environment (looked at %s)", ", ".join(PROXY_TOKEN_VARS))
         return None
+    logger.debug("[BILLING_LAZY_INIT] using the token from %s", token_var)
 
     # Get billing URL from central config (checks env var first)
     billing_url = get_billing_url()
@@ -968,9 +973,9 @@ async def verify_google_play_purchase(
     if not google_id_token:
         import os
 
-        google_id_token = os.environ.get("CIRIS_BILLING_GOOGLE_ID_TOKEN") or os.environ.get(
-            "CIRIS_BILLING_APPLE_ID_TOKEN"
-        )
+        from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+        google_id_token, _tok_var = read_proxy_token()
         if google_id_token:
             logger.info(f"[GOOGLE_PLAY_VERIFY] Using OAuth ID token from environment ({len(google_id_token)} chars)")
     else:

--- a/ciris_engine/logic/adapters/api/routes/setup/config.py
+++ b/ciris_engine/logic/adapters/api/routes/setup/config.py
@@ -515,7 +515,9 @@ async def update_llm_config(
         config_path.write_text(new_content, encoding="utf-8")
 
         # Trigger config reload signal for the Python runtime
-        reload_file = config_path.parent / ".config_reload"
+        from ciris_engine.logic.utils.token_handshake import CONFIG_RELOAD_SIGNAL_FILE
+
+        reload_file = config_path.parent / CONFIG_RELOAD_SIGNAL_FILE
         import time
 
         reload_file.write_text(str(time.time()), encoding="utf-8")

--- a/ciris_engine/logic/adapters/api/routes/tools.py
+++ b/ciris_engine/logic/adapters/api/routes/tools.py
@@ -175,23 +175,27 @@ def _get_billing_url() -> str:
 
 
 def _get_google_id_token(request: Request) -> Optional[str]:
-    """Get Google ID token from request headers or environment."""
+    """Get the OAuth ID token for a tool request.
+
+    A header wins — the caller is naming the identity this request is for.
+    Otherwise the shared selector decides, exactly as billing, the LLM services
+    and the hosted-tools adapter do. Reading the variable names directly here
+    meant the balance, check and purchase endpoints kept forwarding the expired
+    setup token after a client had refreshed under a different name: tools
+    stayed broken while the rest of the agent had already recovered.
+    """
     # Try header first (set by Android)
     token = request.headers.get("X-Google-ID-Token")
     if token:
         return token
 
-    # Try environment (set after login) - Google on Android, Apple on iOS
-    token = os.environ.get("CIRIS_BILLING_GOOGLE_ID_TOKEN")
-    if token:
-        return token
+    from ciris_engine.logic.utils.token_handshake import read_proxy_token
 
-    token = os.environ.get("CIRIS_BILLING_APPLE_ID_TOKEN")
-    if token:
-        return token
+    selected, _var = read_proxy_token()
+    if selected:
+        return selected
 
-    token = os.environ.get("GOOGLE_ID_TOKEN")
-    return token
+    return os.environ.get("GOOGLE_ID_TOKEN")
 
 
 async def _make_billing_request(

--- a/ciris_engine/logic/runtime/billing_helpers.py
+++ b/ciris_engine/logic/runtime/billing_helpers.py
@@ -127,7 +127,14 @@ def create_billing_provider(google_id_token: str) -> Any:
     fail_open = os.getenv("CIRIS_BILLING_FAIL_OPEN", "false").lower() == "true"
 
     def get_fresh_token() -> str:
-        return os.getenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", "") or os.getenv("CIRIS_BILLING_APPLE_ID_TOKEN", "")
+        # Same selector as everywhere else. A first-non-empty read here handed
+        # back the stale Google value when a legacy desktop client had
+        # refreshed under its own name, and the provider installed it over the
+        # fresh token — undoing the refresh on the next billing request.
+        from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+        token, _var = read_proxy_token()
+        return token
 
     return CIRISBillingProvider(
         google_id_token=google_id_token,

--- a/ciris_engine/logic/runtime/billing_helpers.py
+++ b/ciris_engine/logic/runtime/billing_helpers.py
@@ -29,7 +29,9 @@ def create_billing_token_handler(credit_provider: Any) -> Callable[..., Any]:
     """Create handler for billing token refresh signals."""
 
     async def handle_billing_token_refreshed(signal: str, resource: str) -> None:
-        new_token = os.getenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", "") or os.getenv("CIRIS_BILLING_APPLE_ID_TOKEN", "")
+        from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+        new_token, _var = read_proxy_token()
         if new_token and credit_provider:
             credit_provider.update_google_id_token(new_token)
             logger.info("Updated billing provider with refreshed OAuth ID token")
@@ -41,11 +43,21 @@ def create_llm_token_handler(runtime: Any) -> Callable[..., Any]:
     """Create handler for LLM service token refresh signals."""
 
     async def handle_llm_token_refreshed(signal: str, resource: str) -> None:
-        new_token = os.getenv("OPENAI_API_KEY", "")
+        # THIS HANDLER ONLY EVER TOUCHES CIRIS-PROXY SERVICES
+        # (`update_service_token_if_ciris_proxy` returns early for anything
+        # else), and those authenticate with the OAuth ID token — not with
+        # OPENAI_API_KEY. Reading OPENAI_API_KEY here meant the hosted-proxy
+        # case, where it is empty, bailed out and refreshed nothing; and the
+        # BYOK-leftover case, where it holds someone's provider key, pushed the
+        # wrong credential over a good token.
+        from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+        new_token, source_var = read_proxy_token()
         if not new_token:
-            logger.warning("[LLM_TOKEN] No OPENAI_API_KEY in env after token refresh")
+            logger.warning("[TOKEN_HANDSHAKE] no proxy token in env after refresh — services unchanged")
             return
 
+        logger.info("[TOKEN_HANDSHAKE] pushing the token from %s to every proxy service", source_var)
         update_llm_services_token(runtime, new_token)
 
     return handle_llm_token_refreshed

--- a/ciris_engine/logic/runtime/billing_helpers.py
+++ b/ciris_engine/logic/runtime/billing_helpers.py
@@ -172,7 +172,9 @@ async def reinitialize_billing_provider(runtime: Any) -> None:
         logger.info("Billing provider not needed (not using CIRIS proxy)")
         return
 
-    google_id_token = os.getenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", "") or os.getenv("CIRIS_BILLING_APPLE_ID_TOKEN", "")
+    from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+    google_id_token, _tok_var = read_proxy_token()
     if not google_id_token:
         logger.warning("Using CIRIS LLM proxy without OAuth ID token - billing provider not configured")
         return

--- a/ciris_engine/logic/runtime/service_initializer.py
+++ b/ciris_engine/logic/runtime/service_initializer.py
@@ -218,9 +218,9 @@ class ServiceInitializer:
         # Server: Simple API key check
         api_key = os.getenv("CIRIS_BILLING_API_KEY", "")
         # Mobile: OAuth ID token for JWT auth with CIRIS proxy (Google on Android, Apple on iOS)
-        google_id_token = os.getenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", "") or os.getenv(
-            "CIRIS_BILLING_APPLE_ID_TOKEN", ""
-        )
+        from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+        google_id_token, _tok_var = read_proxy_token()
 
         if api_key and not is_android:
             # Server with API key - use API key auth
@@ -1103,6 +1103,7 @@ This directory contains critical cryptographic keys for the CIRIS system.
         # Base URL only applies to OpenAI-compatible providers
         base_url = None
         base_urls = None  # Multi-endpoint support for CIRIS proxy
+        is_ciris_proxy_url_checked = False
         if provider in (LLMProvider.OPENAI, LLMProvider.OPENAI_COMPATIBLE):
             base_url = os.environ.get("OPENAI_API_BASE") or self._get_llm_service_config_value(
                 config, "llm_endpoint", None
@@ -1111,7 +1112,8 @@ This directory contains critical cryptographic keys for the CIRIS system.
             if base_url:
                 from ciris_engine.config.ciris_services import get_all_proxy_endpoints, is_ciris_proxy_url
 
-                if is_ciris_proxy_url(base_url):
+                is_ciris_proxy_url_checked = is_ciris_proxy_url(base_url)
+                if is_ciris_proxy_url_checked:
                     # Skip CIRIS proxy if user has disabled CIRIS services
                     if ciris_services_disabled:
                         logger.info(" Skipping CIRIS proxy (CIRIS_SERVICES_DISABLED=true)")
@@ -1137,6 +1139,27 @@ This directory contains critical cryptographic keys for the CIRIS system.
                             f"[MULTI_ENDPOINT] CIRIS proxy detected, using {len(base_urls)} endpoints: "
                             f"{[ep.region for ep in endpoints]}"
                         )
+
+        # A CIRIS-PROXY URL MEANS THE CREDENTIAL IS THE OAUTH ID TOKEN.
+        #
+        # The proxy has no provider enum of its own — it rides OPENAI_COMPATIBLE
+        # — so the key came from OPENAI_API_KEY, which is where the setup wizard
+        # stashed the ID token once, at setup. That value is an hour-lived JWT.
+        # Every restart therefore rebuilt the primary service around the
+        # setup-time token no matter how many times the refresh handshake had
+        # replaced it since, and the first interaction after a restart 401'd
+        # until another whole handshake completed. The handshake variables are
+        # the live copy; read them here.
+        if base_url and is_ciris_proxy_url_checked and not ciris_services_disabled:
+            from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+            proxy_token, proxy_var = read_proxy_token(current=api_key)
+            if proxy_token and proxy_token != api_key:
+                logger.info(
+                    "[TOKEN_HANDSHAKE] proxy startup credential taken from %s, not the setup-time key",
+                    proxy_var,
+                )
+                api_key = proxy_token
 
         # Needed by BOTH the model default below and the service name further
         # down; computed once, here, so the two cannot disagree about it.
@@ -1371,9 +1394,9 @@ This directory contains critical cryptographic keys for the CIRIS system.
 
         primary_is_local = base_url and not is_ciris_proxy_url(base_url)
         if primary_is_local and not ciris_services_disabled:
-            id_token = os.environ.get("CIRIS_BILLING_GOOGLE_ID_TOKEN", "") or os.environ.get(
-                "CIRIS_BILLING_APPLE_ID_TOKEN", ""
-            )
+            from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+            id_token, _tok_var = read_proxy_token()
             if id_token:
                 logger.info(" Primary LLM is local - registering CIRIS proxy as fallback")
                 await self._initialize_ciris_proxy_fallback(config, id_token)
@@ -1382,9 +1405,9 @@ This directory contains critical cryptographic keys for the CIRIS system.
         # Supports both API key auth and CIRIS proxy with JWT auth (Google ID token)
         second_api_key = os.environ.get("CIRIS_OPENAI_API_KEY_2", "")
         second_base_url = os.environ.get("CIRIS_OPENAI_API_BASE_2", "")
-        google_id_token = os.environ.get("CIRIS_BILLING_GOOGLE_ID_TOKEN", "") or os.environ.get(
-            "CIRIS_BILLING_APPLE_ID_TOKEN", ""
-        )
+        from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+        google_id_token, _tok_var = read_proxy_token()
 
         # Check if secondary LLM is CIRIS proxy (requires JWT auth, not API key)
         is_ciris_proxy_secondary = "ciris.ai" in second_base_url

--- a/ciris_engine/logic/services/infrastructure/resource_monitor/ciris_billing_provider.py
+++ b/ciris_engine/logic/services/infrastructure/resource_monitor/ciris_billing_provider.py
@@ -23,11 +23,11 @@ from ciris_engine.schemas.services.credit_gate import (
 logger = logging.getLogger(__name__)
 
 
-def _read_proxy_token() -> str:
+def _read_proxy_token(current: str = "") -> str:
     """The freshest proxy token, chosen exactly as the LLM side chooses it."""
     from ciris_engine.logic.utils.token_handshake import read_proxy_token
 
-    token, _var = read_proxy_token()
+    token, _var = read_proxy_token(current=current)
     return token
 
 
@@ -112,25 +112,51 @@ class CIRISBillingProvider(CreditGateProtocol):
         5. ResourceMonitor reloads .env (via load_dotenv override=True)
         6. This method reads the updated GOOGLE_ID_TOKEN from environment
         """
-        # First, try the callback if available
+        # THE SHARED SELECTOR DECIDES, AND IT GOES FIRST.
+        #
+        # This used to consult the injected callback first and return the
+        # moment that callback produced anything different. The callback is a
+        # first-non-empty read of the Google/Apple names, so when a legacy
+        # desktop client had refreshed under its own name — leaving a stale
+        # Google value beside a fresh one — the callback handed back the STALE
+        # token, installed it over the fresh one the refresh handler had just
+        # set, and returned before this method ever reached the selector. The
+        # fix upstream was undone on the very next billing request, and billing
+        # kept answering AUTH_EXPIRED while the LLM key looked healthy.
+        #
+        # The selector also needs to know what we are holding: with opaque
+        # tokens it cannot rank by expiry, and "the copy that is not the one
+        # currently being rejected" is the only signal left.
+        selected = _read_proxy_token(current=self._google_id_token)
+        if selected:
+            if selected != self._google_id_token:
+                logger.info(
+                    "[TOKEN_HANDSHAKE] billing token updated from the environment: %d chars -> %d chars",
+                    len(self._google_id_token) if self._google_id_token else 0,
+                    len(selected),
+                )
+                self._google_id_token = selected
+            return self._google_id_token
+
+        # Nothing in the environment at all — fall back to the injected
+        # callback, which is how a caller supplies a token from somewhere other
+        # than .env, then to the legacy variable.
         if self._token_refresh_callback:
             try:
                 new_token = self._token_refresh_callback()
                 if new_token and new_token != self._google_id_token:
                     old_len = len(self._google_id_token) if self._google_id_token else 0
-                    new_len = len(new_token)
-                    logger.info("[BILLING_TOKEN] Token refreshed via callback: %d chars -> %d chars", old_len, new_len)
+                    logger.info(
+                        "[TOKEN_HANDSHAKE] billing token refreshed via callback: %d chars -> %d chars",
+                        old_len,
+                        len(new_token),
+                    )
                     self._google_id_token = new_token
                     return self._google_id_token
             except Exception as exc:
-                logger.warning("[BILLING_TOKEN] Token refresh callback failed: %s", exc)
+                logger.warning("[TOKEN_HANDSHAKE] billing token refresh callback failed: %s", exc)
 
-        # Check environment for updated token (set by auth route or ResourceMonitor after .env reload)
-        # Check Google token (Android), Apple token (iOS), and legacy GOOGLE_ID_TOKEN
-        env_token = (
-            _read_proxy_token()
-            or os.environ.get("GOOGLE_ID_TOKEN", "")
-        )
+        env_token = os.environ.get("GOOGLE_ID_TOKEN", "")
         if env_token and env_token != self._google_id_token:
             old_len = len(self._google_id_token) if self._google_id_token else 0
             new_len = len(env_token)

--- a/ciris_engine/logic/services/infrastructure/resource_monitor/ciris_billing_provider.py
+++ b/ciris_engine/logic/services/infrastructure/resource_monitor/ciris_billing_provider.py
@@ -23,6 +23,14 @@ from ciris_engine.schemas.services.credit_gate import (
 logger = logging.getLogger(__name__)
 
 
+def _read_proxy_token() -> str:
+    """The freshest proxy token, chosen exactly as the LLM side chooses it."""
+    from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+    token, _var = read_proxy_token()
+    return token
+
+
 class CIRISBillingProvider(CreditGateProtocol):
     """Async credit provider that gates interactions via self-hosted CIRIS Billing API.
 
@@ -63,8 +71,12 @@ class CIRISBillingProvider(CreditGateProtocol):
         self._api_key = api_key or os.environ.get("CIRIS_BILLING_API_KEY", "")
         self._google_id_token = (
             google_id_token
-            or os.environ.get("CIRIS_BILLING_GOOGLE_ID_TOKEN", "")
-            or os.environ.get("CIRIS_BILLING_APPLE_ID_TOKEN", "")
+            # Same selector the LLM side uses: billing that keeps reading only
+            # the Google/Apple names goes on sending the stale setup-time token
+            # after a legacy-desktop client refreshed under its own name, so
+            # AUTH_EXPIRED keeps gating every interaction even once the LLM key
+            # has recovered.
+            or _read_proxy_token()
         )
         self._token_refresh_callback = token_refresh_callback
         # Use provided URL or get from central config
@@ -116,8 +128,7 @@ class CIRISBillingProvider(CreditGateProtocol):
         # Check environment for updated token (set by auth route or ResourceMonitor after .env reload)
         # Check Google token (Android), Apple token (iOS), and legacy GOOGLE_ID_TOKEN
         env_token = (
-            os.environ.get("CIRIS_BILLING_GOOGLE_ID_TOKEN", "")
-            or os.environ.get("CIRIS_BILLING_APPLE_ID_TOKEN", "")
+            _read_proxy_token()
             or os.environ.get("GOOGLE_ID_TOKEN", "")
         )
         if env_token and env_token != self._google_id_token:

--- a/ciris_engine/logic/services/infrastructure/resource_monitor/ciris_billing_provider.py
+++ b/ciris_engine/logic/services/infrastructure/resource_monitor/ciris_billing_provider.py
@@ -23,11 +23,11 @@ from ciris_engine.schemas.services.credit_gate import (
 logger = logging.getLogger(__name__)
 
 
-def _read_proxy_token(current: str = "") -> str:
+def _read_proxy_token(current: str = "", callback_token: str = "") -> str:
     """The freshest proxy token, chosen exactly as the LLM side chooses it."""
     from ciris_engine.logic.utils.token_handshake import read_proxy_token
 
-    token, _var = read_proxy_token(current=current)
+    token, _var = read_proxy_token(current=current, callback_token=callback_token)
     return token
 
 
@@ -127,34 +127,33 @@ class CIRISBillingProvider(CreditGateProtocol):
         # The selector also needs to know what we are holding: with opaque
         # tokens it cannot rank by expiry, and "the copy that is not the one
         # currently being rejected" is the only signal left.
-        selected = _read_proxy_token(current=self._google_id_token)
+        # ASK THE CALLBACK, THEN RANK IT WITH EVERYTHING ELSE.
+        #
+        # This has now been wrong in both directions. Consulting the callback
+        # FIRST and returning on any difference let a stale value overwrite a
+        # fresh one — the refresh was undone on the next billing request.
+        # Skipping the callback whenever the environment held anything fixed
+        # that but silently disabled callers who fetch credentials from secure
+        # storage or some other external source, which is exactly what the
+        # parameter is documented for. So the callback is neither first nor
+        # last: it is a candidate, and the selector ranks it.
+        callback_token = ""
+        if self._token_refresh_callback:
+            try:
+                callback_token = self._token_refresh_callback() or ""
+            except Exception as exc:
+                logger.warning("[TOKEN_HANDSHAKE] billing token refresh callback failed: %s", exc)
+
+        selected = _read_proxy_token(current=self._google_id_token, callback_token=callback_token)
         if selected:
             if selected != self._google_id_token:
                 logger.info(
-                    "[TOKEN_HANDSHAKE] billing token updated from the environment: %d chars -> %d chars",
+                    "[TOKEN_HANDSHAKE] billing token updated: %d chars -> %d chars",
                     len(self._google_id_token) if self._google_id_token else 0,
                     len(selected),
                 )
                 self._google_id_token = selected
             return self._google_id_token
-
-        # Nothing in the environment at all — fall back to the injected
-        # callback, which is how a caller supplies a token from somewhere other
-        # than .env, then to the legacy variable.
-        if self._token_refresh_callback:
-            try:
-                new_token = self._token_refresh_callback()
-                if new_token and new_token != self._google_id_token:
-                    old_len = len(self._google_id_token) if self._google_id_token else 0
-                    logger.info(
-                        "[TOKEN_HANDSHAKE] billing token refreshed via callback: %d chars -> %d chars",
-                        old_len,
-                        len(new_token),
-                    )
-                    self._google_id_token = new_token
-                    return self._google_id_token
-            except Exception as exc:
-                logger.warning("[TOKEN_HANDSHAKE] billing token refresh callback failed: %s", exc)
 
         env_token = os.environ.get("GOOGLE_ID_TOKEN", "")
         if env_token and env_token != self._google_id_token:

--- a/ciris_engine/logic/services/infrastructure/resource_monitor/ciris_billing_provider.py
+++ b/ciris_engine/logic/services/infrastructure/resource_monitor/ciris_billing_provider.py
@@ -604,34 +604,15 @@ class CIRISBillingProvider(CreditGateProtocol):
             self._client.headers["Authorization"] = f"Bearer {token}"
 
     def _signal_token_refresh_needed(self) -> None:
-        """Write a signal file to indicate token refresh is needed.
+        """Ask the client for a fresh token (billing's 401 path).
 
-        This is picked up by Android's TokenRefreshManager which will:
-        1. Call Google silentSignIn() to get a fresh ID token
-        2. Update .env with the new token
-        3. Write .config_reload signal
-        4. Python ResourceMonitor detects .config_reload and emits token_refreshed
+        Byte-for-byte the same conversation the LLM service has, so it is the
+        same code now — `utils.token_handshake` owns the directory, the
+        filename and the wording.
         """
-        import time
-        from pathlib import Path
+        from ciris_engine.logic.utils.token_handshake import request_token_refresh
 
-        # Get CIRIS_HOME
-        ciris_home = os.environ.get("CIRIS_HOME")
-        if not ciris_home:
-            try:
-                from ciris_engine.logic.utils.path_resolution import get_ciris_home
-
-                ciris_home = str(get_ciris_home())
-            except Exception:
-                logger.warning("[BILLING_TOKEN] Cannot write refresh signal - CIRIS_HOME not found")
-                return
-
-        try:
-            signal_file = Path(ciris_home) / ".token_refresh_needed"
-            signal_file.write_text(str(time.time()))
-            logger.info("[BILLING_TOKEN] Token refresh signal written to: %s", signal_file)
-        except Exception as exc:
-            logger.warning("[BILLING_TOKEN] Failed to write token refresh signal: %s", exc)
+        request_token_refresh(reason="billing 401")
 
     def _store_cache(self, cache_key: str, result: CreditCheckResult) -> None:
         if self._cache_ttl <= 0:

--- a/ciris_engine/logic/services/infrastructure/resource_monitor/service.py
+++ b/ciris_engine/logic/services/infrastructure/resource_monitor/service.py
@@ -245,9 +245,16 @@ class ResourceMonitorService(BaseScheduledService, ResourceMonitorServiceProtoco
             if not self._ciris_home:
                 return
 
-            # Watch for .config_reload signal (written by Android after token refresh)
-            config_reload_file = self._ciris_home / ".config_reload"
-            env_file = self._ciris_home / ".env"
+            # Watch for the client's answer. Filenames come from the shared
+            # handshake module so this side and the client cannot disagree
+            # about which files the conversation uses.
+            from ciris_engine.logic.utils.token_handshake import (
+                CONFIG_RELOAD_SIGNAL_FILE,
+                ENV_FILE,
+            )
+
+            config_reload_file = self._ciris_home / CONFIG_RELOAD_SIGNAL_FILE
+            env_file = self._ciris_home / ENV_FILE
 
             # Check if config reload signal file exists
             if not config_reload_file.exists():
@@ -260,7 +267,12 @@ class ResourceMonitorService(BaseScheduledService, ResourceMonitorServiceProtoco
                 return
 
             # New config reload signal detected!
-            logger.info(f" Config reload signal detected from Android (timestamp: {signal_mtime})")
+            logger.info(
+                "[TOKEN_HANDSHAKE] client answered: %s (mtime=%s) — reloading %s",
+                config_reload_file,
+                signal_mtime,
+                env_file,
+            )
 
             # Verify .env exists
             if not env_file.exists():
@@ -279,7 +291,7 @@ class ResourceMonitorService(BaseScheduledService, ResourceMonitorServiceProtoco
 
             # 2. Emit token_refreshed signal (LLM service will reset circuit breaker)
             await self.signal_bus.emit("token_refreshed", "openai_api_key")
-            logger.info("[OK] Emitted token_refreshed signal")
+            logger.info("[TOKEN_HANDSHAKE] emitted token_refreshed — services will re-read the env")
 
             # 3. Mark signal as processed and clean up
             self._token_refresh_signal_mtime = signal_mtime

--- a/ciris_engine/logic/services/runtime/llm_service/service.py
+++ b/ciris_engine/logic/services/runtime/llm_service/service.py
@@ -1489,11 +1489,24 @@ class OpenAICompatibleClient(BaseService, LLMServiceProtocol):
 
         # Read fresh API key from appropriate environment variable
         if is_ciris_proxy:
-            # CIRIS proxy uses JWT auth (Google/Apple ID token)
-            new_api_key = os.environ.get("CIRIS_BILLING_GOOGLE_ID_TOKEN", "") or os.environ.get(
-                "CIRIS_BILLING_APPLE_ID_TOKEN", ""
-            )
-            logger.info("[LLM_TOKEN] CIRIS proxy service - reading from CIRIS_BILLING_*_ID_TOKEN")
+            # CIRIS proxy uses JWT auth (Google/Apple ID token).
+            #
+            # THREE NAMES, because three clients wrote three names. Android
+            # writes CIRIS_BILLING_GOOGLE_ID_TOKEN, iOS writes
+            # CIRIS_BILLING_APPLE_ID_TOKEN, and desktop wrote
+            # CIRIS_BILLING_OAUTH_TOKEN — a variable nothing here had ever
+            # read. So on desktop the whole refresh handshake completed
+            # successfully and changed nothing: the client silently re-signed
+            # in, rewrote .env, tripped the reload, and this method re-read the
+            # SAME expired token, reported "unchanged", reset the breaker, and
+            # 401'd again. Forever, from about an hour after setup.
+            #
+            # The desktop client now writes the Google name like Android does;
+            # this reads the legacy name too so a client and an agent that
+            # disagree about the version still recover.
+            from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+            new_api_key, source_var = read_proxy_token(current=self.openai_config.api_key or "")
         else:
             # Standard OpenAI-compatible service uses OPENAI_API_KEY
             new_api_key = os.environ.get("OPENAI_API_KEY", "")
@@ -1508,7 +1521,23 @@ class OpenAICompatibleClient(BaseService, LLMServiceProtocol):
         if key_changed:
             self.update_api_key(new_api_key)
         else:
-            logger.info("[LLM_TOKEN] API key unchanged after refresh - resetting circuit breaker")
+            # SAY WHAT WAS ACTUALLY CHECKED. This branch is what a stranded
+            # desktop user's log looked like for the whole outage, and it read
+            # as routine housekeeping: a reload happened, nothing changed, the
+            # breaker reset, the next call 401'd. Naming the variables that
+            # were consulted separates "the client never wrote a new token"
+            # from "the token is new and the provider still rejects it" — two
+            # different problems that looked identical here.
+            if is_ciris_proxy:
+                logger.warning(
+                    "[LLM_TOKEN] Reload produced NO new token — still holding the same value "
+                    "(read %s). The client signalled a refresh but wrote nothing this agent "
+                    "reads, so every proxy call will keep failing 401. Resetting the breaker "
+                    "anyway so the next attempt is not suppressed.",
+                    source_var or "no CIRIS_BILLING_* variable",
+                )
+            else:
+                logger.info("[LLM_TOKEN] API key unchanged after refresh - resetting circuit breaker")
             self.circuit_breaker.reset()
 
         # Also check if base URL changed (e.g. .env migration from legacy URLs)
@@ -2602,25 +2631,15 @@ class OpenAICompatibleClient(BaseService, LLMServiceProtocol):
         return "UNKNOWN"
 
     def _signal_token_refresh_needed(self) -> None:
-        """Write a signal file to indicate token refresh is needed (for ciris.ai).
+        """Ask the client for a fresh proxy token.
 
-        This file is monitored by the Android app to trigger Google silentSignIn().
-        The signal file is written to CIRIS_HOME/.token_refresh_needed
+        The path, the filename and the logging live in
+        `ciris_engine.logic.utils.token_handshake`. This method used to resolve
+        CIRIS_HOME and spell the filename itself — and so did a second copy in
+        the billing provider, and three Kotlin clients each had their own
+        constants. That is exactly how the desktop half came to write a token
+        variable this half never read.
         """
-        import os
-        from pathlib import Path
+        from ciris_engine.logic.utils.token_handshake import request_token_refresh
 
-        try:
-            # Get CIRIS_HOME from environment (set by mobile_main.py on Android)
-            ciris_home = os.getenv("CIRIS_HOME")
-            if not ciris_home:
-                # Fallback for non-Android environments
-                from ciris_engine.logic.utils.path_resolution import get_ciris_home
-
-                ciris_home = str(get_ciris_home())
-
-            signal_file = Path(ciris_home) / ".token_refresh_needed"
-            signal_file.write_text(str(time.time()))
-            logger.info(f"Token refresh signal written to: {signal_file}")
-        except Exception as e:
-            logger.error(f"Failed to write token refresh signal: {e}")
+        request_token_refresh(reason=f"proxy 401 on model {self.model_name}")

--- a/ciris_engine/logic/utils/platform_detection.py
+++ b/ciris_engine/logic/utils/platform_detection.py
@@ -28,6 +28,20 @@ from ciris_engine.schemas.platform import PlatformCapabilities, PlatformRequirem
 logger = logging.getLogger(__name__)
 
 
+
+def _has_proxy_token() -> bool:
+    """Any OAuth proxy token, under any of the handshake names.
+
+    These presence checks used to ask only about the Google variable, so a
+    client that had refreshed under a different one looked exactly like a user
+    who never signed in — the capability was withdrawn while a good token sat
+    right there in the environment.
+    """
+    from ciris_engine.logic.utils.token_handshake import has_proxy_token
+
+    return has_proxy_token()
+
+
 def is_ios() -> bool:
     """Detect if running on iOS platform.
 
@@ -132,7 +146,7 @@ def _detect_android_capabilities() -> set[PlatformRequirement]:
 
     # Native Google auth is available if Play Services is available
     # AND we have a valid Google ID token
-    google_token = os.getenv("CIRIS_BILLING_GOOGLE_ID_TOKEN") or os.getenv("GOOGLE_ID_TOKEN")
+    google_token = _has_proxy_token() or bool(os.getenv("GOOGLE_ID_TOKEN"))
     if google_token:
         capabilities.add(PlatformRequirement.GOOGLE_NATIVE_AUTH)
 
@@ -273,7 +287,7 @@ def detect_platform_capabilities() -> PlatformCapabilities:
         tpm_available=PlatformRequirement.TPM in capabilities,
         # Token state
         has_valid_device_token=bool(
-            os.getenv("CIRIS_BILLING_GOOGLE_ID_TOKEN") or os.getenv("GOOGLE_ID_TOKEN") or os.getenv("APPLE_ID_TOKEN")
+            _has_proxy_token() or os.getenv("GOOGLE_ID_TOKEN") or os.getenv("APPLE_ID_TOKEN")
         ),
         token_binding_method=_get_token_binding_method(capabilities),
     )

--- a/ciris_engine/logic/utils/token_handshake.py
+++ b/ciris_engine/logic/utils/token_handshake.py
@@ -146,6 +146,44 @@ def jwt_expiry_epoch(token: str) -> Optional[float]:
 _OPAQUE_TIE_ORDER = ("callback", "CIRIS_BILLING_OAUTH_TOKEN", "CIRIS_BILLING_GOOGLE_ID_TOKEN", "CIRIS_BILLING_APPLE_ID_TOKEN")
 
 
+def rank_candidates(candidates: Sequence[Tuple[str, str]]) -> list:
+    """Order (name, token) pairs best-first. One definition of "best".
+
+    EXPIRY STATUS IS A TIER, NOT A NUMBER. Ranking on the raw `exp` alone put
+    an EXPIRED JWT above every opaque token, because an expired token still
+    carries a large positive epoch while a token whose format has no `exp` at
+    all scores zero. So a credential we can prove is dead outranked one that
+    might be alive — including the opaque forms a refresh callback legitimately
+    returns, which meant the callback could hand back a good token and be
+    ignored in favour of the expired value we were already being refused for.
+
+    The three tiers, best first:
+
+      2. live      — a JWT whose `exp` is still in the future; among these the
+                     later expiry is the newer issue
+      1. unknown   — no readable `exp`; among these :data:`_OPAQUE_TIE_ORDER`
+                     decides, which is where the legacy-desktop compatibility
+                     case is resolved
+      0. expired   — a JWT we can prove is dead; kept as a last resort rather
+                     than discarded, because sending a stale token and getting
+                     a clean 401 beats sending nothing at all
+
+    Nothing here reads what is currently installed: the order is a property of
+    the candidates, so repeated calls cannot oscillate.
+    """
+    now = time.time()
+
+    def key(vt: Tuple[str, str]) -> Tuple[int, float, int]:
+        var, token = vt
+        tie = -(_OPAQUE_TIE_ORDER.index(var) if var in _OPAQUE_TIE_ORDER else len(_OPAQUE_TIE_ORDER))
+        expiry = jwt_expiry_epoch(token)
+        if expiry is None:
+            return (1, 0.0, tie)
+        return (2 if expiry > now else 0, expiry, tie)
+
+    return sorted(candidates, key=key, reverse=True)
+
+
 def read_proxy_token(
     current: str = "",
     callback_token: str = "",
@@ -198,15 +236,7 @@ def read_proxy_token(
         )
         return "", ""
 
-    def rank(vt: Tuple[str, str]) -> Tuple[float, int]:
-        var, token = vt
-        expiry = jwt_expiry_epoch(token)
-        tie = _OPAQUE_TIE_ORDER.index(var) if var in _OPAQUE_TIE_ORDER else len(_OPAQUE_TIE_ORDER)
-        # Sort: latest expiry first, then the documented order. Negate the
-        # index so a single reverse=True gives both.
-        return (expiry if expiry is not None else 0.0, -tie)
-
-    ranked = sorted(present, key=rank, reverse=True)
+    ranked = rank_candidates(present)
     var, token = ranked[0]
 
     if len(ranked) > 1:

--- a/ciris_engine/logic/utils/token_handshake.py
+++ b/ciris_engine/logic/utils/token_handshake.py
@@ -159,7 +159,21 @@ def read_proxy_token(
 
     ranked = sorted(present, key=lambda vt: (jwt_expiry_epoch(vt[1]) or 0.0), reverse=True)
     if current and ranked[0][1] == current:
-        alternative = next((vt for vt in ranked if vt[1] != current), None)
+        # Only sideways or forwards, never back. Preferring "any copy that
+        # differs" is right when the tokens are opaque and both score 0 — that
+        # is the legacy-desktop case this exists for — but wrong the moment the
+        # value in hand is genuinely the freshest: a stale sibling left in .env
+        # would then be selected on every reload, downgrading a working key and
+        # restarting the 401 loop this whole module exists to end.
+        current_expiry = jwt_expiry_epoch(current) or 0.0
+        alternative = next(
+            (
+                vt
+                for vt in ranked
+                if vt[1] != current and (jwt_expiry_epoch(vt[1]) or 0.0) >= current_expiry
+            ),
+            None,
+        )
         if alternative is not None:
             logger.info(
                 "%s %s still holds the value already in use; taking the differing copy from %s",

--- a/ciris_engine/logic/utils/token_handshake.py
+++ b/ciris_engine/logic/utils/token_handshake.py
@@ -32,7 +32,7 @@ import logging
 import os
 import time
 from pathlib import Path
-from typing import Optional, Sequence, Tuple
+from typing import List, Optional, Sequence, Set, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -146,7 +146,7 @@ def jwt_expiry_epoch(token: str) -> Optional[float]:
 _OPAQUE_TIE_ORDER = ("callback", "CIRIS_BILLING_OAUTH_TOKEN", "CIRIS_BILLING_GOOGLE_ID_TOKEN", "CIRIS_BILLING_APPLE_ID_TOKEN")
 
 
-def rank_candidates(candidates: Sequence[Tuple[str, str]]) -> list:
+def rank_candidates(candidates: Sequence[Tuple[str, str]]) -> List[Tuple[str, str]]:
     """Order (name, token) pairs best-first. One definition of "best".
 
     EXPIRY STATUS IS A TIER, NOT A NUMBER. Ranking on the raw `exp` alone put
@@ -218,8 +218,8 @@ def read_proxy_token(
     # callback which produced something the environment does not have. Without
     # this, the legacy first-non-empty callback would re-win every tie with the
     # very stale value we are trying to move off.
-    present: list[Tuple[str, str]] = []
-    seen: set[str] = set()
+    present: List[Tuple[str, str]] = []
+    seen: Set[str] = set()
     for var in sources:
         token = os.environ.get(var, "")
         if token and token not in seen:

--- a/ciris_engine/logic/utils/token_handshake.py
+++ b/ciris_engine/logic/utils/token_handshake.py
@@ -220,3 +220,14 @@ def read_proxy_token(
     if current and token != current:
         logger.info("%s selected token differs from the one in use — swapping to %s", LOG_PREFIX, var)
     return token, var
+
+
+def has_proxy_token() -> bool:
+    """Whether ANY proxy token is available.
+
+    The presence checks that gate hosted-proxy features asked only about the
+    Google name, so a client that refreshed under a different one looked to
+    them like a user who had never signed in — the capability was withdrawn
+    while a perfectly good token sat in the environment.
+    """
+    return any(os.environ.get(var) for var in PROXY_TOKEN_VARS)

--- a/ciris_engine/logic/utils/token_handshake.py
+++ b/ciris_engine/logic/utils/token_handshake.py
@@ -137,59 +137,86 @@ def jwt_expiry_epoch(token: str) -> Optional[float]:
         return None
 
 
+#: How to break a tie when NO candidate carries a readable expiry. Order is
+#: meaning, not taste: a token handed back by a caller's callback was fetched
+#: on purpose just now; CIRIS_BILLING_OAUTH_TOKEN is only ever written by a
+#: desktop client that has just refreshed (setup writes the Google name, and
+#: the corrected client deletes this one), so its presence implies it is the
+#: newer of the two.
+_OPAQUE_TIE_ORDER = ("callback", "CIRIS_BILLING_OAUTH_TOKEN", "CIRIS_BILLING_GOOGLE_ID_TOKEN", "CIRIS_BILLING_APPLE_ID_TOKEN")
+
+
 def read_proxy_token(
-    current: str = "", sources: Sequence[str] = PROXY_TOKEN_VARS
+    current: str = "",
+    callback_token: str = "",
+    sources: Sequence[str] = PROXY_TOKEN_VARS,
 ) -> Tuple[str, str]:
-    """The freshest proxy token in the environment, and the name it came under.
+    """The freshest proxy token available, and the name it came under.
 
-    Returns ``("", "")`` when none is present.
+    Returns ``("", "")`` when there is none.
 
-    Not first-non-empty: a real `.env` carries more than one of these — the
-    name written at setup, plus whatever the client last refreshed — and name
-    order returns the setup-time token, which is precisely the expired one. So
-    rank by expiry, and never re-select the value already in hand when a
-    different copy exists, because "keep the credential that is currently
-    401ing" is not a resolution of that tie.
+    THE ANSWER DEPENDS ONLY ON THE CANDIDATES, NEVER ON WHAT IS CURRENTLY
+    INSTALLED. An earlier version broke the tie by preferring "any copy that
+    differs from the one in hand", which made the opaque-token case flip on
+    every single request: holding A it returned B, then holding B the stable
+    sort put A first again and it returned A, for ever. A selector that answers
+    differently depending on who is asking is not a selector. `current` is now
+    read only to describe the outcome in the log.
+
+    Ranking: readable ``exp`` first (a JWT that lasts longer is the newer
+    issue), then :data:`_OPAQUE_TIE_ORDER` for candidates whose expiry cannot
+    be read at all.
+
+    `callback_token` participates as an ordinary candidate. It used to be
+    consulted first and unconditionally, which let a stale value overwrite a
+    fresh one; then it was skipped entirely whenever the environment held
+    anything, which silently disabled callers who fetch credentials from
+    secure storage. It is neither privileged nor ignored — it is ranked.
     """
-    present = [(var, os.environ.get(var, "")) for var in sources]
-    present = [(var, tok) for var, tok in present if tok]
+    # Build the candidate set, DEDUPED BY VALUE. A callback that hands back a
+    # token already sitting in the environment has told us nothing new — it is
+    # echoing, not sourcing — so it keeps the environment's label and does not
+    # get the "fetched on purpose just now" precedence that belongs to a
+    # callback which produced something the environment does not have. Without
+    # this, the legacy first-non-empty callback would re-win every tie with the
+    # very stale value we are trying to move off.
+    present: list[Tuple[str, str]] = []
+    seen: set[str] = set()
+    for var in sources:
+        token = os.environ.get(var, "")
+        if token and token not in seen:
+            present.append((var, token))
+            seen.add(token)
+    if callback_token and callback_token not in seen:
+        present.append(("callback", callback_token))
     if not present:
-        logger.warning("%s no proxy token in the environment (looked at %s)", LOG_PREFIX, ", ".join(sources))
+        logger.warning(
+            "%s no proxy token available (looked at %s%s)",
+            LOG_PREFIX,
+            ", ".join(sources),
+            " and the refresh callback" if callback_token == "" else "",
+        )
         return "", ""
 
-    ranked = sorted(present, key=lambda vt: (jwt_expiry_epoch(vt[1]) or 0.0), reverse=True)
-    if current and ranked[0][1] == current:
-        # Only sideways or forwards, never back. Preferring "any copy that
-        # differs" is right when the tokens are opaque and both score 0 — that
-        # is the legacy-desktop case this exists for — but wrong the moment the
-        # value in hand is genuinely the freshest: a stale sibling left in .env
-        # would then be selected on every reload, downgrading a working key and
-        # restarting the 401 loop this whole module exists to end.
-        current_expiry = jwt_expiry_epoch(current) or 0.0
-        alternative = next(
-            (
-                vt
-                for vt in ranked
-                if vt[1] != current and (jwt_expiry_epoch(vt[1]) or 0.0) >= current_expiry
-            ),
-            None,
-        )
-        if alternative is not None:
-            logger.info(
-                "%s %s still holds the value already in use; taking the differing copy from %s",
-                LOG_PREFIX,
-                ranked[0][0],
-                alternative[0],
-            )
-            ranked = [alternative] + [vt for vt in ranked if vt is not alternative]
+    def rank(vt: Tuple[str, str]) -> Tuple[float, int]:
+        var, token = vt
+        expiry = jwt_expiry_epoch(token)
+        tie = _OPAQUE_TIE_ORDER.index(var) if var in _OPAQUE_TIE_ORDER else len(_OPAQUE_TIE_ORDER)
+        # Sort: latest expiry first, then the documented order. Negate the
+        # index so a single reverse=True gives both.
+        return (expiry if expiry is not None else 0.0, -tie)
 
+    ranked = sorted(present, key=rank, reverse=True)
     var, token = ranked[0]
+
     if len(ranked) > 1:
         logger.info(
-            "%s %d tokens present (%s) — chose %s by expiry",
+            "%s %d tokens present (%s) — chose %s",
             LOG_PREFIX,
             len(ranked),
             ", ".join(v for v, _ in ranked),
             var,
         )
+    if current and token != current:
+        logger.info("%s selected token differs from the one in use — swapping to %s", LOG_PREFIX, var)
     return token, var

--- a/ciris_engine/logic/utils/token_handshake.py
+++ b/ciris_engine/logic/utils/token_handshake.py
@@ -1,0 +1,181 @@
+"""The client↔agent token-refresh handshake, defined once.
+
+The CIRIS-hosted proxy is authenticated with the user's OAuth ID token, and
+those expire in about an hour. Replacing one is a four-step conversation
+across a process boundary, carried by two marker files in CIRIS_HOME:
+
+    agent  401 from the proxy        -> writes `.token_refresh_needed`
+    client polls that file           -> silently re-signs in
+    client rewrites `.env`           -> with a token name the agent reads
+    client writes `.config_reload`   -> agent reloads .env, swaps its key
+
+Every value in that conversation — the two filenames, the directory they
+live in, and the environment variables the token may arrive under — used to
+be written out again at each site: two separate copies of
+`_signal_token_refresh_needed`, three writers of `.config_reload`, three
+Kotlin clients each with their own constants. That is how the desktop client
+came to write `CIRIS_BILLING_OAUTH_TOKEN`, a name no Python code had ever
+read: both halves were locally correct and the handshake was silently dead,
+so a desktop user's agent 401'd every call from about an hour after setup
+and never recovered.
+
+One definition, so the two halves cannot drift again. The Kotlin side mirrors
+these names in `EnvFileUpdater.kt`; that mirror is what the cross-language
+test in `test_desktop_token_refresh_handshake.py` pins.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+#: The agent asks for a fresh token by creating this file.
+TOKEN_REFRESH_REQUEST_FILE = ".token_refresh_needed"
+
+#: The client answers by creating this one, after rewriting `.env`.
+CONFIG_RELOAD_SIGNAL_FILE = ".config_reload"
+
+#: Where the refreshed token is written.
+ENV_FILE = ".env"
+
+#: Every name a proxy token may arrive under. Android writes the Google name,
+#: iOS the Apple one; desktop wrote CIRIS_BILLING_OAUTH_TOKEN before it was
+#: corrected, and that name stays readable so a client and an agent on
+#: different versions still complete the handshake.
+PROXY_TOKEN_VARS: Tuple[str, ...] = (
+    "CIRIS_BILLING_GOOGLE_ID_TOKEN",
+    "CIRIS_BILLING_APPLE_ID_TOKEN",
+    "CIRIS_BILLING_OAUTH_TOKEN",
+)
+
+#: One prefix for every step, so `grep TOKEN_HANDSHAKE` reads as one story
+#: across both processes instead of four unrelated-looking lines.
+LOG_PREFIX = "[TOKEN_HANDSHAKE]"
+
+
+def handshake_home() -> Optional[Path]:
+    """The directory both halves meet in.
+
+    CIRIS_HOME when set, else the shared resolver — never a third opinion.
+    """
+    explicit = os.getenv("CIRIS_HOME")
+    if explicit:
+        return Path(explicit)
+    try:
+        from ciris_engine.logic.utils.path_resolution import get_ciris_home
+
+        # Coerce: callers (and test doubles) hand back either a Path or a str,
+        # and every use here is `home / filename`, which a str cannot do.
+        return Path(get_ciris_home())
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("%s cannot resolve CIRIS_HOME: %s", LOG_PREFIX, exc)
+        return None
+
+
+def token_refresh_request_path() -> Optional[Path]:
+    home = handshake_home()
+    return home / TOKEN_REFRESH_REQUEST_FILE if home else None
+
+
+def config_reload_signal_path() -> Optional[Path]:
+    home = handshake_home()
+    return home / CONFIG_RELOAD_SIGNAL_FILE if home else None
+
+
+def env_path() -> Optional[Path]:
+    home = handshake_home()
+    return home / ENV_FILE if home else None
+
+
+def request_token_refresh(reason: str) -> bool:
+    """Ask the client for a fresh token. Returns whether the ask was written.
+
+    Says WHERE it wrote and WHY, because the failure mode this exists for is a
+    client that is not watching: the ask succeeds, nothing answers, and the
+    only way to tell from the log is to see the path the agent chose and
+    compare it with the one the client polls.
+    """
+    path = token_refresh_request_path()
+    if path is None:
+        logger.error("%s cannot request a refresh: no CIRIS_HOME (reason=%s)", LOG_PREFIX, reason)
+        return False
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(str(time.time()))
+        logger.info("%s asked the client for a fresh token: %s (reason=%s)", LOG_PREFIX, path, reason)
+        return True
+    except Exception as exc:
+        logger.error("%s failed to write the refresh request at %s: %s", LOG_PREFIX, path, exc)
+        return False
+
+
+def jwt_expiry_epoch(token: str) -> Optional[float]:
+    """The `exp` claim of a JWT, or None if this is not a readable JWT.
+
+    UNVERIFIED ON PURPOSE. This is not an authorization decision — the provider
+    still verifies the signature and rejects anything stale. It only orders
+    several copies of our OWN token that different clients wrote under
+    different names, and the only honest ordering between them is which lasts
+    longer. Anything unparseable sorts last rather than raising.
+    """
+    try:
+        parts = token.split(".")
+        if len(parts) != 3:
+            return None
+        payload = parts[1] + "=" * (-len(parts[1]) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload.encode("ascii")))
+        exp = claims.get("exp")
+        return float(exp) if exp is not None else None
+    except Exception:
+        return None
+
+
+def read_proxy_token(
+    current: str = "", sources: Sequence[str] = PROXY_TOKEN_VARS
+) -> Tuple[str, str]:
+    """The freshest proxy token in the environment, and the name it came under.
+
+    Returns ``("", "")`` when none is present.
+
+    Not first-non-empty: a real `.env` carries more than one of these — the
+    name written at setup, plus whatever the client last refreshed — and name
+    order returns the setup-time token, which is precisely the expired one. So
+    rank by expiry, and never re-select the value already in hand when a
+    different copy exists, because "keep the credential that is currently
+    401ing" is not a resolution of that tie.
+    """
+    present = [(var, os.environ.get(var, "")) for var in sources]
+    present = [(var, tok) for var, tok in present if tok]
+    if not present:
+        logger.warning("%s no proxy token in the environment (looked at %s)", LOG_PREFIX, ", ".join(sources))
+        return "", ""
+
+    ranked = sorted(present, key=lambda vt: (jwt_expiry_epoch(vt[1]) or 0.0), reverse=True)
+    if current and ranked[0][1] == current:
+        alternative = next((vt for vt in ranked if vt[1] != current), None)
+        if alternative is not None:
+            logger.info(
+                "%s %s still holds the value already in use; taking the differing copy from %s",
+                LOG_PREFIX,
+                ranked[0][0],
+                alternative[0],
+            )
+            ranked = [alternative] + [vt for vt in ranked if vt is not alternative]
+
+    var, token = ranked[0]
+    if len(ranked) > 1:
+        logger.info(
+            "%s %d tokens present (%s) — chose %s by expiry",
+            LOG_PREFIX,
+            len(ranked),
+            ", ".join(v for v, _ in ranked),
+            var,
+        )
+    return token, var

--- a/client/androidApp/build.gradle
+++ b/client/androidApp/build.gradle
@@ -25,8 +25,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 35
-        versionCode 172
-        versionName "2.9.35"
+        versionCode 173
+        versionName "2.9.36"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/client/androidApp/src/main/python/version.py
+++ b/client/androidApp/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.9.35"
+__version__ = "android-2.9.36"
 
 
 def get_version() -> str:

--- a/client/desktopApp/build.gradle.kts
+++ b/client/desktopApp/build.gradle.kts
@@ -34,7 +34,7 @@ compose.desktop {
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "CIRIS"
-            packageVersion = "2.9.35"
+            packageVersion = "2.9.36"
             description = "CIRIS Agent Desktop Application"
             vendor = "CIRIS L3C"
 

--- a/client/iosApp/iosApp/Info.plist
+++ b/client/iosApp/iosApp/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.35</string>
+	<string>2.9.36</string>
 	<key>CFBundleVersion</key>
-	<string>336</string>
+	<string>337</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/client/shared/src/androidMain/kotlin/ai/ciris/mobile/shared/platform/EnvFileUpdater.android.kt
+++ b/client/shared/src/androidMain/kotlin/ai/ciris/mobile/shared/platform/EnvFileUpdater.android.kt
@@ -22,8 +22,8 @@ actual class EnvFileUpdater {
     companion object {
         private const val TAG = "EnvFileUpdater"
         private const val ENV_FILE_NAME = ".env"
-        private const val CONFIG_RELOAD_FILE = ".config_reload"
-        private const val TOKEN_REFRESH_SIGNAL_FILE = ".token_refresh_needed"
+        private val CONFIG_RELOAD_FILE = TokenHandshake.CONFIG_RELOAD_SIGNAL_FILE
+        private val TOKEN_REFRESH_SIGNAL_FILE = TokenHandshake.TOKEN_REFRESH_REQUEST_FILE
 
         /**
          * Get CIRIS_HOME from environment variable (set by CirisVerify.setup())

--- a/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/platform/EnvFileUpdater.kt
+++ b/client/shared/src/commonMain/kotlin/ai/ciris/mobile/shared/platform/EnvFileUpdater.kt
@@ -13,6 +13,37 @@ import ai.ciris.mobile.shared.config.CIRISConfig
  * Logic extracted from:
  * - android/app/src/main/java/ai/ciris/mobile/auth/TokenRefreshManager.kt (lines 240-334)
  */
+/**
+ * The client half of the token-refresh handshake, named once.
+ *
+ * The agent writes [TOKEN_REFRESH_REQUEST_FILE] when the hosted proxy rejects
+ * its token; we re-sign-in, write the fresh token into [ENV_FILE] under
+ * [tokenEnvVarFor], and answer with [CONFIG_RELOAD_SIGNAL_FILE]. The agent
+ * mirrors these names in `ciris_engine/logic/utils/token_handshake.py`.
+ *
+ * These were three sets of private constants, one per platform, and desktop's
+ * token variable did not match what the agent reads — so the handshake
+ * completed and changed nothing, and hosted-proxy users were dead an hour
+ * after setup with no error that named the cause. One place now, and a test
+ * pins both sides against each other.
+ */
+object TokenHandshake {
+    const val TOKEN_REFRESH_REQUEST_FILE = ".token_refresh_needed"
+    const val CONFIG_RELOAD_SIGNAL_FILE = ".config_reload"
+    const val ENV_FILE = ".env"
+
+    /** Google sign-in — Android and desktop. */
+    const val GOOGLE_TOKEN_VAR = "CIRIS_BILLING_GOOGLE_ID_TOKEN"
+
+    /** Apple sign-in — iOS. */
+    const val APPLE_TOKEN_VAR = "CIRIS_BILLING_APPLE_ID_TOKEN"
+
+    /** What desktop wrote before this was corrected. Readable by the agent for
+     *  one release so a mismatched client/agent pair still recovers; never
+     *  written any more. */
+    const val LEGACY_DESKTOP_TOKEN_VAR = "CIRIS_BILLING_OAUTH_TOKEN"
+}
+
 expect class EnvFileUpdater {
     /**
      * Update the .env file with a new OAuth ID token (Google on Android, Apple on iOS).

--- a/client/shared/src/desktopMain/kotlin/ai/ciris/mobile/shared/platform/EnvFileUpdater.desktop.kt
+++ b/client/shared/src/desktopMain/kotlin/ai/ciris/mobile/shared/platform/EnvFileUpdater.desktop.kt
@@ -13,17 +13,27 @@ actual class EnvFileUpdater {
         File(home).also { it.mkdirs() }
     }
 
-    private val envFile: File get() = File(cirisHome, ".env")
-    private val configReloadFile: File get() = File(cirisHome, ".config_reload")
-    private val tokenRefreshSignalFile: File get() = File(cirisHome, ".token_refresh_needed")
+    private val envFile: File get() = File(cirisHome, TokenHandshake.ENV_FILE)
+    private val configReloadFile: File get() = File(cirisHome, TokenHandshake.CONFIG_RELOAD_SIGNAL_FILE)
+    private val tokenRefreshSignalFile: File get() = File(cirisHome, TokenHandshake.TOKEN_REFRESH_REQUEST_FILE)
     private var lastSignalTimestamp: Long = 0
 
     actual suspend fun updateEnvWithToken(oauthIdToken: String): Result<Boolean> = runCatching {
         val envContent = if (envFile.exists()) envFile.readText() else ""
         val lines = envContent.lines().toMutableList()
 
-        // Update or add CIRIS_BILLING_OAUTH_TOKEN
-        val tokenKey = "CIRIS_BILLING_OAUTH_TOKEN"
+        // WRITE THE NAME PYTHON READS. This wrote CIRIS_BILLING_OAUTH_TOKEN,
+        // which no Python code has ever read — Android writes
+        // CIRIS_BILLING_GOOGLE_ID_TOKEN and iOS writes
+        // CIRIS_BILLING_APPLE_ID_TOKEN, and those are the two the agent looks
+        // for. So on desktop the refresh handshake ran to completion and
+        // achieved nothing: silent re-sign-in, .env rewritten, .config_reload
+        // tripped, and the agent re-read the SAME expired token. The hosted
+        // proxy authenticates with that token, so it 401'd every call from
+        // roughly an hour after setup and never recovered.
+        //
+        // Desktop sign-in is Google, so it takes the Google name.
+        val tokenKey = TokenHandshake.GOOGLE_TOKEN_VAR
         val tokenLine = "$tokenKey=$oauthIdToken"
 
         val existingIndex = lines.indexOfFirst { it.startsWith("$tokenKey=") }
@@ -32,6 +42,10 @@ actual class EnvFileUpdater {
         } else {
             lines.add(tokenLine)
         }
+
+        // Drop the legacy name if this .env still carries one, so a stale
+        // value cannot sit next to the fresh token confusing the next reader.
+        lines.removeAll { it.startsWith("${TokenHandshake.LEGACY_DESKTOP_TOKEN_VAR}=") }
 
         envFile.writeText(lines.joinToString("\n"))
         triggerConfigReload()

--- a/client/shared/src/iosMain/kotlin/ai/ciris/mobile/shared/platform/EnvFileUpdater.ios.kt
+++ b/client/shared/src/iosMain/kotlin/ai/ciris/mobile/shared/platform/EnvFileUpdater.ios.kt
@@ -19,8 +19,8 @@ actual class EnvFileUpdater {
     companion object {
         private const val TAG = "EnvFileUpdater.ios"
         private const val ENV_FILE_NAME = ".env"
-        private const val CONFIG_RELOAD_FILE = ".config_reload"
-        private const val TOKEN_REFRESH_SIGNAL_FILE = ".token_refresh_needed"
+        private val CONFIG_RELOAD_FILE = TokenHandshake.CONFIG_RELOAD_SIGNAL_FILE
+        private val TOKEN_REFRESH_SIGNAL_FILE = TokenHandshake.TOKEN_REFRESH_REQUEST_FILE
     }
 
     private var lastSignalTimestamp: Long = 0

--- a/tests/ciris_adapters/ciris_hosted_tools/test_hosted_tools_token.py
+++ b/tests/ciris_adapters/ciris_hosted_tools/test_hosted_tools_token.py
@@ -1,0 +1,107 @@
+"""How hosted tools finds the OAuth token it authenticates with.
+
+Hosted tool calls and tool-balance requests carry the same OAuth ID token as
+billing and the LLM proxy. When this method disagreed with the others about
+which variable that token lives in, tool requests went on using the stale
+setup-time credential after a client refresh had already revived the rest of
+the agent — the same outage, in the one subsystem nobody thought to check.
+
+So the property under test is agreement, not mechanism: whatever the shared
+selector would choose, from the environment or from the `.env` file, is what
+these requests must carry.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+
+import pytest
+
+PROXY_VARS = (
+    "CIRIS_BILLING_GOOGLE_ID_TOKEN",
+    "CIRIS_BILLING_APPLE_ID_TOKEN",
+    "CIRIS_BILLING_OAUTH_TOKEN",
+)
+
+
+def jwt(exp_offset_seconds: float) -> str:
+    payload = (
+        base64.urlsafe_b64encode(json.dumps({"exp": time.time() + exp_offset_seconds}).encode())
+        .decode()
+        .rstrip("=")
+    )
+    return f"header.{payload}.signature"
+
+
+@pytest.fixture
+def service():
+    from ciris_adapters.ciris_hosted_tools.services import CIRISHostedToolService
+
+    return CIRISHostedToolService.__new__(CIRISHostedToolService)
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch, tmp_path):
+    for var in PROXY_VARS + ("GOOGLE_ID_TOKEN",):
+        monkeypatch.delenv(var, raising=False)
+    # Point the .env search at an empty directory so the file branch cannot
+    # pick up a developer's real token during the environment-only cases.
+    monkeypatch.setenv("CIRIS_HOME", str(tmp_path))
+    monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+    return tmp_path
+
+
+class TestFromTheEnvironment:
+    @pytest.mark.parametrize("var", PROXY_VARS)
+    def test_any_name_the_selector_knows_is_accepted(self, service, monkeypatch, var):
+        monkeypatch.setenv(var, "the-token")
+        assert service._get_google_id_token() == "the-token"
+
+    def test_the_freshest_wins_when_several_are_present(self, service, monkeypatch):
+        fresh, stale = jwt(3600), jwt(-600)
+        monkeypatch.setenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", stale)
+        monkeypatch.setenv("CIRIS_BILLING_OAUTH_TOKEN", fresh)
+        assert service._get_google_id_token() == fresh
+
+    def test_the_legacy_variable_still_works(self, service, monkeypatch):
+        monkeypatch.setenv("GOOGLE_ID_TOKEN", "legacy-token")
+        assert service._get_google_id_token() == "legacy-token"
+
+    def test_nothing_anywhere_is_None_not_an_exception(self, service):
+        assert service._get_google_id_token() is None
+
+
+class TestFromTheEnvFile:
+    """The path that exists because the client rewrites .env after we started."""
+
+    def test_a_refreshed_token_is_read_back_from_the_file(self, service, clean_env):
+        (clean_env / ".env").write_text('CIRIS_BILLING_GOOGLE_ID_TOKEN="from-the-file"\n')
+        assert service._get_google_id_token() == "from-the-file"
+
+    def test_the_legacy_desktop_name_is_read_back_too(self, service, clean_env):
+        """The exact stranding case: the client wrote its refresh into this
+        file under its own name, and the scan used to walk past it."""
+        (clean_env / ".env").write_text("CIRIS_BILLING_OAUTH_TOKEN=refreshed-by-legacy-desktop\n")
+        assert service._get_google_id_token() == "refreshed-by-legacy-desktop"
+
+    def test_the_file_is_ranked_the_same_way_as_the_environment(self, service, clean_env):
+        fresh, stale = jwt(3600), jwt(-600)
+        (clean_env / ".env").write_text(
+            f"CIRIS_BILLING_GOOGLE_ID_TOKEN={stale}\nCIRIS_BILLING_OAUTH_TOKEN={fresh}\n"
+        )
+        assert service._get_google_id_token() == fresh
+
+    def test_single_quoted_values_are_unwrapped(self, service, clean_env):
+        (clean_env / ".env").write_text("CIRIS_BILLING_GOOGLE_ID_TOKEN='quoted-token'\n")
+        assert service._get_google_id_token() == "quoted-token"
+
+    def test_an_empty_assignment_is_not_a_token(self, service, clean_env):
+        (clean_env / ".env").write_text('CIRIS_BILLING_GOOGLE_ID_TOKEN=""\n')
+        assert service._get_google_id_token() is None
+
+    def test_the_environment_beats_the_file(self, service, clean_env, monkeypatch):
+        (clean_env / ".env").write_text("CIRIS_BILLING_GOOGLE_ID_TOKEN=from-file\n")
+        monkeypatch.setenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", "from-env")
+        assert service._get_google_id_token() == "from-env"

--- a/tests/ciris_engine/config/test_ciris_services.py
+++ b/tests/ciris_engine/config/test_ciris_services.py
@@ -197,9 +197,18 @@ class TestGetBillingUrl:
             assert url == custom_url
 
     def test_env_override_ciris_billing_url(self) -> None:
-        """Test CIRIS_BILLING_URL environment override (backward compat)."""
+        """Test CIRIS_BILLING_URL environment override (backward compat).
+
+        CIRIS_BILLING_API_URL is checked FIRST, so this test — which is about
+        the older, lower-precedence name — has to say that the newer one is
+        absent. It used to depend on that being true by luck, and failed
+        whenever anything earlier in the session left CIRIS_BILLING_API_URL in
+        the environment (a `load_dotenv(override=True)` on a real .env will do
+        it), which made an unrelated suite look broken.
+        """
         custom_url = "https://custom-billing.example.com"
         with patch.dict(os.environ, {"CIRIS_BILLING_URL": custom_url}):
+            os.environ.pop("CIRIS_BILLING_API_URL", None)
             url = get_billing_url(use_fallback=False)
             assert url == custom_url
 

--- a/tests/ciris_engine/logic/runtime/test_billing_provider_helpers.py
+++ b/tests/ciris_engine/logic/runtime/test_billing_provider_helpers.py
@@ -221,22 +221,40 @@ class TestCreateLLMTokenHandler:
         return runtime
 
     @pytest.mark.asyncio
-    async def test_handler_calls_update_llm_services(self, runtime):
-        """Handler calls update_llm_services_token with new token."""
+    async def test_handler_pushes_the_refreshed_PROXY_token(self, runtime):
+        """The token this handler distributes is the OAuth ID token.
+
+        It used to read OPENAI_API_KEY, and this test pinned that. But the
+        handler only ever touches CIRIS-proxy services — everything else
+        returns early inside `update_service_token_if_ciris_proxy` — and those
+        authenticate with the ID token, not with a provider API key. Reading
+        OPENAI_API_KEY meant the hosted-proxy case (where it is empty) bailed
+        out and refreshed nothing, while a BYOK leftover in that variable
+        would be pushed over a perfectly good proxy token.
+        """
         handler = runtime._create_llm_token_handler()
 
-        with patch.dict(os.environ, {"OPENAI_API_KEY": "new-api-key"}):
+        with patch.dict(os.environ, {"CIRIS_BILLING_GOOGLE_ID_TOKEN": "fresh-id-token"}, clear=True):
             with patch("ciris_engine.logic.runtime.billing_helpers.update_llm_services_token") as mock_update:
                 await handler("token_refreshed", "llm")
-                mock_update.assert_called_once_with(runtime, "new-api-key")
+                mock_update.assert_called_once_with(runtime, "fresh-id-token")
+
+    @pytest.mark.asyncio
+    async def test_handler_ignores_an_unrelated_OPENAI_API_KEY(self, runtime):
+        """A BYOK key left in the environment is not a proxy credential."""
+        handler = runtime._create_llm_token_handler()
+
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-someone-elses-key"}, clear=True):
+            with patch("ciris_engine.logic.runtime.billing_helpers.update_llm_services_token") as mock_update:
+                await handler("token_refreshed", "llm")
+                mock_update.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_handler_skips_when_no_token(self, runtime):
-        """Handler does nothing when no OPENAI_API_KEY."""
+        """Handler does nothing when no proxy token is present."""
         handler = runtime._create_llm_token_handler()
 
         with patch.dict(os.environ, {}, clear=True):
-            os.environ.pop("OPENAI_API_KEY", None)
             await handler("token_refreshed", "llm")
 
         runtime._update_llm_services_token.assert_not_called()

--- a/tests/ciris_engine/logic/services/infrastructure/test_resource_monitor.py
+++ b/tests/ciris_engine/logic/services/infrastructure/test_resource_monitor.py
@@ -863,8 +863,25 @@ async def test_billing_provider_jwt_auth_mode():
 
 
 @pytest.mark.asyncio
-async def test_billing_provider_token_refresh_callback():
-    """Test that token refresh callback is invoked and updates token."""
+async def test_billing_provider_token_refresh_callback(monkeypatch):
+    """Test that token refresh callback is invoked and updates token.
+
+    The callback is the fallback, not the first stop: a proxy token present in
+    the environment wins, because a first-non-empty callback was handing back a
+    stale token and installing it over a freshly refreshed one. So this test
+    has to say which environment it is testing — it wants the branch where the
+    environment offers nothing. It used to rely on that being true by accident,
+    which made it fail whenever another test left a CIRIS_BILLING_* variable
+    behind.
+    """
+    for var in (
+        "CIRIS_BILLING_GOOGLE_ID_TOKEN",
+        "CIRIS_BILLING_APPLE_ID_TOKEN",
+        "CIRIS_BILLING_OAUTH_TOKEN",
+        "GOOGLE_ID_TOKEN",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
     refresh_count = 0
 
     def token_refresh_callback():
@@ -1199,8 +1216,19 @@ async def test_billing_provider_ensure_started():
 
 
 @pytest.mark.asyncio
-async def test_billing_provider_token_refresh_callback_failure():
-    """Test handling of token refresh callback that raises exception."""
+async def test_billing_provider_token_refresh_callback_failure(monkeypatch):
+    """Test handling of token refresh callback that raises exception.
+
+    Same isolation as the success case: the callback is only reached when the
+    environment holds no proxy token.
+    """
+    for var in (
+        "CIRIS_BILLING_GOOGLE_ID_TOKEN",
+        "CIRIS_BILLING_APPLE_ID_TOKEN",
+        "CIRIS_BILLING_OAUTH_TOKEN",
+        "GOOGLE_ID_TOKEN",
+    ):
+        monkeypatch.delenv(var, raising=False)
 
     def failing_callback():
         raise RuntimeError("Token refresh failed")

--- a/tests/ciris_engine/logic/services/runtime/llm_service/test_desktop_token_refresh_handshake.py
+++ b/tests/ciris_engine/logic/services/runtime/llm_service/test_desktop_token_refresh_handshake.py
@@ -1,0 +1,266 @@
+"""The desktop token-refresh handshake, end to end.
+
+WHAT THIS REPRODUCES
+--------------------
+A desktop user on the CIRIS-hosted proxy works for about an hour and then
+stops, permanently. Their log:
+
+    [BILLING_PROVIDER] Started: auth_mode: JWT (Google ID token)
+                               has_refresh_callback: False
+    ciris_primary error: 401 - {'message': 'Invalid authentication token'}
+    [INTERACT_TIMEOUT] ... timed out after 110s without an agent response
+
+The hosted proxy is authenticated with the OAuth ID token itself
+(`api_key=id_token`), and those expire in about an hour. There is a
+handshake to replace it:
+
+    1. Python gets a 401           -> writes CIRIS_HOME/.token_refresh_needed
+    2. the client polls that file  -> silently re-signs-in
+    3. the client rewrites .env with the fresh token
+    4. the client writes .config_reload
+    5. ResourceMonitor reloads .env and emits `token_refreshed`
+    6. the LLM service re-reads the token and swaps its api_key
+
+Step 3 is where desktop diverges. Android writes
+CIRIS_BILLING_GOOGLE_ID_TOKEN and iOS writes CIRIS_BILLING_APPLE_ID_TOKEN —
+both names Python reads. Desktop writes CIRIS_BILLING_OAUTH_TOKEN, which
+nothing on the Python side has ever read. So the refresh completes, the
+reload fires, and the service re-reads the SAME expired token: the loop runs
+forever and recovers never.
+
+These tests assert the CONTRACT (the names both sides use) rather than the
+implementation, because the defect is precisely that two implementations
+each worked in isolation.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+
+def jwt(exp_offset_seconds: float) -> str:
+    """A token shaped like the real thing — these ARE JWTs, and the agent now
+    chooses between copies by reading `exp`."""
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"exp": time.time() + exp_offset_seconds}).encode()
+    ).decode().rstrip("=")
+    return f"header.{payload}.signature"
+
+PY_READS = ("CIRIS_BILLING_GOOGLE_ID_TOKEN", "CIRIS_BILLING_APPLE_ID_TOKEN")
+
+CLIENT_ROOT = Path(__file__).resolve().parents[6] / "client/shared/src"
+DESKTOP_UPDATER = CLIENT_ROOT / "desktopMain/kotlin/ai/ciris/mobile/shared/platform/EnvFileUpdater.desktop.kt"
+ANDROID_UPDATER = CLIENT_ROOT / "androidMain/kotlin/ai/ciris/mobile/shared/platform/EnvFileUpdater.android.kt"
+IOS_UPDATER = CLIENT_ROOT / "iosMain/kotlin/ai/ciris/mobile/shared/platform/EnvFileUpdater.ios.kt"
+
+
+class TestTheHandshakeContract:
+    """Both halves must name the same variable, on every platform."""
+
+    @pytest.mark.skipif(not DESKTOP_UPDATER.exists(), reason="client tree not present")
+    def test_desktop_writes_a_token_name_python_actually_reads(self):
+        src = DESKTOP_UPDATER.read_text(encoding="utf-8")
+        assert any(name in src for name in PY_READS), (
+            "the desktop updater writes a token variable no Python code reads, so a "
+            "successful silent re-sign-in leaves the expired token in place and every "
+            "hosted-proxy call keeps 401ing. Python reads: " + ", ".join(PY_READS)
+        )
+
+    @pytest.mark.skipif(not ANDROID_UPDATER.exists(), reason="client tree not present")
+    def test_android_still_writes_the_google_name(self):
+        assert "CIRIS_BILLING_GOOGLE_ID_TOKEN" in ANDROID_UPDATER.read_text(encoding="utf-8")
+
+    @pytest.mark.skipif(not IOS_UPDATER.exists(), reason="client tree not present")
+    def test_ios_still_writes_the_apple_name(self):
+        assert "CIRIS_BILLING_APPLE_ID_TOKEN" in IOS_UPDATER.read_text(encoding="utf-8")
+
+
+class TestTheServiceSideOfTheHandshake:
+    """Given a refreshed .env, the LLM service must actually swap its key."""
+
+    @pytest.fixture
+    def proxy_service(self):
+        from ciris_engine.logic.services.runtime.llm_service.service import (
+            OpenAICompatibleClient,
+            OpenAIConfig,
+        )
+
+        config = OpenAIConfig(
+            api_key="expired.jwt.value",
+            model_name="gpt-4o-mini",
+            base_url="https://llm01.ciris-services-1.ai/v1",
+        )
+        service = OpenAICompatibleClient.__new__(OpenAICompatibleClient)
+        service.openai_config = config
+        service.model_name = config.model_name
+        service.client = None
+        service._swapped_to = None
+
+        def _update_api_key(key: str) -> None:
+            service._swapped_to = key
+            service.openai_config.api_key = key
+
+        class _Breaker:
+            def __init__(self) -> None:
+                self.resets = 0
+
+            def reset(self) -> None:
+                self.resets += 1
+
+        service.update_api_key = _update_api_key  # type: ignore[method-assign]
+        service.circuit_breaker = _Breaker()
+        return service
+
+    @pytest.mark.asyncio
+    async def test_a_fresh_google_token_is_picked_up(self, proxy_service, monkeypatch):
+        monkeypatch.setenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", "fresh.jwt.value")
+        await proxy_service.handle_token_refreshed("token_refreshed", "openai_api_key")
+        assert proxy_service._swapped_to == "fresh.jwt.value"
+
+    @pytest.mark.asyncio
+    async def test_the_freshest_copy_wins_when_several_names_are_present(
+        self, proxy_service, monkeypatch
+    ):
+        """A real .env carries more than one: the Google name written at setup
+        and whatever the client last refreshed. Choosing by name order returns
+        the setup-time token, which is exactly the expired one."""
+        stale, fresh = jwt(-600), jwt(3600)
+        proxy_service.openai_config.api_key = stale
+        monkeypatch.setenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", stale)
+        monkeypatch.setenv("CIRIS_BILLING_OAUTH_TOKEN", fresh)
+        await proxy_service.handle_token_refreshed("token_refreshed", "openai_api_key")
+        assert proxy_service._swapped_to == fresh
+
+    @pytest.mark.asyncio
+    async def test_the_desktop_variable_alone_must_not_strand_the_service(
+        self, proxy_service, monkeypatch
+    ):
+        """THE BUG, from the service's side.
+
+        The client re-signed-in successfully and wrote the token it knows how
+        to write. If the service cannot see that name, it re-reads the expired
+        one, reports "unchanged", resets the breaker, and 401s again — which is
+        indistinguishable, in the log, from the user's credential simply being
+        bad.
+        """
+        monkeypatch.setenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", "expired.jwt.value")
+        monkeypatch.setenv("CIRIS_BILLING_OAUTH_TOKEN", "fresh.jwt.value")
+        await proxy_service.handle_token_refreshed("token_refreshed", "openai_api_key")
+        assert proxy_service._swapped_to == "fresh.jwt.value", (
+            "a desktop client that refreshed its token left the service on the expired "
+            "one — the 401 loop never recovers"
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_genuinely_unchanged_token_says_so_loudly(
+        self, proxy_service, monkeypatch, caplog
+    ):
+        """The one case that must stay diagnosable: nothing new arrived.
+
+        This is what a stranded desktop user's log looked like, and it read as
+        routine. It must name the variables it consulted, so the next reader
+        can tell "the client never wrote a new token" apart from "the token is
+        new and still rejected".
+        """
+        import logging
+
+        monkeypatch.setenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", "expired.jwt.value")
+        monkeypatch.delenv("CIRIS_BILLING_OAUTH_TOKEN", raising=False)
+        with caplog.at_level(logging.WARNING):
+            await proxy_service.handle_token_refreshed("token_refreshed", "openai_api_key")
+        blob = caplog.text
+        assert proxy_service._swapped_to is None
+        assert "CIRIS_BILLING_GOOGLE_ID_TOKEN" in blob, (
+            "the no-op path must name which variables it read — otherwise a stranded "
+            "client is invisible in the log"
+        )
+
+
+class TestTheHandshakeIsDefinedOnce:
+    """The names live in one module per language, and the two agree.
+
+    Every value in this handshake used to be re-spelled at each site: two
+    copies of the refresh request in Python, three writers of the reload
+    signal, three Kotlin clients with private constants. The drift was not
+    hypothetical — it shipped, and it took a user's agent offline in a way no
+    error message named.
+    """
+
+    KOTLIN_CONSTANTS = CLIENT_ROOT / "commonMain/kotlin/ai/ciris/mobile/shared/platform/EnvFileUpdater.kt"
+
+    def test_python_defines_the_filenames_once(self):
+        from ciris_engine.logic.utils import token_handshake as th
+
+        assert th.TOKEN_REFRESH_REQUEST_FILE == ".token_refresh_needed"
+        assert th.CONFIG_RELOAD_SIGNAL_FILE == ".config_reload"
+        assert th.ENV_FILE == ".env"
+
+    def test_no_python_site_respells_the_handshake_filenames(self):
+        """Literal filenames belong to the module that defines them."""
+        root = Path(__file__).resolve().parents[6] / "ciris_engine"
+        offenders = []
+        for py in root.rglob("*.py"):
+            if py.name == "token_handshake.py":
+                continue
+            text = py.read_text(encoding="utf-8", errors="ignore")
+            for literal in ('".token_refresh_needed"', '".config_reload"'):
+                if literal in text:
+                    offenders.append(f"{py.relative_to(root)} -> {literal}")
+        assert not offenders, (
+            "these sites spell a handshake filename themselves instead of importing it "
+            "from utils.token_handshake: " + "; ".join(offenders)
+        )
+
+    @pytest.mark.skipif(not KOTLIN_CONSTANTS.exists(), reason="client tree not present")
+    def test_the_two_languages_agree_on_every_name(self):
+        from ciris_engine.logic.utils import token_handshake as th
+
+        kotlin = self.KOTLIN_CONSTANTS.read_text(encoding="utf-8")
+        for value in (
+            th.TOKEN_REFRESH_REQUEST_FILE,
+            th.CONFIG_RELOAD_SIGNAL_FILE,
+            th.ENV_FILE,
+            "CIRIS_BILLING_GOOGLE_ID_TOKEN",
+            "CIRIS_BILLING_APPLE_ID_TOKEN",
+        ):
+            assert f'"{value}"' in kotlin, (
+                f"the client half does not name {value!r}; the two ends of this handshake "
+                "must be pinned to each other or they drift silently"
+            )
+
+    @pytest.mark.skipif(not DESKTOP_UPDATER.exists(), reason="client tree not present")
+    def test_no_platform_respells_the_filenames(self):
+        offenders = []
+        for updater in (DESKTOP_UPDATER, ANDROID_UPDATER, IOS_UPDATER):
+            if not updater.exists():
+                continue
+            text = updater.read_text(encoding="utf-8")
+            for literal in ('".token_refresh_needed"', '".config_reload"'):
+                if literal in text:
+                    offenders.append(f"{updater.name} -> {literal}")
+        assert not offenders, (
+            "platform updaters must take these from TokenHandshake: " + "; ".join(offenders)
+        )
+
+
+class TestTheRequestSideLogsWhereItWrote:
+    def test_the_ask_names_its_path_and_reason(self, tmp_path, monkeypatch, caplog):
+        """A client that is not watching is invisible unless the agent says
+        which directory it put the ask in — that path is the only way to see
+        that the two halves are looking at different places."""
+        import logging
+
+        from ciris_engine.logic.utils.token_handshake import request_token_refresh
+
+        monkeypatch.setenv("CIRIS_HOME", str(tmp_path))
+        with caplog.at_level(logging.INFO):
+            assert request_token_refresh(reason="proxy 401 on gpt-4o-mini") is True
+        assert (tmp_path / ".token_refresh_needed").exists()
+        assert str(tmp_path) in caplog.text
+        assert "proxy 401 on gpt-4o-mini" in caplog.text

--- a/tests/ciris_engine/logic/services/runtime/llm_service/test_desktop_token_refresh_handshake.py
+++ b/tests/ciris_engine/logic/services/runtime/llm_service/test_desktop_token_refresh_handshake.py
@@ -611,3 +611,66 @@ class TestTheHandshakePathsThemselves:
         assert jwt_expiry_epoch("a.b.c") is None          # payload is not base64 JSON
         assert jwt_expiry_epoch("h.eyJzdWIiOiJ4In0.s") is None  # valid JSON, no exp
         assert jwt_expiry_epoch(jwt(60)) is not None
+
+
+class TestNobodyReadsTheTokenNamesDirectly:
+    """One module knows the variable names. Everything else asks it.
+
+    This started as one mismatch — desktop writing a name Python never read —
+    and every round of review since has found another site quietly holding its
+    own copy of the list: billing's provider, its two runtime handlers, its
+    lazy initializer, the tools route, the hosted-tools adapter and its .env
+    scan, the startup credential, and the capability gates that decide whether
+    hosted features exist at all. Each was locally reasonable and collectively
+    they meant a refreshed token reached some subsystems and not others, so the
+    agent recovered in pieces.
+
+    A grep is the only thing that can hold this line, so here it is.
+    """
+
+    ALLOWED = {
+        "ciris_engine/logic/utils/token_handshake.py",  # defines them
+        "ciris_engine/logic/setup/wizard.py",           # writes the .env template
+    }
+
+    def test_no_module_outside_the_handshake_reads_a_token_variable(self):
+        import re
+
+        root = Path(__file__).resolve().parents[6]
+        pattern = re.compile(
+            r'os\.(?:getenv|environ\.get)\(\s*["\']'
+            r'(CIRIS_BILLING_GOOGLE_ID_TOKEN|CIRIS_BILLING_APPLE_ID_TOKEN|CIRIS_BILLING_OAUTH_TOKEN)'
+        )
+        offenders = []
+        for base in ("ciris_engine", "ciris_adapters"):
+            for py in (root / base).rglob("*.py"):
+                rel = py.relative_to(root).as_posix()
+                if rel in self.ALLOWED:
+                    continue
+                for lineno, line in enumerate(py.read_text(encoding="utf-8", errors="ignore").splitlines(), 1):
+                    if pattern.search(line):
+                        offenders.append(f"{rel}:{lineno}")
+        assert not offenders, (
+            "these read a proxy-token variable directly instead of calling "
+            "token_handshake.read_proxy_token() / has_proxy_token(); a token refreshed under a "
+            "name they do not know leaves them on the expired one while the rest of the agent "
+            "recovers: " + ", ".join(offenders)
+        )
+
+    def test_the_consumers_all_import_the_selector(self):
+        """The other direction: the known consumers must actually call it."""
+        root = Path(__file__).resolve().parents[6]
+        consumers = [
+            "ciris_engine/logic/services/runtime/llm_service/service.py",
+            "ciris_engine/logic/services/infrastructure/resource_monitor/ciris_billing_provider.py",
+            "ciris_engine/logic/runtime/billing_helpers.py",
+            "ciris_engine/logic/runtime/service_initializer.py",
+            "ciris_engine/logic/adapters/api/routes/billing.py",
+            "ciris_engine/logic/adapters/api/routes/tools.py",
+            "ciris_adapters/ciris_hosted_tools/services.py",
+        ]
+        missing = [
+            c for c in consumers
+            if "token_handshake" not in (root / c).read_text(encoding="utf-8")
+        ]
+        assert not missing, f"these consume the proxy token without the shared selector: {missing}"

--- a/tests/ciris_engine/logic/services/runtime/llm_service/test_desktop_token_refresh_handshake.py
+++ b/tests/ciris_engine/logic/services/runtime/llm_service/test_desktop_token_refresh_handshake.py
@@ -387,3 +387,62 @@ class TestBillingSharesTheSelector:
         ).read_text(encoding="utf-8")
         handler = src[src.index("async def handle_llm_token_refreshed") : src.index("def update_llm_services_token")]
         assert 'os.getenv("OPENAI_API_KEY"' not in handler
+
+
+class TestTheBillingCallbackCannotUndoARefresh:
+    """The refresh must survive the next billing request.
+
+    `_get_current_token()` runs before every billing call. It used to consult
+    the injected `get_fresh_token` callback FIRST and return the moment that
+    callback produced anything different from the token in hand. That callback
+    was a first-non-empty read of the Google/Apple names — so after a legacy
+    desktop refresh left a stale Google value beside a fresh one, it handed
+    back the STALE token, installed it over the fresh one the refresh handler
+    had just set, and returned before the shared selector was ever reached.
+    Billing then kept answering AUTH_EXPIRED and gating interactions while the
+    LLM key looked perfectly healthy.
+    """
+
+    def _provider(self, installed: str, callback):
+        from ciris_engine.logic.services.infrastructure.resource_monitor.ciris_billing_provider import (
+            CIRISBillingProvider,
+        )
+
+        provider = CIRISBillingProvider.__new__(CIRISBillingProvider)
+        provider._google_id_token = installed
+        provider._token_refresh_callback = callback
+        return provider
+
+    def test_a_stale_callback_cannot_reinstall_the_expired_token(self, monkeypatch):
+        stale, fresh = jwt(-600), jwt(3600)
+        monkeypatch.setenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", stale)
+        monkeypatch.setenv("CIRIS_BILLING_OAUTH_TOKEN", fresh)
+
+        # the old first-non-empty callback, verbatim
+        provider = self._provider(installed=fresh, callback=lambda: stale)
+        assert provider._get_current_token() == fresh, (
+            "the callback reinstalled the expired token, so the very next billing request "
+            "goes out with it and AUTH_EXPIRED resumes"
+        )
+
+    def test_the_same_holds_for_opaque_tokens(self, monkeypatch):
+        """The legacy case has no readable expiry on either side."""
+        monkeypatch.setenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", "opaque-expired")
+        monkeypatch.setenv("CIRIS_BILLING_OAUTH_TOKEN", "opaque-refreshed")
+        provider = self._provider(installed="opaque-expired", callback=lambda: "opaque-expired")
+        assert provider._get_current_token() == "opaque-refreshed"
+
+    def test_the_callback_still_serves_when_the_environment_is_empty(self, monkeypatch):
+        """Demoted, not removed: a caller supplying a token from somewhere
+        other than .env must still be honoured."""
+        for var in ("CIRIS_BILLING_GOOGLE_ID_TOKEN", "CIRIS_BILLING_APPLE_ID_TOKEN", "CIRIS_BILLING_OAUTH_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
+        provider = self._provider(installed="", callback=lambda: "from-the-caller")
+        assert provider._get_current_token() == "from-the-caller"
+
+    def test_the_injected_callback_itself_uses_the_selector(self):
+        src = (
+            Path(__file__).resolve().parents[6] / "ciris_engine/logic/runtime/billing_helpers.py"
+        ).read_text(encoding="utf-8")
+        factory = src[src.index("def create_billing_provider") : src.index("async def reinitialize_billing_provider")]
+        assert "read_proxy_token" in factory, "get_fresh_token must not re-implement the choice"

--- a/tests/ciris_engine/logic/services/runtime/llm_service/test_desktop_token_refresh_handshake.py
+++ b/tests/ciris_engine/logic/services/runtime/llm_service/test_desktop_token_refresh_handshake.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import re
 import time
 from pathlib import Path
 
@@ -63,13 +64,56 @@ IOS_UPDATER = CLIENT_ROOT / "iosMain/kotlin/ai/ciris/mobile/shared/platform/EnvF
 class TestTheHandshakeContract:
     """Both halves must name the same variable, on every platform."""
 
+    @staticmethod
+    def _code_only(path: Path) -> str:
+        """Kotlin source with comments stripped.
+
+        Searching the whole file was the first version of this test and it was
+        worthless: the explanatory comment above the assignment names both
+        correct variables, so reverting the assignment itself back to the
+        broken name would have left this green and let the outage return. A
+        regression test that its own comment can satisfy is not a test.
+        """
+        out, in_block = [], False
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            line = raw
+            if in_block:
+                if "*/" in line:
+                    line = line.split("*/", 1)[1]
+                    in_block = False
+                else:
+                    continue
+            if "/*" in line:
+                head, rest = line.split("/*", 1)
+                if "*/" in rest:
+                    line = head + rest.split("*/", 1)[1]
+                else:
+                    line, in_block = head, True
+            if "//" in line:
+                line = line.split("//", 1)[0]
+            out.append(line)
+        return "\n".join(out)
+
     @pytest.mark.skipif(not DESKTOP_UPDATER.exists(), reason="client tree not present")
-    def test_desktop_writes_a_token_name_python_actually_reads(self):
-        src = DESKTOP_UPDATER.read_text(encoding="utf-8")
-        assert any(name in src for name in PY_READS), (
-            "the desktop updater writes a token variable no Python code reads, so a "
+    def test_desktop_ASSIGNS_a_token_name_python_actually_reads(self):
+        code = self._code_only(DESKTOP_UPDATER)
+        assignment = re.search(r"val\s+tokenKey\s*=\s*(.+)", code)
+        assert assignment, "could not find the tokenKey assignment — this guard has gone blind"
+        rhs = assignment.group(1).strip()
+        accepted = ("TokenHandshake.GOOGLE_TOKEN_VAR", "TokenHandshake.APPLE_TOKEN_VAR") + PY_READS
+        assert any(name in rhs for name in accepted), (
+            f"the desktop updater assigns tokenKey = {rhs} — a variable no Python code reads, so a "
             "successful silent re-sign-in leaves the expired token in place and every "
             "hosted-proxy call keeps 401ing. Python reads: " + ", ".join(PY_READS)
+        )
+
+    @pytest.mark.skipif(not DESKTOP_UPDATER.exists(), reason="client tree not present")
+    def test_desktop_never_assigns_the_dead_legacy_name(self):
+        code = self._code_only(DESKTOP_UPDATER)
+        assignment = re.search(r"val\s+tokenKey\s*=\s*(.+)", code)
+        assert assignment
+        assert "CIRIS_BILLING_OAUTH_TOKEN" not in assignment.group(1), (
+            "writing the legacy name is the original outage"
         )
 
     @pytest.mark.skipif(not ANDROID_UPDATER.exists(), reason="client tree not present")
@@ -264,3 +308,82 @@ class TestTheRequestSideLogsWhereItWrote:
         assert (tmp_path / ".token_refresh_needed").exists()
         assert str(tmp_path) in caplog.text
         assert "proxy 401 on gpt-4o-mini" in caplog.text
+
+
+class TestTheSelectorNeverGoesBackwards:
+    """Choosing between copies must not undo a good credential."""
+
+    def test_a_stale_sibling_cannot_displace_the_freshest_value_in_hand(self, monkeypatch):
+        """The mirror image of the legacy-desktop case.
+
+        After a recovery the .env can hold a fresh token under one name and a
+        stale one under another, with the fresh one already active. Preferring
+        "any copy that differs" would then pick the stale one on every reload —
+        including reloads the setup route triggers for unrelated reasons — and
+        walk a working agent straight back into the 401 loop.
+        """
+        from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+        fresh, stale = jwt(3600), jwt(-600)
+        monkeypatch.setenv("CIRIS_BILLING_OAUTH_TOKEN", fresh)
+        monkeypatch.setenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", stale)
+        token, var = read_proxy_token(current=fresh)
+        assert token == fresh and var == "CIRIS_BILLING_OAUTH_TOKEN"
+
+    def test_an_equally_opaque_sibling_still_wins_when_ours_is_being_rejected(self, monkeypatch):
+        """The legacy-desktop case itself: neither token carries a readable
+        expiry, and the one in hand is the one the provider is refusing."""
+        from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+        monkeypatch.setenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", "opaque-expired")
+        monkeypatch.setenv("CIRIS_BILLING_OAUTH_TOKEN", "opaque-refreshed")
+        token, _ = read_proxy_token(current="opaque-expired")
+        assert token == "opaque-refreshed"
+
+    def test_with_nothing_in_hand_the_freshest_wins(self, monkeypatch):
+        from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+        fresh, stale = jwt(3600), jwt(60)
+        monkeypatch.setenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", stale)
+        monkeypatch.setenv("CIRIS_BILLING_APPLE_ID_TOKEN", fresh)
+        token, var = read_proxy_token()
+        assert token == fresh and var == "CIRIS_BILLING_APPLE_ID_TOKEN"
+
+
+class TestBillingSharesTheSelector:
+    """Billing recovering matters as much as the LLM recovering.
+
+    A refresh that revives the LLM key but leaves billing on the setup-time
+    token just moves the outage: credit checks keep returning AUTH_EXPIRED and
+    gate every interaction, which looks to the user exactly like the agent
+    still being broken.
+    """
+
+    def test_the_billing_provider_reads_through_the_shared_selector(self):
+        src = (
+            Path(__file__).resolve().parents[6]
+            / "ciris_engine/logic/services/infrastructure/resource_monitor/ciris_billing_provider.py"
+        ).read_text(encoding="utf-8")
+        assert "read_proxy_token" in src, (
+            "billing still reads the token names directly, so a client that refreshed under a "
+            "different name revives the LLM and leaves billing expired"
+        )
+
+    def test_the_runtime_handlers_read_through_the_shared_selector(self):
+        src = (
+            Path(__file__).resolve().parents[6] / "ciris_engine/logic/runtime/billing_helpers.py"
+        ).read_text(encoding="utf-8")
+        assert src.count("read_proxy_token") >= 2, (
+            "both the billing and the LLM refresh handlers must use the shared selector"
+        )
+
+    def test_the_llm_refresh_handler_does_not_key_off_OPENAI_API_KEY(self):
+        """That handler only ever touches CIRIS-proxy services, and those
+        authenticate with the ID token. Reading OPENAI_API_KEY meant the
+        hosted-proxy case (empty) refreshed nothing, and the BYOK-leftover case
+        pushed someone's provider key over a good token."""
+        src = (
+            Path(__file__).resolve().parents[6] / "ciris_engine/logic/runtime/billing_helpers.py"
+        ).read_text(encoding="utf-8")
+        handler = src[src.index("async def handle_llm_token_refreshed") : src.index("def update_llm_services_token")]
+        assert 'os.getenv("OPENAI_API_KEY"' not in handler

--- a/tests/ciris_engine/logic/services/runtime/llm_service/test_desktop_token_refresh_handshake.py
+++ b/tests/ciris_engine/logic/services/runtime/llm_service/test_desktop_token_refresh_handshake.py
@@ -674,3 +674,100 @@ class TestNobodyReadsTheTokenNamesDirectly:
             if "token_handshake" not in (root / c).read_text(encoding="utf-8")
         ]
         assert not missing, f"these consume the proxy token without the shared selector: {missing}"
+
+
+class TestExpiryStatusIsATierNotANumber:
+    """A token we can prove is dead must never outrank one that might be alive."""
+
+    def test_an_expired_jwt_loses_to_an_opaque_callback_token(self, monkeypatch):
+        """The defect: an expired JWT still carries a large positive epoch,
+        while a token whose format has no `exp` scores zero. Ranking on the
+        raw number therefore preferred the credential we are actively being
+        refused for over the replacement a callback had just fetched."""
+        from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+        monkeypatch.setenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", jwt(-600))
+        token, var = read_proxy_token(callback_token="google:1089981372")
+        assert (token, var) == ("google:1089981372", "callback")
+
+    def test_an_expired_jwt_loses_to_an_opaque_environment_token(self, monkeypatch):
+        from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+        monkeypatch.setenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", jwt(-600))
+        monkeypatch.setenv("CIRIS_BILLING_OAUTH_TOKEN", "opaque-but-possibly-alive")
+        token, _ = read_proxy_token()
+        assert token == "opaque-but-possibly-alive"
+
+    def test_a_live_jwt_still_beats_an_opaque_token(self, monkeypatch):
+        """The tier order only helps the unknown against the known-dead."""
+        from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+        live = jwt(3600)
+        monkeypatch.setenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", live)
+        token, var = read_proxy_token(callback_token="opaque")
+        assert (token, var) == (live, "CIRIS_BILLING_GOOGLE_ID_TOKEN")
+
+    def test_an_expired_token_is_still_offered_when_it_is_all_there_is(self, monkeypatch):
+        """Last resort, not discarded: a clean 401 is more useful than sending
+        no credential at all."""
+        from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+        dead = jwt(-600)
+        monkeypatch.setenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", dead)
+        assert read_proxy_token()[0] == dead
+
+    def test_the_least_stale_expired_token_wins_among_expired_ones(self, monkeypatch):
+        from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+        older, newer = jwt(-9000), jwt(-60)
+        monkeypatch.setenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", older)
+        monkeypatch.setenv("CIRIS_BILLING_OAUTH_TOKEN", newer)
+        assert read_proxy_token()[0] == newer
+
+
+class TestTheEnvFileScanUsesTheSameRanking:
+    """One ordering, wherever the candidates were read from.
+
+    The hosted-tools .env fallback ranked its own finds by expiry alone, which
+    left the opaque tie to dictionary insertion order — Google first — while
+    the shared selector resolves that tie toward the legacy-desktop name. Same
+    inputs, different answers, so tools sent the stale credential while billing
+    and the LLM used the refreshed one.
+    """
+
+    def test_the_file_resolves_an_opaque_tie_like_the_selector(self, tmp_path, monkeypatch):
+        from ciris_adapters.ciris_hosted_tools.services import CIRISHostedToolService
+        from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+        for var in ("CIRIS_BILLING_GOOGLE_ID_TOKEN", "CIRIS_BILLING_APPLE_ID_TOKEN", "CIRIS_BILLING_OAUTH_TOKEN", "GOOGLE_ID_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("CIRIS_HOME", str(tmp_path))
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+        (tmp_path / ".env").write_text(
+            "CIRIS_BILLING_GOOGLE_ID_TOKEN=opaque-stale\nCIRIS_BILLING_OAUTH_TOKEN=opaque-refreshed\n"
+        )
+
+        service = CIRISHostedToolService.__new__(CIRISHostedToolService)
+        from_file = service._get_google_id_token()
+
+        # what the selector would have said from the same pair
+        monkeypatch.setenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", "opaque-stale")
+        monkeypatch.setenv("CIRIS_BILLING_OAUTH_TOKEN", "opaque-refreshed")
+        from_env, _ = read_proxy_token()
+
+        assert from_file == from_env == "opaque-refreshed"
+
+    def test_the_file_prefers_a_live_token_over_an_expired_one(self, tmp_path, monkeypatch):
+        from ciris_adapters.ciris_hosted_tools.services import CIRISHostedToolService
+
+        for var in ("CIRIS_BILLING_GOOGLE_ID_TOKEN", "CIRIS_BILLING_APPLE_ID_TOKEN", "CIRIS_BILLING_OAUTH_TOKEN", "GOOGLE_ID_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("CIRIS_HOME", str(tmp_path))
+        monkeypatch.setattr("pathlib.Path.home", classmethod(lambda cls: tmp_path))
+        live, dead = jwt(3600), jwt(-600)
+        (tmp_path / ".env").write_text(
+            f"CIRIS_BILLING_OAUTH_TOKEN={dead}\nCIRIS_BILLING_GOOGLE_ID_TOKEN={live}\n"
+        )
+
+        service = CIRISHostedToolService.__new__(CIRISHostedToolService)
+        assert service._get_google_id_token() == live

--- a/tests/ciris_engine/logic/services/runtime/llm_service/test_desktop_token_refresh_handshake.py
+++ b/tests/ciris_engine/logic/services/runtime/llm_service/test_desktop_token_refresh_handshake.py
@@ -446,3 +446,168 @@ class TestTheBillingCallbackCannotUndoARefresh:
         ).read_text(encoding="utf-8")
         factory = src[src.index("def create_billing_provider") : src.index("async def reinitialize_billing_provider")]
         assert "read_proxy_token" in factory, "get_fresh_token must not re-implement the choice"
+
+
+class TestTheSelectorIsStable:
+    """The same environment must give the same answer every time."""
+
+    def test_opaque_tokens_do_not_alternate_across_repeated_calls(self, monkeypatch):
+        """The bug this class exists for.
+
+        With two opaque tokens the earlier tie-break preferred "whichever copy
+        is not the one in hand". Holding A it returned B; holding B, the stable
+        sort put A first again and the guard no longer fired, so it returned A.
+        Credentials flipped on every single billing request — one of them
+        always the rejected one. A selector whose answer depends on who is
+        asking is not a selector.
+        """
+        from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+        monkeypatch.setenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", "opaque-a")
+        monkeypatch.setenv("CIRIS_BILLING_OAUTH_TOKEN", "opaque-b")
+
+        answers = {read_proxy_token(current=held)[0] for held in ("", "opaque-a", "opaque-b")}
+        assert len(answers) == 1, f"the selector answered differently depending on what was held: {answers}"
+
+    def test_repeated_billing_requests_settle_on_one_credential(self, monkeypatch):
+        """The same property through the provider, which is where it bit."""
+        from ciris_engine.logic.services.infrastructure.resource_monitor.ciris_billing_provider import (
+            CIRISBillingProvider,
+        )
+
+        monkeypatch.setenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", "opaque-expired")
+        monkeypatch.setenv("CIRIS_BILLING_OAUTH_TOKEN", "opaque-refreshed")
+
+        provider = CIRISBillingProvider.__new__(CIRISBillingProvider)
+        provider._google_id_token = "opaque-expired"
+        provider._token_refresh_callback = lambda: "opaque-expired"
+
+        seen = {provider._get_current_token() for _ in range(5)}
+        assert seen == {"opaque-refreshed"}, f"credentials alternated across requests: {seen}"
+
+    def test_expiry_still_beats_the_tie_order(self, monkeypatch):
+        """The tie order only applies when nothing carries a readable expiry."""
+        from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+        monkeypatch.setenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", jwt(3600))
+        monkeypatch.setenv("CIRIS_BILLING_OAUTH_TOKEN", jwt(-600))
+        token, var = read_proxy_token()
+        assert var == "CIRIS_BILLING_GOOGLE_ID_TOKEN", "a live token lost to an expired one on name order"
+
+
+class TestTheCallbackParticipates:
+    """Neither privileged nor ignored."""
+
+    def test_an_external_callback_token_is_used_even_when_env_has_one(self, monkeypatch):
+        """A caller fetching credentials from secure storage must not be
+        silenced by a stale bootstrap value left in the environment."""
+        from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+        monkeypatch.setenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", "opaque-bootstrap")
+        token, var = read_proxy_token(callback_token="from-secure-storage")
+        assert token == "from-secure-storage" and var == "callback"
+
+    def test_a_callback_that_merely_echoes_the_environment_gains_no_precedence(self, monkeypatch):
+        """Echoing is not sourcing: the legacy first-non-empty callback returns
+        a value already in .env, and must not win a tie with it."""
+        from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+        monkeypatch.setenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", "opaque-stale")
+        monkeypatch.setenv("CIRIS_BILLING_OAUTH_TOKEN", "opaque-refreshed")
+        token, _ = read_proxy_token(callback_token="opaque-stale")
+        assert token == "opaque-refreshed"
+
+    def test_a_fresher_env_token_still_beats_an_expired_callback(self, monkeypatch):
+        from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+        monkeypatch.setenv("CIRIS_BILLING_GOOGLE_ID_TOKEN", jwt(3600))
+        token, var = read_proxy_token(callback_token=jwt(-600))
+        assert var == "CIRIS_BILLING_GOOGLE_ID_TOKEN"
+
+
+class TestHostedToolsSharesTheSelector:
+    def test_hosted_tools_does_not_read_the_token_names_itself(self):
+        src = (
+            Path(__file__).resolve().parents[6] / "ciris_adapters/ciris_hosted_tools/services.py"
+        ).read_text(encoding="utf-8")
+        method = src[src.index("def _get_google_id_token") : src.index("def _get_google_id_token") + 3000]
+        assert "read_proxy_token" in method, (
+            "hosted tools reads the token names directly, so after a client refreshes under a "
+            "different name its requests keep going out with the stale setup token while the "
+            "rest of the agent has recovered"
+        )
+
+
+class TestTheHandshakePathsThemselves:
+    """The three paths, and the failure modes of writing to them.
+
+    These are the values both processes must agree on, so each one is worth a
+    test of its own: a wrong directory here is invisible at runtime — the ask
+    is written, nothing answers, and the log looks like a client that simply
+    never refreshed.
+    """
+
+    def test_every_path_hangs_off_CIRIS_HOME(self, tmp_path, monkeypatch):
+        from ciris_engine.logic.utils import token_handshake as th
+
+        monkeypatch.setenv("CIRIS_HOME", str(tmp_path))
+        assert th.handshake_home() == tmp_path
+        assert th.token_refresh_request_path() == tmp_path / ".token_refresh_needed"
+        assert th.config_reload_signal_path() == tmp_path / ".config_reload"
+        assert th.env_path() == tmp_path / ".env"
+
+    def test_without_CIRIS_HOME_it_falls_back_to_the_shared_resolver(self, monkeypatch):
+        """Never a third opinion about where home is."""
+        from ciris_engine.logic.utils import token_handshake as th
+
+        monkeypatch.delenv("CIRIS_HOME", raising=False)
+        monkeypatch.setattr(
+            "ciris_engine.logic.utils.path_resolution.get_ciris_home",
+            lambda: "/somewhere/ciris",  # a str, as some callers return
+        )
+        assert th.handshake_home() == Path("/somewhere/ciris")
+        assert th.env_path() == Path("/somewhere/ciris/.env")
+
+    def test_the_ask_creates_the_directory_if_it_is_missing(self, tmp_path, monkeypatch):
+        from ciris_engine.logic.utils.token_handshake import request_token_refresh
+
+        home = tmp_path / "not-yet-there"
+        monkeypatch.setenv("CIRIS_HOME", str(home))
+        assert request_token_refresh(reason="first 401") is True
+        assert (home / ".token_refresh_needed").read_text()
+
+    def test_an_unwritable_home_is_reported_not_raised(self, tmp_path, monkeypatch, caplog):
+        """A 401 handler must not turn into a crash because the disk said no."""
+        import logging
+
+        from ciris_engine.logic.utils.token_handshake import request_token_refresh
+
+        blocker = tmp_path / "blocked"
+        blocker.write_text("i am a file, not a directory")
+        monkeypatch.setenv("CIRIS_HOME", str(blocker))
+        with caplog.at_level(logging.ERROR):
+            assert request_token_refresh(reason="proxy 401") is False
+        assert "failed to write" in caplog.text.lower()
+
+    def test_an_empty_environment_says_what_it_looked_for(self, monkeypatch, caplog):
+        """When there is no token anywhere, the log must name the variables it
+        checked — that line is how a stranded client is diagnosed at all."""
+        import logging
+
+        from ciris_engine.logic.utils.token_handshake import read_proxy_token
+
+        for var in ("CIRIS_BILLING_GOOGLE_ID_TOKEN", "CIRIS_BILLING_APPLE_ID_TOKEN", "CIRIS_BILLING_OAUTH_TOKEN"):
+            monkeypatch.delenv(var, raising=False)
+        with caplog.at_level(logging.WARNING):
+            token, var = read_proxy_token()
+        assert (token, var) == ("", "")
+        assert "CIRIS_BILLING_GOOGLE_ID_TOKEN" in caplog.text
+
+    def test_an_unreadable_jwt_sorts_last_instead_of_raising(self):
+        from ciris_engine.logic.utils.token_handshake import jwt_expiry_epoch
+
+        assert jwt_expiry_epoch("") is None
+        assert jwt_expiry_epoch("not-a-jwt") is None
+        assert jwt_expiry_epoch("a.b.c") is None          # payload is not base64 JSON
+        assert jwt_expiry_epoch("h.eyJzdWIiOiJ4In0.s") is None  # valid JSON, no exp
+        assert jwt_expiry_epoch(jwt(60)) is not None


### PR DESCRIPTION
Diagnosed from a user's log. Their desktop agent works for about an hour after setup, then stops answering — permanently.

```
[BILLING_PROVIDER] Started:  auth_mode: JWT (Google ID token)
                             has_refresh_callback: False
ciris_primary error: 401 - {'message': 'Invalid authentication token'}
[INTERACT_TIMEOUT] message_id=… timed out after 110s without an agent response
```

## Why an hour

The CIRIS-hosted proxy is authenticated with the OAuth ID token itself (`api_key=id_token`), and those expire in about an hour. There is a handshake to replace one:

1. agent gets a 401 → writes `.token_refresh_needed`
2. client polls it → silently re-signs in
3. client rewrites `.env` with the fresh token
4. client writes `.config_reload` → agent reloads and swaps its key

Every step ran correctly on desktop and **achieved nothing**:

| platform | writes | Python readers |
|---|---|---|
| Android | `CIRIS_BILLING_GOOGLE_ID_TOKEN` | 19 ✓ |
| iOS | `CIRIS_BILLING_APPLE_ID_TOKEN` | 14 ✓ |
| **Desktop** | **`CIRIS_BILLING_OAUTH_TOKEN`** | **0** ✗ |

So the agent re-read the same expired token, logged `API key unchanged after refresh`, reset the circuit breaker, and 401'd again. Forever. Nothing in the log named the cause — the timeline even looks like a working credential, since the *billing* endpoint accepted the same identity seven seconds before the LLM proxy rejected it.

## The fix

- Desktop writes the Google name, and clears the dead legacy key out of `.env`.
- The agent reads all three names, so a client and an agent on different versions still complete the handshake.
- Selection is by **JWT `exp`, not name order**. A real `.env` carries the setup-time token *and* the refreshed one, and first-non-empty returns the expired one. It also never re-selects the value already in hand when a different copy exists — "keep the credential that is currently 401ing" is not a resolution of that tie.

## DRY, because the drift *was* the bug

The handshake's directory, its two filenames and its token variables now live in one module per language — `ciris_engine/logic/utils/token_handshake.py` and `TokenHandshake` in commonMain. Removed: a second copy of the refresh request in the billing provider, a third spelling of `.config_reload` in the setup route, three sets of private constants in the platform updaters.

## Logging, because the outage was silent

One `[TOKEN_HANDSHAKE]` prefix across both processes so the conversation greps as one story. The request names the path it wrote and why — the only way to see that the two halves are watching different directories. The no-op path now says which variables it consulted, separating "the client never wrote a new token" from "the token is new and still rejected".

## Tests

12 cases reproducing the chain and pinning the contract: the names the two languages must agree on, that no site re-spells a filename (a sweep over `ciris_engine/`), freshest-wins selection with real JWT shapes, the tie-break, and that the ask logs its path. Desktop Kotlin compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVMJwukQjscjwLQz9NZktK