### PR TITLE
fix(qa): the trace-ship harness reported a healthy transport as broken

### DIFF
--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -6,11 +6,11 @@ from typing import List
 from ciris_engine.schemas.runtime.canonical_peer import CanonicalBootstrapPeer
 
 # Version information
-CIRIS_VERSION = "2.9.37-stable"
+CIRIS_VERSION = "2.9.38-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
 CIRIS_VERSION_MINOR = 9
-CIRIS_VERSION_PATCH = 37
+CIRIS_VERSION_PATCH = 38
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/ciris_engine/logic/runtime/edge_runtime.py
+++ b/ciris_engine/logic/runtime/edge_runtime.py
@@ -322,6 +322,45 @@ def _spawn_delivery_rooting_probe(engine: Any, edge: Any) -> None:
         except Exception as exc:  # noqa: BLE001
             logger.debug("[DELIVERY-STATUS] phase=%s accessor error (non-fatal): %s", phase, exc)
 
+    def _log_trace_plane(phase: str) -> None:
+        """Surface `ciris_server.node_state().trace_plane` as a [TRACE-PLANE] line.
+
+        SAME REASON AS _log_delivery_status ABOVE: the accessor is in-process to
+        the server, so a QA runner — which boots this agent as a subprocess —
+        can never call it and gets `None` no matter how healthy the node is.
+        Logging it here is the only way that value reaches a log tail.
+
+        Why this value and not a derived one: "does this node hold offerable
+        carriers" cannot be answered from the wire (carriers ride the
+        Attestation plane, so there is no Trace envelope kind to count), nor
+        from `trace_events.cohort_scope` (a read-time projection in a different
+        table, downstream of the attestation's own scope), nor from a
+        substring match on the dimension (`trace:` and `trace_summary:` are
+        different namespaces and `covers()` is a prefix test, so a loose
+        `%trace:%` over-counts). persist's `storage_summary()` answers it, and
+        `node_state()` carries that verbatim.
+
+        Purely diagnostic; never disturbs the probe.
+        """
+        try:
+            import json as _json
+
+            import ciris_server  # type: ignore[import-not-found, import-untyped, unused-ignore]
+
+            ns = getattr(ciris_server, "node_state", None)
+            if ns is None:
+                logger.info("[TRACE-PLANE] phase=%s unavailable (ciris_server has no node_state accessor)", phase)
+                return
+            raw = ns()
+            state = _json.loads(raw) if isinstance(raw, str) else raw
+            plane = (state or {}).get("trace_plane")
+            if plane is None:
+                logger.info("[TRACE-PLANE] phase=%s absent (node_state carries no trace_plane)", phase)
+                return
+            logger.info("[TRACE-PLANE] phase=%s %s", phase, _json.dumps(plane, default=str))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[TRACE-PLANE] phase=%s accessor error (non-fatal): %s", phase, exc)
+
     def _user_opted_into_traces() -> bool:
         """Did the OWNER opt in to trace replication? Consent is theirs to give.
 
@@ -424,6 +463,7 @@ def _spawn_delivery_rooting_probe(engine: Any, edge: Any) -> None:
             if not rooted:
                 logger.info("[DELIVERY-PROBE] canonical %s did not root within %ss", ckey, root_deadline)
                 _log_delivery_status("did-not-root")
+                _log_trace_plane("did-not-root")
                 return
 
             # KEX does NOT appear at rooting — it lands only once an inbound
@@ -467,6 +507,7 @@ def _spawn_delivery_rooting_probe(engine: Any, edge: Any) -> None:
                             waited,
                         )
                         _log_delivery_status("kex-present")
+                        _log_trace_plane("kex-present")
                     elif waited - last_reprime >= reprime_cadence:
                         # KEX stall — reprime rather than give up. Warm-up dial-cache
                         # lag (CIRISEdge#336) means the peer may be dialing our stale
@@ -526,10 +567,13 @@ def _spawn_delivery_rooting_probe(engine: Any, edge: Any) -> None:
                         waited,
                     )
                     _log_delivery_status("ship-confirmed")
+                    _log_trace_plane("ship-confirmed")
                     return
                 if waited - last_status >= status_cadence:
                     last_status = waited
-                    _log_delivery_status("kex-present-await-ship" if kex_seen_at is not None else "kex-none-repriming")
+                    _phase = "kex-present-await-ship" if kex_seen_at is not None else "kex-none-repriming"
+                    _log_delivery_status(_phase)
+                    _log_trace_plane(_phase)
             logger.info(
                 "[DELIVERY-PROBE] canonical %s window closed after %ss post-root with SHIP UNCONFIRMED "
                 "(kex=%s, envelopes_sent=0). Do not assume a peer fault: the CIRISEdge#336 dial-cache "
@@ -541,6 +585,7 @@ def _spawn_delivery_rooting_probe(engine: Any, edge: Any) -> None:
                 "present" if kex_seen_at is not None else "none",
             )
             _log_delivery_status("window-closed-unconfirmed")
+            _log_trace_plane("window-closed-unconfirmed")
         except Exception as exc:  # noqa: BLE001 — pure diagnostics, never disturb boot
             logger.debug("[DELIVERY-PROBE] probe error (non-fatal): %s", exc)
 

--- a/ciris_engine/logic/runtime/edge_runtime.py
+++ b/ciris_engine/logic/runtime/edge_runtime.py
@@ -288,6 +288,48 @@ def initialize_edge_runtime(identity_dir: Path) -> None:
             )
 
 
+#: When to reprime after rooting, in seconds post-root, before falling back to
+#: the steady cadence. Front-loaded on purpose — see :func:`should_reprime`.
+REPRIME_SCHEDULE = (45, 120, 300)
+
+#: Steady-state reprime cadence (s) once REPRIME_SCHEDULE is spent.
+REPRIME_CADENCE = 180
+
+#: How many reprimes must pass with nothing received before we call the peer
+#: silent rather than slow. Two, so a single unlucky window does not accuse it.
+SILENT_PEER_AFTER_REPRIMES = 2
+
+
+def should_reprime(waited: int, reprimes_done: int, last_reprime: int) -> bool:
+    """Is it time to reprime the canonical?
+
+    Front-loaded, then steady. A flat 180s cadence spends the first three
+    minutes of every window doing nothing, so a run that ends at ~3 minutes
+    gets exactly ONE attempt — which is what a live QA run did: 141 rounds, 21
+    Key envelopes sent, zero inbound, KEX never landed, window torn down
+    before a second nudge. Reprime is idempotent (CIRISServer#288), so an early
+    attempt costs one dial and buys the peer a chance to heal its own
+    dial-cache (CIRISEdge#336) while the window is still young.
+    """
+    if reprimes_done < len(REPRIME_SCHEDULE):
+        return waited >= REPRIME_SCHEDULE[reprimes_done]
+    return waited - last_reprime >= REPRIME_CADENCE
+
+
+def peer_is_silent(received_total: int, reprimes_done: int) -> bool:
+    """Is the peer not answering at all, as opposed to answering slowly?
+
+    Two stalls wear the same `kex_present=false` label and only one is worth
+    waiting through. Inbound arriving means rounds flow and KEX simply has not
+    landed yet — that self-heals. Nothing arriving, after we have asked more
+    than once, is what a fail-closed refusal looks like from this side: a
+    canonical rejects an unknown `attesting_key_id` and says nothing back
+    (CIRISServer#488), so a structural refusal and congestion are
+    indistinguishable to the sender, and reprime cannot fix either.
+    """
+    return received_total == 0 and reprimes_done >= SILENT_PEER_AFTER_REPRIMES
+
+
 def _spawn_delivery_rooting_probe(engine: Any, edge: Any) -> None:
     """One-shot background observability for the trace-delivery last mile.
 
@@ -493,8 +535,6 @@ def _spawn_delivery_rooting_probe(engine: Any, edge: Any) -> None:
             # (CIRISServer#288), so the first one costs a dial and buys the
             # peer an early chance to heal its own cache; only after that does
             # the slow cadence make sense.
-            reprime_schedule = (45, 120, 300)  # s post-root for the first three
-            reprime_cadence = 180  # steady-state cadence (s) once the schedule is spent
             reprimes_done = 0
             inbound_seen = False
             waited = 0
@@ -520,9 +560,7 @@ def _spawn_delivery_rooting_probe(engine: Any, edge: Any) -> None:
                         )
                         _log_delivery_status("kex-present")
                         _log_trace_plane("kex-present")
-                    elif (
-                        reprimes_done < len(reprime_schedule) and waited >= reprime_schedule[reprimes_done]
-                    ) or (reprimes_done >= len(reprime_schedule) and waited - last_reprime >= reprime_cadence):
+                    elif should_reprime(waited, reprimes_done, last_reprime):
                         # KEX stall — reprime rather than give up. Warm-up dial-cache
                         # lag (CIRISEdge#336) means the peer may be dialing our stale
                         # dest for minutes; every reprime re-roots the canonical
@@ -552,7 +590,7 @@ def _spawn_delivery_rooting_probe(engine: Any, edge: Any) -> None:
                             _m = edge.metrics_snapshot() or {}
                             _recv = sum((_m.get("envelopes_received_total") or {}).values())
                             inbound_seen = inbound_seen or _recv > 0
-                            if _recv == 0 and reprimes_done >= 2:
+                            if peer_is_silent(_recv, reprimes_done):
                                 logger.warning(
                                     "[DELIVERY-PROBE] canonical %s: %ss post-root, %d reprimes, and ZERO "
                                     "envelopes received from ANY peer. The peer is not replying — which is "

--- a/ciris_engine/logic/runtime/edge_runtime.py
+++ b/ciris_engine/logic/runtime/edge_runtime.py
@@ -484,7 +484,19 @@ def _spawn_delivery_rooting_probe(engine: Any, edge: Any) -> None:
             #               optimism and never premature peer-blame.
             window_deadline = 900  # full delivery window (s) — mobile test-mode keeps the app alive this long
             status_cadence = 60  # live [DELIVERY-STATUS] emit cadence (s)
-            reprime_cadence = 180  # KEX-stall reprime cadence (s)
+
+            # REPRIME EARLY, THEN SETTLE. A flat 180s cadence spends the first
+            # three minutes of every window doing nothing, and a run that ends
+            # at ~3 minutes therefore gets ONE attempt — which is what a live
+            # QA run did: 141 rounds, zero inbound envelopes, KEX never landed,
+            # window torn down before a second nudge. Reprime is idempotent
+            # (CIRISServer#288), so the first one costs a dial and buys the
+            # peer an early chance to heal its own cache; only after that does
+            # the slow cadence make sense.
+            reprime_schedule = (45, 120, 300)  # s post-root for the first three
+            reprime_cadence = 180  # steady-state cadence (s) once the schedule is spent
+            reprimes_done = 0
+            inbound_seen = False
             waited = 0
             kex_seen_at: Optional[int] = None
             last_status = 0
@@ -508,13 +520,61 @@ def _spawn_delivery_rooting_probe(engine: Any, edge: Any) -> None:
                         )
                         _log_delivery_status("kex-present")
                         _log_trace_plane("kex-present")
-                    elif waited - last_reprime >= reprime_cadence:
+                    elif (
+                        reprimes_done < len(reprime_schedule) and waited >= reprime_schedule[reprimes_done]
+                    ) or (reprimes_done >= len(reprime_schedule) and waited - last_reprime >= reprime_cadence):
                         # KEX stall — reprime rather than give up. Warm-up dial-cache
                         # lag (CIRISEdge#336) means the peer may be dialing our stale
                         # dest for minutes; every reprime re-roots the canonical
                         # against current handles and gives its next round a fresh
                         # chance to route (mirror of the flip that healed OUR dials).
                         last_reprime = waited
+                        reprimes_done += 1
+
+                        # IS ANYTHING COMING BACK AT ALL? Two very different
+                        # stalls wear the same "kex_present=false" label, and
+                        # only one of them is worth waiting through:
+                        #
+                        #   inbound > 0 — rounds are flowing, the peer replies,
+                        #                 KEX simply has not landed yet. Waiting
+                        #                 is the right move; it self-heals.
+                        #   inbound = 0 — the peer is not answering us at all.
+                        #                 A canonical fail-closes on an unknown
+                        #                 attesting_key_id and says nothing back
+                        #                 (CIRISServer#488), so from here a
+                        #                 structural refusal is indistinguishable
+                        #                 from congestion and reprime will not
+                        #                 fix it — our key is not registered
+                        #                 there. Observed live: 141 rounds, 21
+                        #                 Key envelopes sent, ZERO inbound, and
+                        #                 the node never reached the canonical.
+                        try:
+                            _m = edge.metrics_snapshot() or {}
+                            _recv = sum((_m.get("envelopes_received_total") or {}).values())
+                            inbound_seen = inbound_seen or _recv > 0
+                            if _recv == 0 and reprimes_done >= 2:
+                                logger.warning(
+                                    "[DELIVERY-PROBE] canonical %s: %ss post-root, %d reprimes, and ZERO "
+                                    "envelopes received from ANY peer. The peer is not replying — which is "
+                                    "what a fail-closed refusal looks like from this side when the canonical "
+                                    "holds no key for us (CIRISServer#488). Reprime cannot fix that; the key "
+                                    "has to be registered there.",
+                                    ckey,
+                                    waited,
+                                    reprimes_done,
+                                )
+                            else:
+                                logger.info(
+                                    "[DELIVERY-PROBE] canonical %s: %ss post-root, %d reprimes, %d envelopes "
+                                    "received — the peer IS replying, so KEX has not landed yet rather than "
+                                    "being refused. Waiting.",
+                                    ckey,
+                                    waited,
+                                    reprimes_done,
+                                    _recv,
+                                )
+                        except Exception as _m_exc:  # noqa: BLE001 — diagnostics only
+                            logger.debug("[DELIVERY-PROBE] metrics_snapshot unavailable: %s", _m_exc)
                         try:
                             import ciris_server  # type: ignore[import-not-found, import-untyped, unused-ignore]
 

--- a/client/androidApp/build.gradle
+++ b/client/androidApp/build.gradle
@@ -25,8 +25,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 35
-        versionCode 174
-        versionName "2.9.37"
+        versionCode 175
+        versionName "2.9.38"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/client/androidApp/src/main/python/version.py
+++ b/client/androidApp/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.9.37"
+__version__ = "android-2.9.38"
 
 
 def get_version() -> str:

--- a/client/desktopApp/build.gradle.kts
+++ b/client/desktopApp/build.gradle.kts
@@ -34,7 +34,7 @@ compose.desktop {
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "CIRIS"
-            packageVersion = "2.9.37"
+            packageVersion = "2.9.38"
             description = "CIRIS Agent Desktop Application"
             vendor = "CIRIS L3C"
 

--- a/client/iosApp/iosApp/Info.plist
+++ b/client/iosApp/iosApp/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.37</string>
+	<string>2.9.38</string>
 	<key>CFBundleVersion</key>
-	<string>338</string>
+	<string>339</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/tests/ciris_engine/logic/runtime/test_delivery_retry_policy.py
+++ b/tests/ciris_engine/logic/runtime/test_delivery_retry_policy.py
@@ -1,0 +1,95 @@
+"""When to reprime, and when to stop pretending waiting will help.
+
+Both decisions come from one live run that failed: 141 anti-entropy rounds,
+21 Key envelopes sent, ZERO envelopes received, KEX never landed, and the
+delivery window torn down at 3m16s. Under the old flat 180s cadence that run
+got exactly ONE reprime, and its log said "give it a round" the whole time —
+to a peer that was never going to answer, because the canonical held no key
+for that node and a fail-closed refusal is silent (CIRISServer#488).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ciris_engine.logic.runtime.edge_runtime import (
+    REPRIME_CADENCE,
+    REPRIME_SCHEDULE,
+    peer_is_silent,
+    should_reprime,
+)
+
+
+class TestTheScheduleIsFrontLoaded:
+    def test_the_first_nudge_lands_inside_a_short_window(self):
+        """The failing run had ~196s of window after rooting. A first reprime
+        at 180s leaves no room for a second; at 45s it leaves three."""
+        assert REPRIME_SCHEDULE[0] < 60
+        assert len(REPRIME_SCHEDULE) >= 3
+        assert REPRIME_SCHEDULE == tuple(sorted(REPRIME_SCHEDULE)), "must be increasing"
+
+    @pytest.mark.parametrize("waited", [0, 15, 30, 44])
+    def test_nothing_fires_before_the_first_slot(self, waited):
+        assert should_reprime(waited, reprimes_done=0, last_reprime=0) is False
+
+    def test_the_first_slot_fires_at_45s(self):
+        assert should_reprime(45, reprimes_done=0, last_reprime=0) is True
+
+    def test_each_slot_fires_in_turn(self):
+        # having done one at 45, the next waits for 120 — not 45+cadence
+        assert should_reprime(60, reprimes_done=1, last_reprime=45) is False
+        assert should_reprime(120, reprimes_done=1, last_reprime=45) is True
+        assert should_reprime(299, reprimes_done=2, last_reprime=120) is False
+        assert should_reprime(300, reprimes_done=2, last_reprime=120) is True
+
+    def test_a_short_window_gets_more_than_the_single_attempt_it_used_to(self):
+        """The regression this exists to prevent, walked at the probe's own
+        15s step over the 196s the failing run actually had.
+
+        The old flat 180s cadence fired ONCE, at 180 — 16 seconds before
+        teardown. The schedule fires at 45 and 120: two real attempts, both
+        early enough for a reply to come back. Not three — the third slot is
+        at 300s, past this window — and asserting three would be asserting a
+        number rather than the behaviour.
+        """
+        fired, done, last = [], 0, 0
+        for waited in range(0, 196, 15):
+            if should_reprime(waited, done, last):
+                fired.append(waited)
+                done += 1
+                last = waited
+        assert fired == [45, 120], f"expected two early attempts, got {fired}"
+
+        # what the old policy managed over the same window, for contrast
+        old_policy = [w for w in range(0, 196, 15) if w and w % 180 == 0]
+        assert len(old_policy) == 1 and len(fired) > len(old_policy)
+
+    def test_after_the_schedule_it_settles_to_the_steady_cadence(self):
+        spent = len(REPRIME_SCHEDULE)
+        assert should_reprime(400, reprimes_done=spent, last_reprime=300) is False
+        assert should_reprime(300 + REPRIME_CADENCE, reprimes_done=spent, last_reprime=300) is True
+
+    def test_the_steady_cadence_is_not_faster_than_the_last_slot(self):
+        """Front-loading must not turn into hammering a peer that is simply slow."""
+        assert REPRIME_CADENCE >= 120
+
+
+class TestSilentVersusSlow:
+    def test_inbound_traffic_means_slow_not_silent(self):
+        """Rounds are flowing; KEX just has not landed. Waiting is correct."""
+        assert peer_is_silent(received_total=1, reprimes_done=5) is False
+        assert peer_is_silent(received_total=50, reprimes_done=9) is False
+
+    def test_one_unanswered_reprime_is_not_yet_an_accusation(self):
+        assert peer_is_silent(received_total=0, reprimes_done=0) is False
+        assert peer_is_silent(received_total=0, reprimes_done=1) is False
+
+    def test_two_unanswered_reprimes_with_nothing_received_is_silence(self):
+        """The live failure exactly: zero inbound, asked more than once."""
+        assert peer_is_silent(received_total=0, reprimes_done=2) is True
+        assert peer_is_silent(received_total=0, reprimes_done=7) is True
+
+    def test_a_single_late_reply_clears_the_verdict(self):
+        """One envelope back is enough to say the peer is answering — the
+        distinction is 'replies at all', not 'replies enough'."""
+        assert peer_is_silent(received_total=1, reprimes_done=99) is False

--- a/tests/tools/qa_runner/test_accord_metrics_outcomes.py
+++ b/tests/tools/qa_runner/test_accord_metrics_outcomes.py
@@ -57,7 +57,10 @@ class TestRetirementIsNotFailure:
     def test_the_runner_renders_skips_as_their_own_status(self):
         src = MODULE.read_text(encoding="utf-8")
         assert 'startswith(SKIP_PREFIX)' in src
-        assert '"⏭️  SKIP"' in src, "a skip must not be recorded as a pass or a fail"
+        assert '"[SKIP]"' in src, "a skip must not be recorded as a pass or a fail"
+        # and it must stay ASCII: an emoji here kills the process on a Windows
+        # cp1252 console, which the repo guards against repo-wide
+        assert "⏭" not in src, "the skip marker must be ASCII, like [OK] and [FAIL]"
 
 
 class TestAFailureAlwaysSaysSomething:

--- a/tests/tools/qa_runner/test_accord_metrics_outcomes.py
+++ b/tests/tools/qa_runner/test_accord_metrics_outcomes.py
@@ -1,0 +1,81 @@
+"""A check that cannot run is not a check that failed.
+
+A live run reported two red tests:
+
+    ❌ Lens Key Registration Check: Lens server returned 404: 404 — lens retired;
+       see /v1/identity and /lens/api/v1/*
+    ❌ Lens Key ID Consistency: Cannot fetch keys: HTTP 404
+
+Nothing about the agent was wrong. Someone else's service retired an endpoint
+and said so in the response body. Reporting that in red is how a suite teaches
+its readers that red does not mean anything — and this suite already had a
+third red in the same run that DID matter.
+
+The same run also produced:
+
+    ❌ Verb Second Pass Trace:
+
+with nothing after the colon, because the only failure path was
+`return False, str(e)` and `str(TimeoutError())` is the empty string.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+MODULE = Path(__file__).resolve().parents[3] / "tools/qa_runner/modules/accord_metrics_tests.py"
+
+
+class TestRetirementIsNotFailure:
+    @pytest.mark.parametrize(
+        "status,body,expected",
+        [
+            (404, "404 — lens retired; see /v1/identity and /lens/api/v1/*", True),
+            (410, "Gone: retired", True),
+            (404, "not found", False),          # an ordinary 404 is still a failure
+            (500, "retired", False),            # a 500 mentioning it is not a retirement
+            (503, "service unavailable", False),
+            (404, "", False),
+            (404, None, False),
+        ],
+    )
+    def test_only_a_declared_retirement_counts(self, status, body, expected):
+        from tools.qa_runner.modules.accord_metrics_tests import _endpoint_retired
+
+        assert _endpoint_retired(status, body) is expected
+
+    def test_both_lens_checks_route_a_retirement_to_SKIP(self):
+        src = MODULE.read_text(encoding="utf-8")
+        for fn in ("_test_lens_key_registration", "_test_lens_key_id_consistency"):
+            start = src.index(f"async def {fn}")
+            body = src[start : src.index("\n    async def ", start + 10)]
+            assert "_endpoint_retired" in body, f"{fn} still fails red on a retired endpoint"
+            assert "SKIP_PREFIX" in body, f"{fn} does not report the retirement as a skip"
+
+    def test_the_runner_renders_skips_as_their_own_status(self):
+        src = MODULE.read_text(encoding="utf-8")
+        assert 'startswith(SKIP_PREFIX)' in src
+        assert '"⏭️  SKIP"' in src, "a skip must not be recorded as a pass or a fail"
+
+
+class TestAFailureAlwaysSaysSomething:
+    def test_the_verb_test_names_the_exception_type(self):
+        src = MODULE.read_text(encoding="utf-8")
+        start = src.index("async def _test_verb_second_pass_traces")
+        body = src[start : src.index("\n    async def ", start + 10)]
+        assert "type(e).__name__" in body, (
+            "an exception whose str() is empty must still be named, or the report reads "
+            "'FAIL Verb Second Pass Trace:' with nothing after it"
+        )
+        assert "verbs captured before the failure" in body, (
+            "say how far it got — a stall and a wrong verb look identical otherwise"
+        )
+
+    def test_the_generic_loop_names_the_exception_type(self):
+        src = MODULE.read_text(encoding="utf-8")
+        loop = src[src.index("for name, test_fn in tests:") :]
+        loop = loop[: loop.index("\n    async def ")]
+        assert "type(e).__name__" in loop
+        assert "exc_info=True" in loop, "the traceback belongs in the log even when the message is empty"

--- a/tests/tools/qa_runner/test_federation_delivery_verdict.py
+++ b/tests/tools/qa_runner/test_federation_delivery_verdict.py
@@ -207,7 +207,7 @@ class TestSkipDoesNotFailTheRun:
 
 
 class TestTheTracePlaneComesFromTheSubstrate:
-    """Ask the node, do not re-derive it.
+    """Ask the node, do not re-derive it — and READ the answer, do not call it.
 
     Three derivations were tried and all three were wrong:
 
@@ -216,65 +216,73 @@ class TestTheTracePlaneComesFromTheSubstrate:
       * `LIKE '%trace:%'` over the attestations — read 4 against a true 3, and
         at a 1:1 carrier ratio that inflation is enough to report carriers on a
         node that holds none. `trace:` and `trace_summary:` are different
-        namespaces and only one crosses the wire; the trailing colon is what
-        decides, because `covers()` is a prefix test.
+        namespaces and only one crosses the wire; the trailing colon decides,
+        because `covers()` is a prefix test.
       * `trace_events.cohort_scope` — a read-time projection in a different
         table, downstream of the attestation's own scope. 71 rows at
-        `federation` there is fully consistent with the carriers sitting at
-        `self`.
+        `federation` there is fully consistent with carriers sitting at `self`.
 
-    `node_state().trace_plane` is persist's `storage_summary()` verbatim, which
-    is the value the node acts on.
+    And a fourth mistake, mine: calling `node_state()` from the runner. It is
+    in-process to the server, which this runner boots as a subprocess, so the
+    call returns nothing however healthy the node is. The node logs the value;
+    the runner reads the line.
     """
 
-    def test_it_parses_the_standing(self, runner, monkeypatch):
-        import json as _json
-        import sys, types
+    def _line(self, plane: dict, phase: str = "kex-present-await-ship") -> str:
+        return f"[TRACE-PLANE] phase={phase} " + json.dumps(plane)
 
-        fake = types.ModuleType("ciris_server")
-        fake.node_state = lambda *a, **k: _json.dumps(
-            {"trace_plane": {"standing": "live", "band": "green", "carriers": 3,
-                             "last_admitted_at": "2026-08-24T14:41:00Z", "extra": "ignored"}}
+    def test_it_parses_the_logged_standing(self, runner):
+        line = self._line(
+            {"standing": "live", "band": "green", "carriers": 3,
+             "last_admitted_at": "2026-08-24T14:41:00Z", "extra": "ignored"}
         )
-        monkeypatch.setitem(sys.modules, "ciris_server", fake)
-        plane = runner._trace_plane_from_node_state()
+        plane = runner._trace_plane_from_node_state(lambda: line)
         assert plane is not None
         assert (plane.standing, plane.band, plane.carriers) == ("live", "green", 3)
-        assert not hasattr(plane, "extra")
+        assert not hasattr(plane, "extra"), "extra keys ignored, not absorbed untyped"
 
-    def test_a_dark_plane_is_reported_not_swallowed(self, runner, monkeypatch):
-        import json as _json
-        import sys, types
-
-        fake = types.ModuleType("ciris_server")
-        fake.node_state = lambda *a, **k: _json.dumps(
-            {"trace_plane": {"standing": "unreadable", "band": "dark", "carriers": 0}}
-        )
-        monkeypatch.setitem(sys.modules, "ciris_server", fake)
-        plane = runner._trace_plane_from_node_state()
+    def test_a_dark_plane_is_reported_not_swallowed(self, runner):
+        line = self._line({"standing": "unreadable", "band": "dark", "carriers": 0})
+        plane = runner._trace_plane_from_node_state(lambda: line)
         assert plane.band == "dark" and plane.carriers == 0
 
-    def test_no_runtime_is_None_not_an_invented_zero(self, runner, monkeypatch):
-        """A harness that already stopped its server must say it cannot tell —
-        reporting carriers=0 there is the same mistake as reading an absent
-        probe verdict as knows_peer=false."""
-        import sys, types
+    def test_the_last_line_wins(self, runner):
+        log = "\n".join(
+            [self._line({"carriers": 0}, "kex-none-repriming"), self._line({"carriers": 4}, "ship-confirmed")]
+        )
+        assert runner._trace_plane_from_node_state(lambda: log).carriers == 4
 
-        fake = types.ModuleType("ciris_server")
+    @pytest.mark.parametrize("log", ["", "no such line here", "[TRACE-PLANE] phase=x not-json"])
+    def test_no_line_is_None_not_an_invented_zero(self, runner, log):
+        """Saying carriers=0 when nothing reported is the same mistake as
+        reading an absent probe verdict as knows_peer=false."""
+        assert runner._trace_plane_from_node_state(lambda: log) is None
 
-        def _boom(*a, **k):
-            raise RuntimeError("no runtime")
+    def test_an_unreadable_log_is_survivable(self, runner):
+        def boom() -> str:
+            raise OSError("log went away")
 
-        fake.node_state = _boom
-        monkeypatch.setitem(sys.modules, "ciris_server", fake)
-        assert runner._trace_plane_from_node_state() is None
+        assert runner._trace_plane_from_node_state(boom) is None
+
+    def test_the_node_logs_it_because_the_runner_cannot_call_it(self):
+        """The agent side of the pattern must exist, or the runner reads nothing."""
+        from pathlib import Path
+
+        src = (
+            Path(__file__).resolve().parents[3]
+            / "ciris_engine/logic/runtime/edge_runtime.py"
+        ).read_text(encoding="utf-8")
+        assert "def _log_trace_plane" in src
+        assert "[TRACE-PLANE]" in src
+        # logged wherever delivery status is, since the two are read together
+        assert src.count("_log_trace_plane(") >= 6, "every [DELIVERY-STATUS] point needs its twin"
 
     def test_the_harness_does_not_count_trace_kind_envelopes(self):
         """The wire histogram cannot answer this, so no CODE should ask it to.
 
         Checked against executable statements only — the docstrings above name
-        these wrong derivations on purpose, so that the next person to reach
-        for one finds out why it does not work before writing it.
+        these wrong derivations on purpose, so the next person to reach for one
+        finds out why it does not work before writing it.
         """
         import ast
         from pathlib import Path
@@ -282,8 +290,7 @@ class TestTheTracePlaneComesFromTheSubstrate:
         src = (Path(__file__).resolve().parents[3] / "tools/qa_runner/runner.py").read_text(encoding="utf-8")
         tree = ast.parse(src)
         literals = {
-            node.value
-            for node in ast.walk(tree)
+            node.value for node in ast.walk(tree)
             if isinstance(node, ast.Constant) and isinstance(node.value, str)
         }
         docstrings = set()
@@ -292,17 +299,17 @@ class TestTheTracePlaneComesFromTheSubstrate:
                 doc = ast.get_docstring(node, clean=False)
                 if doc:
                     docstrings.add(doc)
-        executable = literals - docstrings
         for banned in ("kind=Trace", "LIKE '%trace:%'", "trace_events.cohort_scope"):
-            offenders = [lit for lit in executable if banned in lit]
-            assert not offenders, (
-                f"{banned!r} appears in executable code, not just in the note explaining "
-                f"why it is wrong: {offenders}"
-            )
+            offenders = [lit for lit in literals - docstrings if banned in lit]
+            assert not offenders, f"{banned!r} appears in executable code: {offenders}"
 
-    def test_the_harness_does_ask_node_state(self):
+    def test_the_value_still_originates_from_the_substrate(self):
+        """The runner reads a line, but the line must carry node_state()'s own
+        answer — not something the agent computed for itself either."""
         from pathlib import Path
 
-        src = (Path(__file__).resolve().parents[3] / "tools/qa_runner/runner.py").read_text(encoding="utf-8")
-        assert "ciris_server.node_state()" in src, "the substrate's own read is the happy path"
-        assert "trace_plane" in src
+        agent = (
+            Path(__file__).resolve().parents[3]
+            / "ciris_engine/logic/runtime/edge_runtime.py"
+        ).read_text(encoding="utf-8")
+        assert "node_state" in agent and "trace_plane" in agent

--- a/tests/tools/qa_runner/test_federation_delivery_verdict.py
+++ b/tests/tools/qa_runner/test_federation_delivery_verdict.py
@@ -56,12 +56,11 @@ def runner():
 class TestPeerStateFromDeliveryStatus:
     def test_it_reads_the_canonical_peer_entry(self, runner):
         state = runner._peer_state_from_delivery_status(lambda: STATUS_LINE)
-        assert state == {
-            "key_id": "ciris-canonical-1-d7bdeu223k",
-            "knows_peer": True,
-            "kex_present": True,
-            "deliverable": True,
-        }
+        assert state is not None
+        assert state.key_id == "ciris-canonical-1-d7bdeu223k"
+        assert state.knows_peer is True
+        assert state.kex_present is True
+        assert state.deliverable is True
 
     def test_it_prefers_the_canonical_target_over_the_first_peer(self, runner):
         line = "[DELIVERY-STATUS] phase=x " + json.dumps(
@@ -73,7 +72,7 @@ class TestPeerStateFromDeliveryStatus:
                 ],
             }
         )
-        assert runner._peer_state_from_delivery_status(lambda: line)["key_id"] == "canonical-1"
+        assert runner._peer_state_from_delivery_status(lambda: line).key_id == "canonical-1"
 
     @pytest.mark.parametrize(
         "log",
@@ -120,3 +119,88 @@ class TestUnknownIsNotFalse:
             "the unverified verdict must say plainly that it is not a failure, or readers will "
             "treat the yellow as red and chase a healthy transport again"
         )
+
+
+class TestTheFallbackCannotManufactureGreen:
+    """Every way the delivery_status fallback could claim more than it knows."""
+
+    def _status(self, targets, peers, phase="kex-present-await-ship"):
+        return "[DELIVERY-STATUS] phase=%s %s" % (
+            phase,
+            json.dumps({"delivery_started": True, "edge_up": True, "canonical_targets": targets, "peers": peers}),
+        )
+
+    def test_an_unrelated_peer_is_never_substituted_for_the_canonical(self, runner):
+        """The canonical is named. If it has not appeared in `peers` yet, that
+        IS the finding — handing back some other rooted, KEX-ready federation
+        peer would report the canonical's preconditions GREEN under exactly the
+        missing-canonical condition being diagnosed."""
+        line = self._status(
+            targets=["ciris-canonical-1-d7bdeu223k"],
+            peers=[{"key_id": "some-other-peer", "knows_peer": True, "kex_present": True, "deliverable": True}],
+        )
+        assert runner._peer_state_from_delivery_status(lambda: line) is None
+
+    def test_with_no_named_target_the_single_peer_is_still_usable(self, runner):
+        line = self._status(targets=[], peers=[{"key_id": "p1", "knows_peer": True}])
+        state = runner._peer_state_from_delivery_status(lambda: line)
+        assert state is not None and state.key_id == "p1"
+
+    def test_absent_fields_stay_unknown_rather_than_false(self, runner):
+        """The whole point of the change: unknown must not read as false."""
+        line = self._status(targets=["c1"], peers=[{"key_id": "c1"}])
+        state = runner._peer_state_from_delivery_status(lambda: line)
+        assert state.knows_peer is None
+        assert state.kex_present is None
+        assert state.deliverable is None
+
+    def test_the_state_is_a_typed_model_not_a_raw_dict(self, runner):
+        from tools.qa_runner.runner import CanonicalPeerState
+
+        line = self._status(targets=["c1"], peers=[{"key_id": "c1", "knows_peer": True, "junk": "ignored"}])
+        state = runner._peer_state_from_delivery_status(lambda: line)
+        assert isinstance(state, CanonicalPeerState)
+        assert not hasattr(state, "junk"), "extra keys must be ignored, not absorbed untyped"
+
+
+class TestDeliverableIsHonoured:
+    """rooted + KEX does not imply deliverable, and the node says so itself."""
+
+    def test_a_non_deliverable_peer_is_not_reported_as_sealable(self):
+        from tools.qa_runner.runner import CanonicalPeerState
+
+        # the shape: delivery not started / edge down, yet both booleans true
+        state = CanonicalPeerState(key_id="c1", knows_peer=True, kex_present=True, deliverable=False)
+        # mirrors the verdict logic: PRESENT requires deliverable is not False
+        kex_state = "PRESENT" if (state.kex_present is True and state.deliverable is not False) else "not-deliverable"
+        assert kex_state == "not-deliverable", (
+            "reporting PRESENT here would print 'trace envelopes can seal' AND skip the "
+            "diagnosis that names deliverable=false"
+        )
+
+    def test_the_source_gates_PRESENT_on_deliverable(self):
+        from pathlib import Path
+
+        src = (Path(__file__).resolve().parents[3] / "tools/qa_runner/runner.py").read_text(encoding="utf-8")
+        assert "deliverable is not False" in src, (
+            "the fallback must not set kex_state=PRESENT while the node says the peer is not deliverable"
+        )
+
+
+class TestSkipDoesNotFailTheRun:
+    """The fix that was defeated by the aggregator."""
+
+    def test_skip_counts_as_non_failing(self):
+        from tools.qa_runner.runner import _is_non_failing
+
+        assert _is_non_failing("✅ PASS") is True
+        assert _is_non_failing("⏭️  SKIP") is True
+        assert _is_non_failing("❌ FAIL") is False
+
+    def test_the_aggregators_use_the_predicate(self):
+        from pathlib import Path
+
+        src = (Path(__file__).resolve().parents[3] / "tools/qa_runner/runner.py").read_text(encoding="utf-8")
+        assert '"PASS" in result["status"]' not in src, "per-test aggregation still ignores SKIP"
+        assert 'all("PASS" in r["status"] for r in results)' not in src, "module aggregation still ignores SKIP"
+        assert src.count("_is_non_failing(") >= 3, "both aggregation sites must use the shared predicate"

--- a/tests/tools/qa_runner/test_federation_delivery_verdict.py
+++ b/tests/tools/qa_runner/test_federation_delivery_verdict.py
@@ -141,10 +141,13 @@ class TestTheFallbackCannotManufactureGreen:
         )
         assert runner._peer_state_from_delivery_status(lambda: line) is None
 
-    def test_with_no_named_target_the_single_peer_is_still_usable(self, runner):
+    def test_with_no_named_target_there_is_no_canonical_to_report(self, runner):
+        """This test used to assert the opposite — that a lone peer was usable
+        when no canonical was named. It is not: without a named target, that
+        peer is simply some peer, and reporting its rooting as the canonical's
+        is the same manufactured green as substituting a non-matching one."""
         line = self._status(targets=[], peers=[{"key_id": "p1", "knows_peer": True}])
-        state = runner._peer_state_from_delivery_status(lambda: line)
-        assert state is not None and state.key_id == "p1"
+        assert runner._peer_state_from_delivery_status(lambda: line) is None
 
     def test_absent_fields_stay_unknown_rather_than_false(self, runner):
         """The whole point of the change: unknown must not read as false."""
@@ -172,7 +175,7 @@ class TestDeliverableIsHonoured:
         # the shape: delivery not started / edge down, yet both booleans true
         state = CanonicalPeerState(key_id="c1", knows_peer=True, kex_present=True, deliverable=False)
         # mirrors the verdict logic: PRESENT requires deliverable is not False
-        kex_state = "PRESENT" if (state.kex_present is True and state.deliverable is not False) else "not-deliverable"
+        kex_state = "PRESENT" if (state.kex_present is True and state.deliverable is True) else "not-deliverable"
         assert kex_state == "not-deliverable", (
             "reporting PRESENT here would print 'trace envelopes can seal' AND skip the "
             "diagnosis that names deliverable=false"
@@ -182,8 +185,9 @@ class TestDeliverableIsHonoured:
         from pathlib import Path
 
         src = (Path(__file__).resolve().parents[3] / "tools/qa_runner/runner.py").read_text(encoding="utf-8")
-        assert "deliverable is not False" in src, (
-            "the fallback must not set kex_state=PRESENT while the node says the peer is not deliverable"
+        assert "fallback.deliverable is True" in src, (
+            "PRESENT must require an affirmative deliverable — `is not False` also admitted the "
+            "unknown case, on no evidence"
         )
 
 
@@ -233,24 +237,24 @@ class TestTheTracePlaneComesFromTheSubstrate:
 
     def test_it_parses_the_logged_standing(self, runner):
         line = self._line(
-            {"standing": "live", "band": "green", "carriers": 3,
+            {"standing": "live", "band": "green", "age_seconds": 12.5,
              "last_admitted_at": "2026-08-24T14:41:00Z", "extra": "ignored"}
         )
         plane = runner._trace_plane_from_node_state(lambda: line)
         assert plane is not None
-        assert (plane.standing, plane.band, plane.carriers) == ("live", "green", 3)
+        assert (plane.standing, plane.band, plane.age_seconds) == ("live", "green", 12.5)
         assert not hasattr(plane, "extra"), "extra keys ignored, not absorbed untyped"
 
     def test_a_dark_plane_is_reported_not_swallowed(self, runner):
-        line = self._line({"standing": "unreadable", "band": "dark", "carriers": 0})
+        line = self._line({"standing": "unreadable", "band": "dark"})
         plane = runner._trace_plane_from_node_state(lambda: line)
-        assert plane.band == "dark" and plane.carriers == 0
+        assert plane.band == "dark" and plane.standing == "unreadable"
 
     def test_the_last_line_wins(self, runner):
         log = "\n".join(
-            [self._line({"carriers": 0}, "kex-none-repriming"), self._line({"carriers": 4}, "ship-confirmed")]
+            [self._line({"band": "dark"}, "kex-none-repriming"), self._line({"band": "green"}, "ship-confirmed")]
         )
-        assert runner._trace_plane_from_node_state(lambda: log).carriers == 4
+        assert runner._trace_plane_from_node_state(lambda: log).band == "green"
 
     @pytest.mark.parametrize("log", ["", "no such line here", "[TRACE-PLANE] phase=x not-json"])
     def test_no_line_is_None_not_an_invented_zero(self, runner, log):
@@ -313,3 +317,79 @@ class TestTheTracePlaneComesFromTheSubstrate:
             / "ciris_engine/logic/runtime/edge_runtime.py"
         ).read_text(encoding="utf-8")
         assert "node_state" in agent and "trace_plane" in agent
+
+
+class TestTheModelMatchesTheSubstrate:
+    def test_it_does_not_model_a_field_the_node_never_returns(self):
+        """`carriers` was invented. `trace_plane` does not return it — the
+        substring appears nowhere in the 0.5.188 extension — so because the
+        model ignored extras and defaulted to None, every real payload
+        validated and the verdict printed `carriers=?` forever: a diagnostic
+        incapable of ever producing a reading."""
+        from tools.qa_runner.runner import TracePlaneStanding
+
+        assert "carriers" not in TracePlaneStanding.model_fields
+        for real in ("standing", "band", "last_admitted_at", "age_seconds"):
+            assert real in TracePlaneStanding.model_fields
+
+
+class TestNoNamedTargetIsNotAnAnswer:
+    def test_an_empty_target_list_yields_no_canonical_state(self, runner):
+        """Without a named canonical, peers[0] is just some peer — and a rooted,
+        KEX-ready unrelated peer would be reported as the canonical's own
+        preconditions."""
+        line = "[DELIVERY-STATUS] phase=x " + json.dumps(
+            {"canonical_targets": [], "peers": [{"key_id": "p1", "knows_peer": True, "kex_present": True, "deliverable": True}]}
+        )
+        assert runner._peer_state_from_delivery_status(lambda: line) is None
+
+
+class TestUnknownDeliverabilityIsNotGreen:
+    def test_omitted_deliverable_does_not_reach_PRESENT(self):
+        from pathlib import Path
+
+        src = (Path(__file__).resolve().parents[3] / "tools/qa_runner/runner.py").read_text(encoding="utf-8")
+        assert "fallback.deliverable is True" in src, (
+            "green must require an affirmative deliverable; `is not False` admits the unknown "
+            "state this model exists to preserve"
+        )
+        assert "deliverable is not False" not in src
+
+
+class TestIncompleteIsNotAbsent:
+    def test_the_two_unknowns_read_differently(self):
+        from pathlib import Path
+
+        src = (Path(__file__).resolve().parents[3] / "tools/qa_runner/runner.py").read_text(encoding="utf-8")
+        assert "no canonical peer entry in delivery_status()" in src
+        assert "exists but reports no knows_peer" in src, (
+            "an entry that omits knows_peer printed a canonical key two lines above, so calling "
+            "it 'no peer entry' contradicts the output right before it"
+        )
+
+
+class TestTheRetryIsFrontLoaded:
+    """A 180s first nudge spends the whole of a short window doing nothing."""
+
+    def test_the_schedule_starts_well_before_the_old_cadence(self):
+        from pathlib import Path
+
+        src = (
+            Path(__file__).resolve().parents[3] / "ciris_engine/logic/runtime/edge_runtime.py"
+        ).read_text(encoding="utf-8")
+        assert "reprime_schedule = (45, 120, 300)" in src, (
+            "the live run that failed got ONE reprime in 3m16s; the first attempt has to come "
+            "much earlier than 180s"
+        )
+        assert "reprimes_done" in src
+
+    def test_a_silent_peer_is_named_as_such(self):
+        """Zero inbound is a refusal wall, not congestion — and reprime cannot
+        fix it, so the log must stop implying that waiting will help."""
+        from pathlib import Path
+
+        src = (
+            Path(__file__).resolve().parents[3] / "ciris_engine/logic/runtime/edge_runtime.py"
+        ).read_text(encoding="utf-8")
+        assert "envelopes_received_total" in src
+        assert "ZERO" in src and "488" in src

--- a/tests/tools/qa_runner/test_federation_delivery_verdict.py
+++ b/tests/tools/qa_runner/test_federation_delivery_verdict.py
@@ -368,28 +368,38 @@ class TestIncompleteIsNotAbsent:
         )
 
 
-class TestTheRetryIsFrontLoaded:
-    """A 180s first nudge spends the whole of a short window doing nothing."""
+class TestTheRetryPolicyLivesWhereItCanBeTested:
+    """The retry behaviour itself is covered in
+    `tests/ciris_engine/logic/runtime/test_delivery_retry_policy.py`, against
+    the imported functions.
 
-    def test_the_schedule_starts_well_before_the_old_cadence(self):
+    What used to be here were two source-greps for literal strings —
+    `"reprime_schedule = (45, 120, 300)"` and the like. They broke the moment
+    the decisions were extracted into `should_reprime` / `peer_is_silent`,
+    which is the third time in this PR a grep-the-source guard has failed on a
+    rename while the behaviour it was guarding stayed correct. A test that
+    breaks on refactor and passes on regression is worse than none, so these
+    assert the seam exists and leave the behaviour to the behavioural tests.
+    """
+
+    def test_the_decisions_are_importable_functions(self):
+        from ciris_engine.logic.runtime.edge_runtime import peer_is_silent, should_reprime
+
+        assert callable(should_reprime) and callable(peer_is_silent)
+
+    def test_the_first_attempt_comes_long_before_the_old_flat_cadence(self):
+        """The one fact worth pinning here: the failing run got ONE reprime in
+        3m16s under a flat 180s cadence."""
+        from ciris_engine.logic.runtime.edge_runtime import REPRIME_SCHEDULE
+
+        assert REPRIME_SCHEDULE[0] < 180
+
+    def test_the_probe_reads_what_the_peer_sent_back(self):
         from pathlib import Path
 
         src = (
             Path(__file__).resolve().parents[3] / "ciris_engine/logic/runtime/edge_runtime.py"
         ).read_text(encoding="utf-8")
-        assert "reprime_schedule = (45, 120, 300)" in src, (
-            "the live run that failed got ONE reprime in 3m16s; the first attempt has to come "
-            "much earlier than 180s"
+        assert "envelopes_received_total" in src, (
+            "silent-vs-slow needs the inbound count; without it both stalls look identical"
         )
-        assert "reprimes_done" in src
-
-    def test_a_silent_peer_is_named_as_such(self):
-        """Zero inbound is a refusal wall, not congestion — and reprime cannot
-        fix it, so the log must stop implying that waiting will help."""
-        from pathlib import Path
-
-        src = (
-            Path(__file__).resolve().parents[3] / "ciris_engine/logic/runtime/edge_runtime.py"
-        ).read_text(encoding="utf-8")
-        assert "envelopes_received_total" in src
-        assert "ZERO" in src and "488" in src

--- a/tests/tools/qa_runner/test_federation_delivery_verdict.py
+++ b/tests/tools/qa_runner/test_federation_delivery_verdict.py
@@ -204,3 +204,105 @@ class TestSkipDoesNotFailTheRun:
         assert '"PASS" in result["status"]' not in src, "per-test aggregation still ignores SKIP"
         assert 'all("PASS" in r["status"] for r in results)' not in src, "module aggregation still ignores SKIP"
         assert src.count("_is_non_failing(") >= 3, "both aggregation sites must use the shared predicate"
+
+
+class TestTheTracePlaneComesFromTheSubstrate:
+    """Ask the node, do not re-derive it.
+
+    Three derivations were tried and all three were wrong:
+
+      * `kind=Trace` on the wire — no such envelope kind exists; carriers ride
+        the Attestation plane, so the histogram cannot answer the question.
+      * `LIKE '%trace:%'` over the attestations — read 4 against a true 3, and
+        at a 1:1 carrier ratio that inflation is enough to report carriers on a
+        node that holds none. `trace:` and `trace_summary:` are different
+        namespaces and only one crosses the wire; the trailing colon is what
+        decides, because `covers()` is a prefix test.
+      * `trace_events.cohort_scope` — a read-time projection in a different
+        table, downstream of the attestation's own scope. 71 rows at
+        `federation` there is fully consistent with the carriers sitting at
+        `self`.
+
+    `node_state().trace_plane` is persist's `storage_summary()` verbatim, which
+    is the value the node acts on.
+    """
+
+    def test_it_parses_the_standing(self, runner, monkeypatch):
+        import json as _json
+        import sys, types
+
+        fake = types.ModuleType("ciris_server")
+        fake.node_state = lambda *a, **k: _json.dumps(
+            {"trace_plane": {"standing": "live", "band": "green", "carriers": 3,
+                             "last_admitted_at": "2026-08-24T14:41:00Z", "extra": "ignored"}}
+        )
+        monkeypatch.setitem(sys.modules, "ciris_server", fake)
+        plane = runner._trace_plane_from_node_state()
+        assert plane is not None
+        assert (plane.standing, plane.band, plane.carriers) == ("live", "green", 3)
+        assert not hasattr(plane, "extra")
+
+    def test_a_dark_plane_is_reported_not_swallowed(self, runner, monkeypatch):
+        import json as _json
+        import sys, types
+
+        fake = types.ModuleType("ciris_server")
+        fake.node_state = lambda *a, **k: _json.dumps(
+            {"trace_plane": {"standing": "unreadable", "band": "dark", "carriers": 0}}
+        )
+        monkeypatch.setitem(sys.modules, "ciris_server", fake)
+        plane = runner._trace_plane_from_node_state()
+        assert plane.band == "dark" and plane.carriers == 0
+
+    def test_no_runtime_is_None_not_an_invented_zero(self, runner, monkeypatch):
+        """A harness that already stopped its server must say it cannot tell —
+        reporting carriers=0 there is the same mistake as reading an absent
+        probe verdict as knows_peer=false."""
+        import sys, types
+
+        fake = types.ModuleType("ciris_server")
+
+        def _boom(*a, **k):
+            raise RuntimeError("no runtime")
+
+        fake.node_state = _boom
+        monkeypatch.setitem(sys.modules, "ciris_server", fake)
+        assert runner._trace_plane_from_node_state() is None
+
+    def test_the_harness_does_not_count_trace_kind_envelopes(self):
+        """The wire histogram cannot answer this, so no CODE should ask it to.
+
+        Checked against executable statements only — the docstrings above name
+        these wrong derivations on purpose, so that the next person to reach
+        for one finds out why it does not work before writing it.
+        """
+        import ast
+        from pathlib import Path
+
+        src = (Path(__file__).resolve().parents[3] / "tools/qa_runner/runner.py").read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        literals = {
+            node.value
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Constant) and isinstance(node.value, str)
+        }
+        docstrings = set()
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                doc = ast.get_docstring(node, clean=False)
+                if doc:
+                    docstrings.add(doc)
+        executable = literals - docstrings
+        for banned in ("kind=Trace", "LIKE '%trace:%'", "trace_events.cohort_scope"):
+            offenders = [lit for lit in executable if banned in lit]
+            assert not offenders, (
+                f"{banned!r} appears in executable code, not just in the note explaining "
+                f"why it is wrong: {offenders}"
+            )
+
+    def test_the_harness_does_ask_node_state(self):
+        from pathlib import Path
+
+        src = (Path(__file__).resolve().parents[3] / "tools/qa_runner/runner.py").read_text(encoding="utf-8")
+        assert "ciris_server.node_state()" in src, "the substrate's own read is the happy path"
+        assert "trace_plane" in src

--- a/tests/tools/qa_runner/test_federation_delivery_verdict.py
+++ b/tests/tools/qa_runner/test_federation_delivery_verdict.py
@@ -1,0 +1,122 @@
+"""The federation-delivery verdict must not invent facts it does not have.
+
+A live run against the canonical peer reported:
+
+    transport-rooted : ❓ probe verdict not found  (edge.knows_peer — authoritative)
+    ❌ Canonical NOT transport-rooted (edge.knows_peer=false) — neither rounds
+       nor trace envelopes can flow. Check the canonical boot-prime + bootstrap dial.
+    delivery_status  : phase=kex-present-await-ship started=True edge_up=True
+    → deliverable=true but trace not landing
+
+Three sentences, and the middle one contradicts both its neighbours. The node
+log for that same run showed the peer rooted from its baked KeyRecord, 300
+anti-entropy rounds, 50 inbound envelopes and zero dropped frames — the
+transport was fine. What had actually happened is that the `[DELIVERY-PROBE]`
+line never landed, and an absent verdict was rendered as `false`.
+
+That is worse than no verdict: it points the reader at the boot-prime and the
+bootstrap dial, which were healthy, and away from the ship stage, which was
+not. So: unknown is its own outcome, and when the probe line is missing the
+verdict comes from `delivery_status()` — the same value the node acts on.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+STATUS_LINE = (
+    "[DELIVERY-STATUS] phase=kex-present-await-ship "
+    + json.dumps(
+        {
+            "delivery_started": True,
+            "edge_up": True,
+            "canonical_targets": ["ciris-canonical-1-d7bdeu223k"],
+            "peers": [
+                {
+                    "key_id": "ciris-canonical-1-d7bdeu223k",
+                    "knows_peer": True,
+                    "kex_present": True,
+                    "deliverable": True,
+                }
+            ],
+        }
+    )
+)
+
+
+@pytest.fixture
+def runner():
+    from tools.qa_runner.runner import QARunner
+
+    return QARunner.__new__(QARunner)
+
+
+class TestPeerStateFromDeliveryStatus:
+    def test_it_reads_the_canonical_peer_entry(self, runner):
+        state = runner._peer_state_from_delivery_status(lambda: STATUS_LINE)
+        assert state == {
+            "key_id": "ciris-canonical-1-d7bdeu223k",
+            "knows_peer": True,
+            "kex_present": True,
+            "deliverable": True,
+        }
+
+    def test_it_prefers_the_canonical_target_over_the_first_peer(self, runner):
+        line = "[DELIVERY-STATUS] phase=x " + json.dumps(
+            {
+                "canonical_targets": ["canonical-1"],
+                "peers": [
+                    {"key_id": "some-other-peer", "knows_peer": False},
+                    {"key_id": "canonical-1", "knows_peer": True},
+                ],
+            }
+        )
+        assert runner._peer_state_from_delivery_status(lambda: line)["key_id"] == "canonical-1"
+
+    @pytest.mark.parametrize(
+        "log",
+        ["", "nothing of interest here", "[DELIVERY-STATUS] phase=x not-json-at-all"],
+    )
+    def test_it_returns_None_rather_than_raising(self, runner, log):
+        assert runner._peer_state_from_delivery_status(lambda: log) is None
+
+    def test_a_reader_that_explodes_is_survivable(self, runner):
+        """Diagnostics must never be the thing that fails a run."""
+
+        def boom() -> str:
+            raise OSError("log went away")
+
+        assert runner._peer_state_from_delivery_status(boom) is None
+
+
+class TestUnknownIsNotFalse:
+    """The verdict text itself — the part that misled."""
+
+    def test_the_source_no_longer_claims_knows_peer_false_on_an_absent_verdict(self):
+        from pathlib import Path
+
+        src = Path(__file__).resolve().parents[3] / "tools/qa_runner/runner.py"
+        text = src.read_text(encoding="utf-8")
+        claim = "Canonical NOT transport-rooted (edge.knows_peer=false)"
+        # The claim may still exist — but only under an explicit `is False`.
+        idx = text.index(claim)
+        preceding = text[:idx]
+        guard = preceding.rsplit("elif ", 1)[-1].split("\n", 1)[0]
+        assert "transport_rooted is False" in guard, (
+            "the hard 'knows_peer=false' verdict must be reachable only when the probe "
+            f"actually said False; it is currently guarded by: {guard!r}"
+        )
+
+    def test_there_is_a_distinct_unverified_verdict(self):
+        from pathlib import Path
+
+        src = Path(__file__).resolve().parents[3] / "tools/qa_runner/runner.py"
+        text = src.read_text(encoding="utf-8")
+        assert "UNVERIFIED" in text, "an absent verdict needs its own outcome, not a false one"
+        # contiguous in the source; the full sentence spans a string concatenation
+        assert "evidence of a broken transport" in text.lower(), (
+            "the unverified verdict must say plainly that it is not a failure, or readers will "
+            "treat the yellow as red and chase a healthy transport again"
+        )

--- a/tools/qa_runner/modules/accord_metrics_tests.py
+++ b/tools/qa_runner/modules/accord_metrics_tests.py
@@ -52,6 +52,21 @@ logger = logging.getLogger(__name__)
 # Live Lens server URL
 LENS_SERVER_URL = "https://lens.ciris-services-1.ai/lens-api/api/v1"
 
+#: Returned as the message of a check that could not run at all, so the harness
+#: can separate "the agent is wrong" from "the thing we ask has gone away".
+SKIP_PREFIX = "SKIP:"
+
+
+def _endpoint_retired(status: int, body: str) -> bool:
+    """Whether a non-200 means the endpoint itself is gone, not that we failed it.
+
+    The Lens server answers a retired path with a 404 whose body names its
+    successors ("lens retired; see /v1/identity and /lens/api/v1/*"). That is a
+    deployment fact about someone else's service, and dressing it as an agent
+    failure cost a live run two red tests that had nothing to do with the agent.
+    """
+    return status in (404, 410) and "retired" in (body or "").lower()
+
 
 class AccordMetricsTests:
     """Test module for accord metrics trace capture and signing.
@@ -367,6 +382,16 @@ class AccordMetricsTests:
             try:
                 logger.info(f"Running: {name}")
                 success, message = await test_fn()
+                # A THIRD OUTCOME: the check could not run at all. A dependency
+                # that has been retired upstream is not the agent failing, and
+                # reporting it in red is how a suite teaches people to ignore
+                # red. Such a check says so by returning SKIP_PREFIX, and lands
+                # as its own status.
+                if not success and message.startswith(SKIP_PREFIX):
+                    reason = message[len(SKIP_PREFIX):].strip()
+                    self.results.append({"test": name, "status": "⏭️  SKIP", "error": None, "skipped": reason})
+                    self.console.print(f"  [yellow]⏭️  SKIP[/yellow] {name}: {reason}")
+                    continue
                 status = "✅ PASS" if success else "❌ FAIL"
                 self.results.append(
                     {
@@ -380,12 +405,15 @@ class AccordMetricsTests:
                 else:
                     self.console.print(f"  [red]{status}[/red] {name}: {message}")
             except Exception as e:
-                logger.error(f"Error in {name}: {e}")
+                # Same reason as above: an exception whose str() is empty must
+                # still say what it was, or the report reads "FAIL <name>:".
+                detail = f"{type(e).__name__}: {e}" if str(e) else type(e).__name__
+                logger.error(f"Error in {name}: {detail}", exc_info=True)
                 self.results.append(
                     {
                         "test": name,
                         "status": "❌ FAIL",
-                        "error": str(e),
+                        "error": detail,
                     }
                 )
                 self.console.print(f" [red][FAIL] FAIL[/red] {name}: {e}")
@@ -542,7 +570,14 @@ class AccordMetricsTests:
                 )
             return True, f"Captured VERB_SECOND_PASS_RESULT for both verbs: {sorted(verbs_seen)}"
         except Exception as e:
-            return False, str(e)
+            # NAME THE EXCEPTION. `str(e)` on a bare TimeoutError() is the empty
+            # string, so this test reported "❌ FAIL Verb Second Pass Trace:" with
+            # nothing after the colon — a failure with no content is barely
+            # better than no test. Type plus whatever verbs were captured before
+            # it died is enough to tell a stall from a wrong verb.
+            seen = sorted(locals().get("verbs_seen", set()) or [])
+            detail = f"{type(e).__name__}: {e}" if str(e) else type(e).__name__
+            return False, f"{detail} (verbs captured before the failure: {seen or 'none'})"
 
     async def _test_generic_trace_fields(self) -> tuple[bool, str]:
         """Validate generic traces have all fields required for CIRIS scoring.
@@ -1132,6 +1167,15 @@ class AccordMetricsTests:
                 async with session.get(url, timeout=aiohttp.ClientTimeout(total=10)) as response:
                     if response.status != 200:
                         error_text = await response.text()
+                        if _endpoint_retired(response.status, error_text):
+                            return False, (
+                                f"{SKIP_PREFIX} the Lens public-keys endpoint is retired upstream "
+                                f"({url} → {response.status}). The server names its successors: "
+                                "/v1/identity and /lens/api/v1/*, neither of which serves this "
+                                "check today. Nothing about the agent is being tested here until "
+                                "the replacement surface exists — failing red would only train "
+                                "readers to ignore red."
+                            )
                         return False, f"Lens server returned {response.status}: {error_text}"
 
                     data = await response.json()
@@ -1165,6 +1209,14 @@ class AccordMetricsTests:
                 keys_url = f"{LENS_SERVER_URL}/accord/public-keys"
                 async with session.get(keys_url, timeout=aiohttp.ClientTimeout(total=10)) as response:
                     if response.status != 200:
+                        body = await response.text()
+                        if _endpoint_retired(response.status, body):
+                            return False, (
+                                f"{SKIP_PREFIX} the Lens public-keys endpoint is retired upstream "
+                                f"({keys_url} → {response.status}); key-id consistency cannot be "
+                                "checked until the successor surface (/v1/identity, /lens/api/v1/*) "
+                                "serves it."
+                            )
                         return False, f"Cannot fetch keys: HTTP {response.status}"
                     keys_data = await response.json()
 

--- a/tools/qa_runner/modules/accord_metrics_tests.py
+++ b/tools/qa_runner/modules/accord_metrics_tests.py
@@ -416,7 +416,7 @@ class AccordMetricsTests:
                         "error": detail,
                     }
                 )
-                self.console.print(f" [red][FAIL] FAIL[/red] {name}: {e}")
+                self.console.print(f" [red][FAIL] FAIL[/red] {name}: {detail}")
 
         return self.results
 

--- a/tools/qa_runner/modules/accord_metrics_tests.py
+++ b/tools/qa_runner/modules/accord_metrics_tests.py
@@ -389,8 +389,12 @@ class AccordMetricsTests:
                 # as its own status.
                 if not success and message.startswith(SKIP_PREFIX):
                     reason = message[len(SKIP_PREFIX):].strip()
-                    self.results.append({"test": name, "status": "⏭️  SKIP", "error": None, "skipped": reason})
-                    self.console.print(f"  [yellow]⏭️  SKIP[/yellow] {name}: {reason}")
+                    # ASCII ONLY. A Windows cp1252 console raises
+                    # UnicodeEncodeError on an emoji and kills the process —
+                    # the repo has a guard test for exactly this, and my skip
+                    # marker tripped it. [SKIP] reads the same as [OK]/[FAIL].
+                    self.results.append({"test": name, "status": "[SKIP]", "error": None, "skipped": reason})
+                    self.console.print(f"  [yellow][SKIP][/yellow] {name}: {reason}")
                     continue
                 status = "✅ PASS" if success else "❌ FAIL"
                 self.results.append(

--- a/tools/qa_runner/runner.py
+++ b/tools/qa_runner/runner.py
@@ -1166,6 +1166,28 @@ class QARunner:
                     break
             time.sleep(8)
 
+        # THE PROBE LINE IS NOT THE ONLY WITNESS. When it never lands — the probe
+        # is best-effort and its line has moved before — `delivery_status()`
+        # still carries the same facts per peer (knows_peer / kex_present /
+        # deliverable), and it is the value the node itself acts on. Reading it
+        # here is what keeps a missing probe line from being reported as a dead
+        # transport: a live run with 300 anti-entropy rounds, 50 inbound
+        # envelopes and zero dropped frames was declared "NOT transport-rooted
+        # (edge.knows_peer=false)" purely because this verdict was absent.
+        if transport_rooted is None:
+            fallback = self._peer_state_from_delivery_status(_read_probe_log)
+            if fallback is not None:
+                transport_rooted = fallback.get("knows_peer")
+                if fallback.get("kex_present") is True:
+                    kex_state = "PRESENT"
+                elif fallback.get("kex_present") is False:
+                    kex_state = "None"
+                canonical_key = canonical_key or fallback.get("key_id")
+                self.console.print(
+                    "  [dim](probe line absent — verdict taken from delivery_status(), "
+                    "which is what the node itself acts on)[/dim]"
+                )
+
         self.console.print(f"  canonical peer      : {canonical_key or '<from probe>'}")
         rooted_str = "✅ YES" if transport_rooted else ("❌ NO" if transport_rooted is False else "❓ probe verdict not found")
         self.console.print(f"  transport-rooted    : {rooted_str}  (edge.knows_peer — authoritative)")
@@ -1222,12 +1244,26 @@ class QARunner:
             )
             self.console.print(f"[bold yellow]{verdict}[/bold yellow]")
             logger.warning("[FEDERATION-DELIVERY] %s", verdict)
-        else:
+        elif transport_rooted is False:
             verdict = (
                 "❌ Canonical NOT transport-rooted (edge.knows_peer=false) — neither rounds nor "
                 "trace envelopes can flow. Check the canonical boot-prime + bootstrap dial."
             )
             self.console.print(f"[bold red]{verdict}[/bold red]")
+            logger.warning("[FEDERATION-DELIVERY] %s", verdict)
+        else:
+            # UNKNOWN IS NOT FALSE. Saying "edge.knows_peer=false" when nothing
+            # ever reported knows_peer sends the reader to the boot-prime and
+            # the bootstrap dial — both of which were fine — and it contradicts
+            # the delivery_status line printed immediately below, which said
+            # deliverable=true. An absent verdict is its own outcome.
+            verdict = (
+                "❓ Federation delivery UNVERIFIED — no probe verdict and no peer entry in "
+                "delivery_status(), so rooting could not be established either way. This is not "
+                "evidence of a broken transport; check the node log for `canonical boot prime: "
+                "rooted` and for anti-entropy rounds before concluding anything."
+            )
+            self.console.print(f"[bold yellow]{verdict}[/bold yellow]")
             logger.warning("[FEDERATION-DELIVERY] %s", verdict)
 
         # Not fully green → surface delivery_status() (CIRISServer#294, >=0.5.125)
@@ -1235,6 +1271,30 @@ class QARunner:
         if not (transport_rooted and kex_state == "PRESENT"):
             self._diagnose_delivery_status(_read_probe_log)
         return rooted
+
+    def _peer_state_from_delivery_status(self, read_probe_log: Callable[[], str]) -> Optional[dict]:
+        """The canonical peer's entry from the last [DELIVERY-STATUS] line.
+
+        Same source `_diagnose_delivery_status` renders, read as data instead of
+        prose so the verdict above can use it when the probe line is missing.
+        Best-effort; returns None when there is nothing to read.
+        """
+        import json as _json
+
+        try:
+            lines = [ln for ln in read_probe_log().splitlines() if "[DELIVERY-STATUS]" in ln]
+            if not lines:
+                return None
+            m = re.search(r"\[DELIVERY-STATUS\]\s+phase=(\S+)\s+(\{.*\})", lines[-1])
+            if not m:
+                return None
+            st = _json.loads(m.group(2))
+            peers = st.get("peers") or []
+            targets = st.get("canonical_targets") or []
+            peer = next((p for p in peers if p.get("key_id") in targets), peers[0] if peers else None)
+            return dict(peer) if peer else None
+        except Exception:  # noqa: BLE001 — diagnostics must never break the run
+            return None
 
     def _diagnose_delivery_status(self, read_probe_log: Callable[[], str]) -> None:
         """Print the ciris_server.delivery_status() snapshot + the #926 decision

--- a/tools/qa_runner/runner.py
+++ b/tools/qa_runner/runner.py
@@ -241,12 +241,20 @@ class TracePlaneStanding(BaseModel):
     separating an unreadable corpus from one that holds traces none of which
     are recent. That is the value the node itself acts on, so it is the value
     a verdict should quote.
+
+    THESE FOUR FIELDS AND NO OTHERS. An earlier version modelled `carriers`,
+    which `trace_plane` does not return — the substring appears nowhere in the
+    0.5.188 extension, while `standing`, `band`, `last_admitted_at` and
+    `age_seconds` all do. Because the model ignores extras and defaults to
+    None, every real payload validated and the verdict printed `carriers=?`
+    forever: a diagnostic that could never produce a reading. A carrier count
+    needs a surface that actually exposes one.
     """
 
     standing: Optional[str] = None
     band: Optional[str] = None
     last_admitted_at: Optional[str] = None
-    carriers: Optional[int] = None
+    age_seconds: Optional[float] = None
 
     model_config = ConfigDict(extra="ignore")
 
@@ -1235,6 +1243,7 @@ class QARunner:
         # transport: a live run with 300 anti-entropy rounds, 50 inbound
         # envelopes and zero dropped frames was declared "NOT transport-rooted
         # (edge.knows_peer=false)" purely because this verdict was absent.
+        fallback: Optional[CanonicalPeerState] = None
         if transport_rooted is None:
             fallback = self._peer_state_from_delivery_status(_read_probe_log)
             if fallback is not None:
@@ -1245,12 +1254,19 @@ class QARunner:
                 # rooted+KEX as green there would print "trace envelopes can seal"
                 # AND skip _diagnose_delivery_status — whose decision tree is the
                 # one thing that would have named deliverable=false.
-                if fallback.kex_present is True and fallback.deliverable is not False:
+                # GREEN NEEDS AN AFFIRMATIVE DELIVERABLE. `is not False` let the
+                # unknown case through — and unknown is a state this very model
+                # exists to preserve, so a status snapshot that simply omitted
+                # the field printed "trace envelopes can seal" and skipped the
+                # diagnosis, on no evidence at all.
+                if fallback.kex_present is True and fallback.deliverable is True:
                     kex_state = "PRESENT"
                 elif fallback.kex_present is False:
                     kex_state = "None"
                 elif fallback.deliverable is False:
                     kex_state = "not-deliverable"
+                elif fallback.kex_present is True:
+                    kex_state = "kex-yes-deliverable-unknown"
                 canonical_key = canonical_key or fallback.key_id
                 self.console.print(
                     "  [dim](probe line absent — verdict taken from delivery_status(), "
@@ -1270,8 +1286,9 @@ class QARunner:
         if plane is not None:
             self.console.print(
                 f"  trace plane         : standing={plane.standing or '?'} band={plane.band or '?'} "
-                f"carriers={plane.carriers if plane.carriers is not None else '?'} "
-                f"last_admitted={plane.last_admitted_at or 'never'}  (node_state().trace_plane)"
+                f"last_admitted={plane.last_admitted_at or 'never'} "
+                f"age={f'{plane.age_seconds:.0f}s' if plane.age_seconds is not None else '?'}"
+                "  (node_state().trace_plane)"
             )
         else:
             self.console.print(
@@ -1343,11 +1360,27 @@ class QARunner:
             # the bootstrap dial — both of which were fine — and it contradicts
             # the delivery_status line printed immediately below, which said
             # deliverable=true. An absent verdict is its own outcome.
+            #
+            # AND THE TWO WAYS OF NOT KNOWING ARE DIFFERENT. "No peer entry"
+            # and "an entry that omits knows_peer" send a reader to different
+            # places, and the second one printed a canonical key two lines
+            # above — so claiming there was no entry contradicts the output
+            # immediately preceding it.
+            if fallback is None:
+                why = (
+                    "no probe verdict and no canonical peer entry in delivery_status() — the "
+                    "canonical may not be admitted yet, or no canonical target is named at all"
+                )
+            else:
+                why = (
+                    "the canonical peer entry exists but reports no knows_peer, so the snapshot "
+                    "is incomplete rather than absent — give it another round"
+                )
             verdict = (
-                "❓ Federation delivery UNVERIFIED — no probe verdict and no peer entry in "
-                "delivery_status(), so rooting could not be established either way. This is not "
-                "evidence of a broken transport; check the node log for `canonical boot prime: "
-                "rooted` and for anti-entropy rounds before concluding anything."
+                f"❓ Federation delivery UNVERIFIED — {why}. Rooting could not be established "
+                "either way. This is not evidence of a broken transport; check the node log for "
+                "`canonical boot prime: rooted` and for anti-entropy rounds before concluding "
+                "anything."
             )
             self.console.print(f"[bold yellow]{verdict}[/bold yellow]")
             logger.warning("[FEDERATION-DELIVERY] %s", verdict)
@@ -1405,16 +1438,16 @@ class QARunner:
             st = _json.loads(m.group(2))
             peers = st.get("peers") or []
             targets = st.get("canonical_targets") or []
-            if targets:
-                # NAMED TARGETS ARE THE ONLY ANSWER. Falling back to peers[0]
-                # when no target has appeared yet hands back SOME OTHER peer —
-                # and an unrelated federation peer that is rooted and KEX-ready
-                # would then be reported as the canonical's own preconditions,
-                # GREEN, under exactly the missing-canonical condition this
-                # diagnosis exists to surface.
-                peer = next((p for p in peers if p.get("key_id") in targets), None)
-            else:
-                peer = peers[0] if peers else None
+            # A NAMED TARGET IS THE ONLY THING THAT IDENTIFIES THE CANONICAL.
+            # Two ways this used to guess, and both could report an unrelated
+            # rooted, KEX-ready federation peer as the canonical's own
+            # preconditions — GREEN, under exactly the missing-canonical
+            # condition the diagnosis exists to surface: matching no target and
+            # falling back to peers[0], and having no targets named at all and
+            # taking peers[0] anyway. Neither is an answer about the canonical.
+            if not targets:
+                return None
+            peer = next((p for p in peers if p.get("key_id") in targets), None)
             return CanonicalPeerState.model_validate(peer) if peer else None
         except Exception:  # noqa: BLE001 — diagnostics must never break the run
             return None

--- a/tools/qa_runner/runner.py
+++ b/tools/qa_runner/runner.py
@@ -26,6 +26,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from pydantic import BaseModel, ConfigDict
+
 import requests
 from rich.console import Console
 from rich.panel import Panel
@@ -208,6 +210,37 @@ def _closes_identity(test: Any) -> bool:
         name in test.name.lower() and endpoint in test.endpoint
         for name, endpoint in _IDENTITY_CLOSING
     )
+
+
+def _is_non_failing(status: str) -> bool:
+    """Whether a per-test status should let the module pass.
+
+    A check that could not run is not a check that failed — but the aggregation
+    only knew PASS, so recording a retired upstream endpoint as SKIP still made
+    the module fail and still returned a nonzero QA result. The endpoint kept
+    breaking the run; it just stopped looking like it was the reason.
+    """
+    return "PASS" in status or "SKIP" in status
+
+
+class CanonicalPeerState(BaseModel):
+    """One peer entry from `ciris_server.delivery_status()`.
+
+    Typed rather than a raw dict because the verdict above turns these three
+    booleans into a claim about whether traces can flow, and a silently absent
+    or renamed field would read as False — which is the exact failure mode this
+    whole change is correcting.
+
+    Every field is Optional: the node omits what it does not yet know, and
+    "unknown" must stay distinguishable from "false" all the way through.
+    """
+
+    key_id: Optional[str] = None
+    knows_peer: Optional[bool] = None
+    kex_present: Optional[bool] = None
+    deliverable: Optional[bool] = None
+
+    model_config = ConfigDict(extra="ignore")
 
 
 class QARunner:
@@ -1177,12 +1210,20 @@ class QARunner:
         if transport_rooted is None:
             fallback = self._peer_state_from_delivery_status(_read_probe_log)
             if fallback is not None:
-                transport_rooted = fallback.get("knows_peer")
-                if fallback.get("kex_present") is True:
+                transport_rooted = fallback.knows_peer
+                # DELIVERABLE IS THE NODE'S OWN VERDICT, and it is not implied by
+                # rooting plus KEX: delivery may not have started, or the edge may
+                # be down, and the peer still reports both of those true. Treating
+                # rooted+KEX as green there would print "trace envelopes can seal"
+                # AND skip _diagnose_delivery_status — whose decision tree is the
+                # one thing that would have named deliverable=false.
+                if fallback.kex_present is True and fallback.deliverable is not False:
                     kex_state = "PRESENT"
-                elif fallback.get("kex_present") is False:
+                elif fallback.kex_present is False:
                     kex_state = "None"
-                canonical_key = canonical_key or fallback.get("key_id")
+                elif fallback.deliverable is False:
+                    kex_state = "not-deliverable"
+                canonical_key = canonical_key or fallback.key_id
                 self.console.print(
                     "  [dim](probe line absent — verdict taken from delivery_status(), "
                     "which is what the node itself acts on)[/dim]"
@@ -1272,7 +1313,9 @@ class QARunner:
             self._diagnose_delivery_status(_read_probe_log)
         return rooted
 
-    def _peer_state_from_delivery_status(self, read_probe_log: Callable[[], str]) -> Optional[dict]:
+    def _peer_state_from_delivery_status(
+        self, read_probe_log: Callable[[], str]
+    ) -> Optional["CanonicalPeerState"]:
         """The canonical peer's entry from the last [DELIVERY-STATUS] line.
 
         Same source `_diagnose_delivery_status` renders, read as data instead of
@@ -1291,8 +1334,17 @@ class QARunner:
             st = _json.loads(m.group(2))
             peers = st.get("peers") or []
             targets = st.get("canonical_targets") or []
-            peer = next((p for p in peers if p.get("key_id") in targets), peers[0] if peers else None)
-            return dict(peer) if peer else None
+            if targets:
+                # NAMED TARGETS ARE THE ONLY ANSWER. Falling back to peers[0]
+                # when no target has appeared yet hands back SOME OTHER peer —
+                # and an unrelated federation peer that is rooted and KEX-ready
+                # would then be reported as the canonical's own preconditions,
+                # GREEN, under exactly the missing-canonical condition this
+                # diagnosis exists to surface.
+                peer = next((p for p in peers if p.get("key_id") in targets), None)
+            else:
+                peer = peers[0] if peers else None
+            return CanonicalPeerState.model_validate(peer) if peer else None
         except Exception:  # noqa: BLE001 — diagnostics must never break the run
             return None
 
@@ -1822,7 +1874,7 @@ class QARunner:
                 # Store results in runner's results dict
                 for result in results:
                     test_name = result["test"]
-                    passed = "PASS" in result["status"]
+                    passed = _is_non_failing(result["status"])
 
                     self.results[f"{module.value}::{test_name}"] = {
                         "success": passed,
@@ -1837,7 +1889,7 @@ class QARunner:
                 # status counted as Passed in the Total/Passed/Failed summary
                 # yet made this return False, failing the whole leg with
                 # Failed=0 (the exit-1-on-green bug).
-                return all("PASS" in r["status"] for r in results)
+                return all(_is_non_failing(r["status"]) for r in results)
 
         # Run all SDK modules sequentially (they use async internally)
         for module in modules:

--- a/tools/qa_runner/runner.py
+++ b/tools/qa_runner/runner.py
@@ -1266,7 +1266,7 @@ class QARunner:
         # can infer about it. Carriers ride the Attestation plane, so no wire
         # histogram and no trace_events count can answer "do I hold offerable
         # carriers" — persist's storage_summary can, and node_state carries it.
-        plane = self._trace_plane_from_node_state()
+        plane = self._trace_plane_from_node_state(_read_probe_log)
         if plane is not None:
             self.console.print(
                 f"  trace plane         : standing={plane.standing or '?'} band={plane.band or '?'} "
@@ -1275,8 +1275,8 @@ class QARunner:
             )
         else:
             self.console.print(
-                "  trace plane         : (node_state() unavailable — server already stopped, or "
-                "ciris_server not importable here)"
+                "  trace plane         : (no [TRACE-PLANE] line — agent older than this probe, "
+                "or the delivery window never opened)"
             )
         logger.info(
             "[FEDERATION-DELIVERY] canonical=%s transport_rooted=%s kex=%s",
@@ -1358,24 +1358,30 @@ class QARunner:
             self._diagnose_delivery_status(_read_probe_log)
         return rooted
 
-    def _trace_plane_from_node_state(self) -> Optional[TracePlaneStanding]:
-        """`node_state().trace_plane`, or None when the node cannot be asked.
+    def _trace_plane_from_node_state(
+        self, read_probe_log: Callable[[], str]
+    ) -> Optional[TracePlaneStanding]:
+        """The node's `[TRACE-PLANE]` line, or None when it never logged one.
 
-        In-process only, read-only, and safe to poll — but it needs a live
-        runtime, so a harness that has already stopped the server gets None
-        and says so rather than guessing.
+        READ, DO NOT CALL. `node_state()` is in-process to the server, and this
+        runner boots that server as a SUBPROCESS — so calling it here returns
+        nothing no matter how healthy the node is, which is exactly the
+        "unavailable" this printed on its first outing. The node logs the value
+        instead (edge_runtime `_log_trace_plane`), the same in-process-accessor
+        → logged-surface pattern `[DELIVERY-STATUS]` already uses.
         """
+        import json as _json
+
         try:
-            import json as _json
-
-            import ciris_server  # type: ignore[import-not-found, import-untyped, unused-ignore]
-
-            raw = ciris_server.node_state()
-            state = _json.loads(raw) if isinstance(raw, str) else raw
-            plane = (state or {}).get("trace_plane")
-            return TracePlaneStanding.model_validate(plane) if plane else None
+            lines = [ln for ln in read_probe_log().splitlines() if "[TRACE-PLANE]" in ln]
+            if not lines:
+                return None
+            m = re.search(r"\[TRACE-PLANE\]\s+phase=\S+\s+(\{.*\})", lines[-1])
+            if not m:
+                return None
+            return TracePlaneStanding.model_validate(_json.loads(m.group(1)))
         except Exception as exc:  # noqa: BLE001 — diagnostics never break a run
-            logger.debug("[FEDERATION-DELIVERY] node_state() unavailable: %s", exc)
+            logger.debug("[FEDERATION-DELIVERY] trace-plane line unreadable: %s", exc)
             return None
 
     def _peer_state_from_delivery_status(

--- a/tools/qa_runner/runner.py
+++ b/tools/qa_runner/runner.py
@@ -223,6 +223,34 @@ def _is_non_failing(status: str) -> bool:
     return "PASS" in status or "SKIP" in status
 
 
+class TracePlaneStanding(BaseModel):
+    """The node's own answer to "is the trace plane alive", from `node_state()`.
+
+    ASK THE SUBSTRATE. The first version of this harness tried to answer the
+    question itself and got it wrong three separate ways: counting `kind=Trace`
+    on the wire (no such envelope kind exists — carriers ride the Attestation
+    plane), a loose `LIKE '%trace:%'` over the attestations (which read 4
+    against a true 3, and at a 1:1 carrier ratio that inflation is enough to
+    report carriers on a node holding none), and `trace_events.cohort_scope`
+    (a read-time projection in a different table, downstream of the
+    attestation's — 71 rows at `federation` there is entirely consistent with
+    the carriers sitting at `self`).
+
+    `ciris_server.node_state()` carries `trace_plane` verbatim from persist's
+    `Engine.storage_summary()`: banded live / quiet / dark, with `standing`
+    separating an unreadable corpus from one that holds traces none of which
+    are recent. That is the value the node itself acts on, so it is the value
+    a verdict should quote.
+    """
+
+    standing: Optional[str] = None
+    band: Optional[str] = None
+    last_admitted_at: Optional[str] = None
+    carriers: Optional[int] = None
+
+    model_config = ConfigDict(extra="ignore")
+
+
 class CanonicalPeerState(BaseModel):
     """One peer entry from `ciris_server.delivery_status()`.
 
@@ -1233,6 +1261,23 @@ class QARunner:
         rooted_str = "✅ YES" if transport_rooted else ("❌ NO" if transport_rooted is False else "❓ probe verdict not found")
         self.console.print(f"  transport-rooted    : {rooted_str}  (edge.knows_peer — authoritative)")
         self.console.print(f"  peer KEX resolvable : {kex_state}  (gates the sealed-envelope TRACE path)")
+
+        # WHAT THE NODE SAYS ABOUT ITS OWN PLANE, rather than what this harness
+        # can infer about it. Carriers ride the Attestation plane, so no wire
+        # histogram and no trace_events count can answer "do I hold offerable
+        # carriers" — persist's storage_summary can, and node_state carries it.
+        plane = self._trace_plane_from_node_state()
+        if plane is not None:
+            self.console.print(
+                f"  trace plane         : standing={plane.standing or '?'} band={plane.band or '?'} "
+                f"carriers={plane.carriers if plane.carriers is not None else '?'} "
+                f"last_admitted={plane.last_admitted_at or 'never'}  (node_state().trace_plane)"
+            )
+        else:
+            self.console.print(
+                "  trace plane         : (node_state() unavailable — server already stopped, or "
+                "ciris_server not importable here)"
+            )
         logger.info(
             "[FEDERATION-DELIVERY] canonical=%s transport_rooted=%s kex=%s",
             canonical_key,
@@ -1312,6 +1357,26 @@ class QARunner:
         if not (transport_rooted and kex_state == "PRESENT"):
             self._diagnose_delivery_status(_read_probe_log)
         return rooted
+
+    def _trace_plane_from_node_state(self) -> Optional[TracePlaneStanding]:
+        """`node_state().trace_plane`, or None when the node cannot be asked.
+
+        In-process only, read-only, and safe to poll — but it needs a live
+        runtime, so a harness that has already stopped the server gets None
+        and says so rather than guessing.
+        """
+        try:
+            import json as _json
+
+            import ciris_server  # type: ignore[import-not-found, import-untyped, unused-ignore]
+
+            raw = ciris_server.node_state()
+            state = _json.loads(raw) if isinstance(raw, str) else raw
+            plane = (state or {}).get("trace_plane")
+            return TracePlaneStanding.model_validate(plane) if plane else None
+        except Exception as exc:  # noqa: BLE001 — diagnostics never break a run
+            logger.debug("[FEDERATION-DELIVERY] node_state() unavailable: %s", exc)
+            return None
 
     def _peer_state_from_delivery_status(
         self, read_probe_log: Callable[[], str]


### PR DESCRIPTION
Found by running the trace-ship harness live against the canonical peer on 2.9.37 / ciris-server 0.5.188. The product finding is filed as [CIRISServer#487](https://github.com/CIRISAI/CIRISServer/issues/487); this PR is the harness half.

## The verdict contradicted itself

```
transport-rooted : ❓ probe verdict not found  (edge.knows_peer — authoritative)
❌ Canonical NOT transport-rooted (edge.knows_peer=false) — neither rounds nor
   trace envelopes can flow. Check the canonical boot-prime + bootstrap dial.
delivery_status  : phase=kex-present-await-ship started=True edge_up=True
→ deliverable=true but trace not landing
```

The node log for that same run:

| measure | value |
|---|---|
| canonical | rooted from baked KeyRecord |
| anti-entropy rounds | 300 |
| timeouts | 30 |
| inbound envelopes | 50 |
| **FramesDropped** | **0** |

Five other envelope kinds were replicating happily. The transport was fine — the `[DELIVERY-PROBE]` line simply never landed, and an **absent** verdict was rendered as `false`. That points the reader at the boot-prime and the bootstrap dial, both healthy, and away from the ship stage, which is the part that is genuinely stuck.

- Unknown is now its own outcome; the hard `knows_peer=false` verdict is reachable only when the probe actually said `False`.
- When the probe line is missing, the verdict is taken from `delivery_status()` — the same per-peer `knows_peer` / `kex_present` / `deliverable` the node itself acts on, read as data rather than prose.

## A check that cannot run is not a check that failed

The Lens public-keys endpoint is retired upstream and says so in its own 404 body — `lens retired; see /v1/identity and /lens/api/v1/*`. Two checks failed red for it. Red that doesn't mean anything is how a suite teaches people to ignore red, and this run had a third red that *did* matter.

Retirement is now detected from the declared body and reported as **SKIP**, a third outcome distinct from pass and fail. An ordinary 404, or a 500 that merely contains the word "retired", still fails.

## A failure that says nothing

```
❌ FAIL Verb Second Pass Trace:
```

Nothing after the colon: the only failure path was `return False, str(e)`, and `str(TimeoutError())` is the empty string. Failures now name the exception type and report how far the test got; the generic loop does the same and logs the traceback.

## Tests

Replay the real shapes — the `[DELIVERY-STATUS]` line verbatim from the run that misreported, peer selection by canonical target, unreadable logs and a reader that raises, the retirement predicate's true and false cases, plus source-level guards that the hard verdict stays behind `is False` and that both Lens checks route retirement to SKIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVMJwukQjscjwLQz9NZktK