### PR TITLE
fix(attestation): a slow verifier bricked the install instead of degrading

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -252,6 +252,17 @@ jobs:
           # repo. SIGTERM at 45m inside a 60m job leaves room for that; sizing
           # the inner bounds closer to 60 would recreate the exact failure above,
           # where the outer bound wins and the inner ones never report.
+          # COVERAGE_FILE: emit the raw coverage DATA file, not a per-shard XML
+          # report. The old flow wrote 8 full-tree XMLs and "merged" them by
+          # appending <package> elements, which never OR'd the per-line hits, so
+          # Sonar resolved each file to ONE arbitrary shard's view and scored lines
+          # as uncovered that other shards had covered (CIRISAgent#1116).
+          # `coverage combine` unions properly, and is the only thing that can
+          # merge BRANCH data at all.
+          #
+          # No leading dot in the name: upload-artifact skips hidden files unless
+          # include-hidden-files is set, which would silently drop the data.
+          COVERAGE_FILE=coverage-data-shard-${{ matrix.shard }} \
           CIRIS_TEST_CONTROLLER_DEADLINE_SECONDS=2580 \
           timeout --signal=SIGTERM --kill-after=30 2700 \
             pytest tests/ -n 4 --dist=loadgroup \
@@ -260,13 +271,13 @@ jobs:
             --store-durations --durations-path=test_durations_shard_${{ matrix.shard }} \
             --reruns=2 --reruns-delay=1 --max-worker-restart=4 \
             --session-timeout=2520 \
-            --cov=./ --cov-report=xml:coverage-shard-${{ matrix.shard }}.xml
+            --cov=./ --cov-report=
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v6
         with:
-          name: coverage-shard-${{ matrix.shard }}
-          path: coverage-shard-${{ matrix.shard }}.xml
+          name: coverage-data-shard-${{ matrix.shard }}
+          path: coverage-data-shard-${{ matrix.shard }}
           retention-days: 1
 
       - name: Upload durations artifact
@@ -664,37 +675,43 @@ jobs:
       - name: Download all coverage artifacts
         uses: actions/download-artifact@v7
         with:
-          pattern: coverage-shard-*
+          pattern: coverage-data-shard-*
           path: coverage/
           merge-multiple: true
 
       - name: Combine coverage reports
         run: |
           pip install coverage
-          # Combine XML reports into single coverage.xml
-          python -c "
-          import xml.etree.ElementTree as ET
-          import glob
-
-          files = glob.glob('coverage/coverage-shard-*.xml')
-          if not files:
-              print('No coverage files found')
-              exit(0)
-
-          # Use first file as base
-          base = ET.parse(files[0])
-          base_root = base.getroot()
-
-          # Merge others
-          for f in files[1:]:
-              tree = ET.parse(f)
-              for pkg in tree.findall('.//package'):
-                  base_root.find('.//packages').append(pkg)
-
-          base.write('coverage.xml')
-          print(f'Combined {len(files)} coverage reports')
-          "
-          ls -la coverage*.xml || true
+          # UNION the shards, do not concatenate them.
+          #
+          # This used to parse the 8 per-shard XMLs and append their <package>
+          # elements into one tree. That produced a coverage.xml with 8 entries
+          # per file — one per shard, each holding only that shard's hits — and
+          # nothing ever OR'd the per-line counts. Sonar resolved the duplicate
+          # keys to a single arbitrary shard, so lines covered by tests in a
+          # different shard were reported UNCOVERED, and new_coverage came out
+          # far below the truth (CIRISAgent#1116: edge_runtime.py lines 314-316
+          # and 330 were covered by shards 1-6 and scored as uncovered).
+          #
+          # `coverage combine` is what actually merges: it unions line hits and
+          # arc/branch data, which the XML append could not do at all.
+          shopt -s nullglob
+          files=(coverage/coverage-data-shard-*)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No coverage data files found — every shard's data is missing."
+            exit 1
+          fi
+          echo "Combining ${#files[@]} shard data file(s):"
+          printf '  %s\n' "${files[@]}"
+          # A shard whose data is missing must be LOUD: a silently absent shard
+          # is exactly the failure mode that produced the wrong number before.
+          if [ ${#files[@]} -ne 8 ]; then
+            echo "::warning::Expected 8 shard data files, found ${#files[@]} — coverage is understated."
+          fi
+          coverage combine "${files[@]}"
+          coverage xml            # [xml] output = coverage.xml in .coveragerc
+          coverage report --format=total | sed 's/^/Combined line coverage: /'
+          ls -la coverage.xml
 
       - name: Download all duration artifacts
         uses: actions/download-artifact@v7

--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -6,11 +6,11 @@ from typing import List
 from ciris_engine.schemas.runtime.canonical_peer import CanonicalBootstrapPeer
 
 # Version information
-CIRIS_VERSION = "2.9.38-stable"
+CIRIS_VERSION = "2.9.39-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
 CIRIS_VERSION_MINOR = 9
-CIRIS_VERSION_PATCH = 38
+CIRIS_VERSION_PATCH = 39
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/ciris_engine/logic/runtime/ciris_runtime.py
+++ b/ciris_engine/logic/runtime/ciris_runtime.py
@@ -87,6 +87,8 @@ from .shutdown_continuity import (
     update_identity_with_shutdown_reference,
 )
 
+from ciris_engine.schemas.services.attestation import AttestationGateOutcome
+
 logger = logging.getLogger(__name__)
 
 # Keep single domain for backwards compatibility (tests)
@@ -1626,7 +1628,24 @@ class CIRISRuntime(ServicePropertyMixin):
 
         logger.info("Awaiting startup attestation (15s budget) before processor start...")
         try:
-            await auth_service.await_attestation_ready()
+            outcome = await auth_service.await_attestation_ready()
+            if isinstance(outcome, AttestationGateOutcome) and outcome.is_breach():
+                # The gate no longer raises on a latency breach, so the receipts
+                # have to be driven off the returned outcome instead. Without
+                # this the wedged-verifier case — the one this whole path exists
+                # for — would log "complete" and dump nothing.
+                self._log_attestation_failure_receipts(
+                    auth_service,
+                    RuntimeError(f"Startup attestation SLO breach: {outcome.value}"),
+                )
+                logger.warning(
+                    "Startup attestation breached its latency budget (%s) — starting the "
+                    "processor anyway (DEGRADED). batch_context still refuses to build a "
+                    "thought without an attestation result, so nothing runs unattested. "
+                    "Receipts above are a fileable ciris_verify issue.",
+                    outcome.value,
+                )
+                return
             logger.info("Startup attestation complete — processor cleared to start.")
         except Exception as e:
             # Receipts first: this stays a fileable ciris_verify issue.

--- a/ciris_engine/logic/runtime/ciris_runtime.py
+++ b/ciris_engine/logic/runtime/ciris_runtime.py
@@ -1582,10 +1582,11 @@ class CIRISRuntime(ServicePropertyMixin):
         # processor only starts once the attestation cache is populated and
         # every subsequent thought sees a no-op await.
         #
-        # Auth service enforces a 15s end-to-end budget; if blown, the gate
-        # raises (with a verifier-debugging receipts dump — see _await_
-        # attestation_ready) and startup fails loudly. Silently absorbing
-        # 60-120s would mask a verifier regression.
+        # Auth service enforces an end-to-end latency budget. If blown, the
+        # gate dumps verifier-debugging receipts and starts the processor
+        # DEGRADED rather than aborting — see _await_attestation_ready. The
+        # breach is never silent (that would mask a verifier regression), but
+        # it is also never fatal: a slow disk must not brick the install.
         await self._await_attestation_ready()
 
         effective_num_rounds = DEFAULT_NUM_ROUNDS
@@ -1596,12 +1597,17 @@ class CIRISRuntime(ServicePropertyMixin):
         await self.agent_processor.start_processing(effective_num_rounds)
 
     async def _await_attestation_ready(self) -> None:
-        """Block on the AuthenticationService's 15s attestation budget.
+        """Block on the AuthenticationService's attestation budget.
+
+        Non-fatal by design: a budget breach is a latency regression, not a
+        correctness failure, so it degrades to a warning and lets the
+        processor start. Enforcement lives in batch_context, which refuses
+        to build a thought without an attestation result.
 
         Looks up the service by capability (await_attestation_ready) rather
         than registry type, mirroring batch_context's lookup so the two gate
-        sites stay aligned. The 15s budget is enforced by the auth service
-        itself; budget breach raises here and aborts processor start.
+        sites stay aligned. The budget is enforced by the auth service
+        itself; a breach is reported here and startup continues degraded.
 
         On budget breach we dump receipts (per-stage timings, cache state,
         baseline_attestation, the active verifier mode) at ERROR level so
@@ -1623,8 +1629,27 @@ class CIRISRuntime(ServicePropertyMixin):
             await auth_service.await_attestation_ready()
             logger.info("Startup attestation complete — processor cleared to start.")
         except Exception as e:
+            # Receipts first: this stays a fileable ciris_verify issue.
             self._log_attestation_failure_receipts(auth_service, e)
-            raise
+            # Then DEGRADE rather than abort. This gate is a latency pre-warm,
+            # not the enforcement point — per-thought batch_context blocks on
+            # the same await_attestation_ready() and refuses to build a thought
+            # without an attestation result, so starting the processor here
+            # cannot produce an unattested thought.
+            #
+            # Aborting instead cost a Windows user the whole app: 2.9.37 on
+            # py3.14 spent >18s inside one ciris_verify_tree() call, blew the
+            # 20s budget, and the runtime shut down 22s after boot — no UI, no
+            # setup wizard, no way in. A slow disk should degrade first-thought
+            # latency, not brick the install.
+            logger.warning(
+                "Startup attestation did not complete within budget — starting the "
+                "processor anyway (DEGRADED). First-thought latency will absorb the "
+                "remaining attestation time, and batch_context still refuses to build "
+                "a thought without an attestation result, so nothing runs unattested. "
+                "Receipts above are a fileable ciris_verify issue: %s",
+                e,
+            )
 
     def _log_attestation_failure_receipts(self, auth_service: Any, exc: BaseException) -> None:
         """Dump everything an upstream ciris_verify maintainer would need to

--- a/ciris_engine/logic/services/infrastructure/authentication/service.py
+++ b/ciris_engine/logic/services/infrastructure/authentication/service.py
@@ -110,6 +110,38 @@ def _startup_attestation_budget() -> float:
 STARTUP_ATTESTATION_BUDGET_SECONDS = _startup_attestation_budget()
 
 
+# THE GATE MUST NOT RACE THE DEGRADE IT IS WAITING FOR.
+#
+# verifier_runner already keeps the promise that "an attestation is always
+# produced within the budget": attestation_deadline_seconds() bounds its own
+# run and hands back a degraded `level=0, binary=FAIL` result instead of
+# hanging. The gate below waits for that result.
+#
+# Both were bounded by the SAME budget, measured from (within milliseconds of)
+# the same instant — so the gate's wait expired just before the runner could
+# assemble and cache its degraded result, and the gate lost the race every
+# time. Field report (2.9.37, Windows 11 / py3.14): one ciris_verify_tree()
+# call, `elapsed=20.0s` dead on the budget, `attestation_task_done: False`,
+# `stage_timings_seconds: {}` — the runner was mid-degrade — and the runtime
+# aborted 22s after boot with no UI and no way into the setup wizard.
+#
+# The grace is what lets the runner's bounded degrade actually land. It is not
+# "more budget for a slow verifier": past deadline+grace the runner's own
+# timeout has failed, which is a different bug (see the ceiling branch below).
+ATTESTATION_GATE_GRACE_SECONDS = 5.0
+
+
+def _attestation_gate_deadline() -> float:
+    """How long the processor gate waits: the runner's deadline, plus grace.
+
+    Read at call time, like every other budget knob here — a value frozen at
+    import silently discards the override mobile_main sets during startup.
+    """
+    from .attestation.verifier_runner import attestation_deadline_seconds
+
+    return attestation_deadline_seconds() + ATTESTATION_GATE_GRACE_SECONDS
+
+
 class AuthenticationService(BaseInfrastructureService, AuthenticationServiceProtocol):
     """Infrastructure service for WA authentication and identity management."""
 
@@ -186,6 +218,7 @@ class AuthenticationService(BaseInfrastructureService, AuthenticationServiceProt
         # bools/strs/ints for stage outcomes, plus exception receipts on
         # the failure branch.
         self._attestation_stage_timings: Dict[str, Any] = {}
+        self._attestation_slo_breach_logged: bool = False
         self._baseline_attestation: Optional[AttestationResult] = (
             None  # First successful result for degradation detection
         )
@@ -2499,6 +2532,24 @@ class AuthenticationService(BaseInfrastructureService, AuthenticationServiceProt
         result = build_attestation_result(verify_result, attestation_mode)
         return result
 
+    def _log_attestation_slo_breach(self, message: str) -> None:
+        """Report a startup-attestation latency-SLO breach without killing the run.
+
+        One definition so the two breach sites (completed-but-slow, and
+        still-running-past-budget) read identically in the log and stay in
+        step. Logged at WARNING, not ERROR: the run continues, and the
+        incident-capture handler already promotes a repeated warning. The
+        fileable receipts dump still happens at the processor gate.
+        """
+        # Once at WARNING, then DEBUG. Every per-thought batch_context call
+        # lands here too once the deadline has passed, and a warning per
+        # thought buries the one that matters.
+        if getattr(self, "_attestation_slo_breach_logged", False):
+            logger.debug("[attestation] SLO BREACH (repeat): %s", message)
+            return
+        self._attestation_slo_breach_logged = True
+        logger.warning("[attestation] SLO BREACH: %s", message)
+
     async def await_attestation_ready(
         self,
         budget_seconds: Optional[float] = None,
@@ -2524,8 +2575,9 @@ class AuthenticationService(BaseInfrastructureService, AuthenticationServiceProt
         Behavior:
           - If start() never ran: RuntimeError (no task to await).
           - If task is still running and budget remains: await up to
-            the remaining budget. On timeout: raise RuntimeError with
-            the "attestation exceeded budget — this is a bug" message,
+            the remaining budget. On timeout: report an SLO breach and
+            keep waiting to the hard ceiling (the breach is a latency
+            regression, not a correctness failure),
             because per the contract any run that takes >15s should be
             investigated as a verifier regression, not waited out.
           - If task already finished: returns immediately.
@@ -2561,13 +2613,18 @@ class AuthenticationService(BaseInfrastructureService, AuthenticationServiceProt
         if self._attestation_task.done():
             total = getattr(self, "_attestation_stage_timings", {}).get("run_attestation_total_seconds")
             if isinstance(total, (int, float)) and total > budget_seconds:
-                raise RuntimeError(
+                # SLO breach on a SUCCESSFUL attestation. The result is valid —
+                # a slow filesystem does not make the tree hash wrong — so this
+                # is reported, not raised. Raising here used to poison every
+                # later caller for the life of the process.
+                self._log_attestation_slo_breach(
                     f"Startup attestation completed but exceeded the "
                     f"{budget_seconds:.0f}s budget (total={total:.1f}s). "
-                    f"This is a bug — the verifier should complete within "
-                    f"the contract window on a clean run. Investigate the "
-                    f"verifier (slow filesystem walk? blocking I/O? network "
-                    f"probe?) rather than raising the budget."
+                    f"The attestation is VALID and startup continues — this is "
+                    f"a latency regression, not a correctness failure. "
+                    f"Investigate the verifier (slow filesystem walk? blocking "
+                    f"I/O? network probe? CIRISVerify#212 registry fetch?) "
+                    f"rather than raising the budget."
                 )
             # Awaiting a completed task is a no-op except that exceptions
             # raised inside the task are re-raised here.
@@ -2577,11 +2634,16 @@ class AuthenticationService(BaseInfrastructureService, AuthenticationServiceProt
         # Compute remaining budget from task-creation time. If for any
         # reason the timestamp wasn't recorded (shouldn't happen — set
         # alongside task creation), fall back to the full budget.
+        # Wait against the GATE deadline, not the raw budget: the runner
+        # degrades at attestation_deadline_seconds(), and the gate has to
+        # outlast that by the grace or it times out mid-degrade and loses the
+        # race it is supposed to be observing.
+        gate_deadline = _attestation_gate_deadline()
         if started_at is not None:
             elapsed = asyncio.get_event_loop().time() - started_at
-            remaining = max(0.0, budget_seconds - elapsed)
+            remaining = max(0.0, gate_deadline - elapsed)
         else:
-            remaining = budget_seconds
+            remaining = gate_deadline
 
         try:
             await asyncio.wait_for(
@@ -2589,19 +2651,29 @@ class AuthenticationService(BaseInfrastructureService, AuthenticationServiceProt
                 timeout=remaining,
             )
         except asyncio.TimeoutError as exc:
-            # Don't cancel the task — let it keep running so refresh/audit
-            # paths still benefit from an eventual result. But surface the
-            # contract violation immediately so the caller (processor gate)
-            # aborts startup rather than absorbing the latency silently.
+            # Past deadline+grace the runner's OWN bounded degrade did not
+            # land, so this is not "a slow verifier" — verifier_runner's
+            # timeout has itself failed. Report it as a fileable bug.
+            #
+            # Never cancel the task: refresh/audit paths still want the result.
+            #
+            # Reported, not raised. Raising here was permanent for the process:
+            # `remaining` is measured from task-creation time, so once elapsed
+            # passed the deadline every later caller found max(0.0, ...) == 0.0
+            # and timed out instantly. The per-thought batch_context gate calls
+            # this same method, so one slow boot meant the agent could never
+            # think again — even after the attestation landed a second later.
             elapsed_total = asyncio.get_event_loop().time() - started_at if started_at is not None else None
             elapsed_str = f"{elapsed_total:.1f}s" if elapsed_total is not None else "unknown"
-            raise RuntimeError(
-                f"Startup attestation exceeded the {budget_seconds:.0f}s budget "
-                f"(elapsed={elapsed_str}). This is a bug — the verifier should "
-                f"complete within the contract window on a clean run. Investigate "
-                f"the verifier (slow filesystem walk? blocking I/O? network probe?) "
-                f"rather than raising the budget."
-            ) from exc
+            self._log_attestation_slo_breach(
+                f"Startup attestation exceeded the {gate_deadline:.0f}s gate deadline "
+                f"(budget {budget_seconds:.0f}s + {ATTESTATION_GATE_GRACE_SECONDS:.0f}s grace, "
+                f"elapsed={elapsed_str}) and is STILL RUNNING. verifier_runner's own "
+                f"bounded degrade should have produced a result by now — investigate "
+                f"the verifier (slow filesystem walk? blocking I/O? network probe? "
+                f"CIRISVerify#212 registry fetch?) rather than raising the budget. "
+                f"Startup continues; callers get the result when it lands. ({exc!r})"
+            )
 
     def get_cached_attestation(self, allow_stale: bool = False) -> Optional[AttestationResult]:
         """Get the cached attestation result if available.

--- a/ciris_engine/logic/services/infrastructure/authentication/service.py
+++ b/ciris_engine/logic/services/infrastructure/authentication/service.py
@@ -36,7 +36,11 @@ from ciris_engine.logic.utils.path_resolution import get_secrets_home
 from ciris_engine.logic.utils.shutdown_manager import request_global_shutdown
 from ciris_engine.protocols.services.infrastructure.authentication import AuthenticationServiceProtocol
 from ciris_engine.schemas.runtime.enums import ServiceType
-from ciris_engine.schemas.services.attestation import AttestationCacheStatus, AttestationResult
+from ciris_engine.schemas.services.attestation import (
+    AttestationCacheStatus,
+    AttestationGateOutcome,
+    AttestationResult,
+)
 from ciris_engine.schemas.services.authority.wise_authority import AuthenticationResult, TokenVerification, WAUpdate
 from ciris_engine.schemas.services.authority_core import (
     AuthorizationContext,
@@ -131,15 +135,26 @@ STARTUP_ATTESTATION_BUDGET_SECONDS = _startup_attestation_budget()
 ATTESTATION_GATE_GRACE_SECONDS = 5.0
 
 
-def _attestation_gate_deadline() -> float:
-    """How long the processor gate waits: the runner's deadline, plus grace.
+def _attestation_gate_deadline(budget_seconds: float) -> float:
+    """How long the gate waits, given the CALLER's budget.
 
-    Read at call time, like every other budget knob here — a value frozen at
+    The grace exists for one reason: to outlast verifier_runner's own bounded
+    degrade so its result can land. It therefore applies only when the caller
+    is actually long enough to be racing that degrade.
+
+    A caller asking for LESS than the runner's deadline (refresh and audit
+    paths pass budgets as short as 0.05s) is deliberately giving up early and
+    is not racing anything — honour that budget exactly rather than silently
+    stretching it to the global deadline.
+
+    Read at call time, like every other budget knob here: a value frozen at
     import silently discards the override mobile_main sets during startup.
     """
     from .attestation.verifier_runner import attestation_deadline_seconds
 
-    return attestation_deadline_seconds() + ATTESTATION_GATE_GRACE_SECONDS
+    if budget_seconds < attestation_deadline_seconds():
+        return budget_seconds
+    return budget_seconds + ATTESTATION_GATE_GRACE_SECONDS
 
 
 class AuthenticationService(BaseInfrastructureService, AuthenticationServiceProtocol):
@@ -2553,7 +2568,7 @@ class AuthenticationService(BaseInfrastructureService, AuthenticationServiceProt
     async def await_attestation_ready(
         self,
         budget_seconds: Optional[float] = None,
-    ) -> None:
+    ) -> AttestationGateOutcome:
         """Block until the startup attestation task has completed.
 
         ciris_verify is a hard runtime dependency — there is no path that
@@ -2626,10 +2641,12 @@ class AuthenticationService(BaseInfrastructureService, AuthenticationServiceProt
                     f"I/O? network probe? CIRISVerify#212 registry fetch?) "
                     f"rather than raising the budget."
                 )
-            # Awaiting a completed task is a no-op except that exceptions
-            # raised inside the task are re-raised here.
+                # Awaiting a completed task is a no-op except that exceptions
+                # raised inside the task are re-raised here.
+                await self._attestation_task
+                return AttestationGateOutcome.SLO_BREACH_COMPLETED
             await self._attestation_task
-            return
+            return AttestationGateOutcome.READY
 
         # Compute remaining budget from task-creation time. If for any
         # reason the timestamp wasn't recorded (shouldn't happen — set
@@ -2638,7 +2655,7 @@ class AuthenticationService(BaseInfrastructureService, AuthenticationServiceProt
         # degrades at attestation_deadline_seconds(), and the gate has to
         # outlast that by the grace or it times out mid-degrade and loses the
         # race it is supposed to be observing.
-        gate_deadline = _attestation_gate_deadline()
+        gate_deadline = _attestation_gate_deadline(budget_seconds)
         if started_at is not None:
             elapsed = asyncio.get_event_loop().time() - started_at
             remaining = max(0.0, gate_deadline - elapsed)
@@ -2650,6 +2667,7 @@ class AuthenticationService(BaseInfrastructureService, AuthenticationServiceProt
                 asyncio.shield(self._attestation_task),
                 timeout=remaining,
             )
+            return AttestationGateOutcome.READY
         except asyncio.TimeoutError as exc:
             # Past deadline+grace the runner's OWN bounded degrade did not
             # land, so this is not "a slow verifier" — verifier_runner's
@@ -2674,6 +2692,7 @@ class AuthenticationService(BaseInfrastructureService, AuthenticationServiceProt
                 f"CIRISVerify#212 registry fetch?) rather than raising the budget. "
                 f"Startup continues; callers get the result when it lands. ({exc!r})"
             )
+            return AttestationGateOutcome.SLO_BREACH_PENDING
 
     def get_cached_attestation(self, allow_stale: bool = False) -> Optional[AttestationResult]:
         """Get the cached attestation result if available.

--- a/ciris_engine/schemas/services/attestation.py
+++ b/ciris_engine/schemas/services/attestation.py
@@ -5,9 +5,39 @@ CIRISVerify is REQUIRED for CIRIS 2.0+ agents.
 """
 
 from datetime import datetime
+from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
+
+
+class AttestationGateOutcome(str, Enum):
+    """How the startup-attestation gate resolved.
+
+    The gate is a latency pre-warm, not the enforcement point — batch_context
+    blocks on the same call and refuses to build a thought without an
+    attestation result — so a latency-SLO breach is reported rather than
+    raised. The caller still has to KNOW a breach happened, though, or the
+    receipts that make it a fileable ciris_verify issue never get dumped.
+    That is what this outcome carries.
+    """
+
+    READY = "ready"
+    """Attestation completed within the gate deadline."""
+
+    SLO_BREACH_COMPLETED = "slo_breach_completed"
+    """Attestation succeeded but overran the budget. The result is VALID — a
+    slow filesystem does not make the tree hash wrong — so this is a latency
+    regression, not a correctness failure."""
+
+    SLO_BREACH_PENDING = "slo_breach_pending"
+    """Still running past deadline + grace, so verifier_runner's own bounded
+    degrade did not land either. That is a verifier bug, and the gate degrades
+    rather than aborting the runtime."""
+
+    def is_breach(self) -> bool:
+        """True when receipts should be dumped for a ciris_verify issue."""
+        return self is not AttestationGateOutcome.READY
 
 
 class AttestationResult(BaseModel):

--- a/client/androidApp/build.gradle
+++ b/client/androidApp/build.gradle
@@ -25,8 +25,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 35
-        versionCode 175
-        versionName "2.9.38"
+        versionCode 176
+        versionName "2.9.39"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/client/androidApp/src/main/python/version.py
+++ b/client/androidApp/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.9.38"
+__version__ = "android-2.9.39"
 
 
 def get_version() -> str:

--- a/client/desktopApp/build.gradle.kts
+++ b/client/desktopApp/build.gradle.kts
@@ -34,7 +34,7 @@ compose.desktop {
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "CIRIS"
-            packageVersion = "2.9.38"
+            packageVersion = "2.9.39"
             description = "CIRIS Agent Desktop Application"
             vendor = "CIRIS L3C"
 

--- a/client/iosApp/iosApp/Info.plist
+++ b/client/iosApp/iosApp/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.38</string>
+	<string>2.9.39</string>
 	<key>CFBundleVersion</key>
-	<string>339</string>
+	<string>340</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/tests/ci/test_coverage_shards_are_unioned.py
+++ b/tests/ci/test_coverage_shards_are_unioned.py
@@ -1,0 +1,68 @@
+"""Shard coverage must be UNIONED, not concatenated.
+
+CIRISAgent#1116: the combine step used to parse the 8 per-shard Cobertura XMLs
+and append their ``<package>`` elements into one tree. That produced a
+``coverage.xml`` holding 8 entries per file — one per shard, each with only that
+shard's hits — and nothing ever OR'd the per-line counts. Sonar resolved the
+duplicate keys to a single arbitrary shard, so lines covered by tests that
+happened to land in a different shard were reported UNCOVERED.
+
+Measured on run 32784489152: ``edge_runtime.py`` lines 314-316 and 330 were
+covered by shards 1-6 and scored as uncovered, and the PR's ``new_coverage``
+came out at 14.6% against an 80% gate.
+
+The failure was silent — a wrong number looks exactly like a real one — so the
+contract is pinned here rather than left to review.
+"""
+
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "build.yml"
+
+
+def _combine_step_script() -> str:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    for job in workflow["jobs"].values():
+        for step in job.get("steps") or []:
+            if isinstance(step, dict) and step.get("name") == "Combine coverage reports":
+                return step.get("run", "")
+    pytest.fail("no 'Combine coverage reports' step found in build.yml")
+
+
+def test_combine_uses_coverage_combine() -> None:
+    """`coverage combine` is the only thing that unions line hits — and the
+    only thing that can merge branch/arc data at all."""
+    assert "coverage combine" in _combine_step_script()
+
+
+def test_combine_does_not_concatenate_xml() -> None:
+    """The exact defect: appending <package> elements instead of merging."""
+    script = _combine_step_script()
+    assert "findall('.//package')" not in script
+    assert "append(pkg)" not in script
+
+
+def test_shards_emit_raw_coverage_data() -> None:
+    """`coverage combine` needs the raw data files; a per-shard XML report
+    cannot be unioned after the fact."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "COVERAGE_FILE=coverage-data-shard-" in text
+    assert "--cov-report=xml:coverage-shard-" not in text
+
+
+def test_shard_data_files_are_not_hidden() -> None:
+    """A dot-prefixed name would be silently skipped by upload-artifact unless
+    include-hidden-files is set — losing the data the fix depends on."""
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "COVERAGE_FILE=.coverage" not in text
+
+
+def test_a_missing_shard_is_reported() -> None:
+    """A silently absent shard understates coverage exactly the way the old
+    merge did, so it has to be said out loud."""
+    script = _combine_step_script()
+    assert "::warning" in script or "::error" in script

--- a/tests/ciris_engine/logic/runtime/test_attestation_gate.py
+++ b/tests/ciris_engine/logic/runtime/test_attestation_gate.py
@@ -117,10 +117,15 @@ class TestAwaitAttestationGate:
         assert any("AuthenticationService unavailable" in m for m in msgs), msgs
 
     @pytest.mark.asyncio
-    async def test_gate_reraises_attestation_failure(self):
-        """An exception from await_attestation_ready propagates so
-        startup fails loudly — the whole point of the gate is to refuse
-        to start the processor on a broken attestation."""
+    async def test_gate_degrades_instead_of_aborting_on_failure(self, caplog):
+        """A breach must NOT propagate. The gate is a latency pre-warm, not
+        the enforcement point — batch_context refuses to build a thought
+        without an attestation result, so starting the processor here cannot
+        produce an unattested thought.
+
+        Aborting instead bricked a Windows install: 2.9.37 on py3.14 spent
+        >18s in one ciris_verify_tree() call, blew the budget, and the runtime
+        shut down 22s after boot with no UI and no way into the wizard."""
         runtime = _bare_runtime()
         auth = _make_auth_service(
             await_side_effect=RuntimeError(
@@ -129,8 +134,12 @@ class TestAwaitAttestationGate:
         )
         runtime.service_initializer = MagicMock(auth_service=auth)
 
-        with pytest.raises(RuntimeError, match="exceeded the 15s budget"):
-            await runtime._await_attestation_ready()
+        with caplog.at_level("WARNING"):
+            await runtime._await_attestation_ready()  # must not raise
+
+        warnings = "\n".join(r.getMessage() for r in caplog.records if r.levelname == "WARNING")
+        assert "DEGRADED" in warnings
+        assert "exceeded the 15s budget" in warnings
 
     @pytest.mark.asyncio
     async def test_gate_dumps_receipts_on_failure(self, caplog):
@@ -150,8 +159,7 @@ class TestAwaitAttestationGate:
         runtime.service_initializer = MagicMock(auth_service=auth)
 
         with caplog.at_level("ERROR"):
-            with pytest.raises(RuntimeError):
-                await runtime._await_attestation_ready()
+            await runtime._await_attestation_ready()  # degrades, does not raise
 
         joined = "\n".join(r.getMessage() for r in caplog.records if r.levelname == "ERROR")
 
@@ -185,8 +193,7 @@ class TestAwaitAttestationGate:
         runtime.service_initializer = MagicMock(auth_service=auth)
 
         with caplog.at_level("ERROR"):
-            with pytest.raises(RuntimeError):
-                await runtime._await_attestation_ready()
+            await runtime._await_attestation_ready()  # degrades, does not raise
 
         joined = "\n".join(r.getMessage() for r in caplog.records if r.levelname == "ERROR")
         assert "ATTESTATION GATE BUDGET BREACH" in joined
@@ -212,8 +219,7 @@ class TestAwaitAttestationGate:
         runtime.service_initializer = MagicMock(auth_service=auth)
 
         with caplog.at_level("ERROR"):
-            with pytest.raises(RuntimeError):
-                await runtime._await_attestation_ready()
+            await runtime._await_attestation_ready()  # degrades, does not raise
 
         joined = "\n".join(r.getMessage() for r in caplog.records if r.levelname == "ERROR")
         assert "Exception chain" in joined

--- a/tests/ciris_engine/logic/runtime/test_attestation_gate.py
+++ b/tests/ciris_engine/logic/runtime/test_attestation_gate.py
@@ -18,6 +18,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from ciris_engine.schemas.services.attestation import AttestationGateOutcome
+
 from ciris_engine.logic.runtime.ciris_runtime import CIRISRuntime
 
 
@@ -260,3 +262,69 @@ class TestProcessorGateOrdering:
             "_await_attestation_ready must be a coroutine — awaiting "
             "the attestation task synchronously would freeze the runtime."
         )
+
+
+class TestBreachOutcomeStillFilesReceipts:
+    """The gate stopped raising on a latency breach, so the RETURNED OUTCOME is
+    now the only channel that can trigger the receipts dump. If the gate ignored
+    it, the wedged-verifier case — the one this path exists for — would log
+    "complete" and file nothing."""
+
+    @pytest.mark.asyncio
+    async def test_pending_breach_dumps_receipts_and_degrades(self, caplog):
+        runtime = _bare_runtime()
+        auth = _make_auth_service()
+        auth.await_attestation_ready = AsyncMock(
+            return_value=AttestationGateOutcome.SLO_BREACH_PENDING
+        )
+        runtime.service_initializer = MagicMock(auth_service=auth)
+
+        with caplog.at_level("INFO"):
+            await runtime._await_attestation_ready()  # degrades, does not raise
+
+        errors = "\n".join(r.getMessage() for r in caplog.records if r.levelname == "ERROR")
+        warnings = "\n".join(r.getMessage() for r in caplog.records if r.levelname == "WARNING")
+        infos = "\n".join(r.getMessage() for r in caplog.records if r.levelname == "INFO")
+
+        # Receipts still land, still fileable.
+        assert "ATTESTATION GATE BUDGET BREACH" in errors
+        assert "run_attestation_total_seconds" in errors
+        assert "CIRISVerify/issues" in errors
+        # And the run continues, loudly.
+        assert "DEGRADED" in warnings
+        # It must NOT claim success.
+        assert "Startup attestation complete" not in infos
+
+    @pytest.mark.asyncio
+    async def test_completed_breach_also_files(self, caplog):
+        """A slow-but-successful attestation is still a latency regression
+        worth filing — the result is valid, the timing is not."""
+        runtime = _bare_runtime()
+        auth = _make_auth_service()
+        auth.await_attestation_ready = AsyncMock(
+            return_value=AttestationGateOutcome.SLO_BREACH_COMPLETED
+        )
+        runtime.service_initializer = MagicMock(auth_service=auth)
+
+        with caplog.at_level("ERROR"):
+            await runtime._await_attestation_ready()
+
+        errors = "\n".join(r.getMessage() for r in caplog.records if r.levelname == "ERROR")
+        assert "ATTESTATION GATE BUDGET BREACH" in errors
+
+    @pytest.mark.asyncio
+    async def test_ready_outcome_does_not_file_anything(self, caplog):
+        """A healthy boot must stay quiet — receipts on every start would
+        train everyone to ignore them."""
+        runtime = _bare_runtime()
+        auth = _make_auth_service()
+        auth.await_attestation_ready = AsyncMock(return_value=AttestationGateOutcome.READY)
+        runtime.service_initializer = MagicMock(auth_service=auth)
+
+        with caplog.at_level("INFO"):
+            await runtime._await_attestation_ready()
+
+        errors = "\n".join(r.getMessage() for r in caplog.records if r.levelname == "ERROR")
+        infos = "\n".join(r.getMessage() for r in caplog.records if r.levelname == "INFO")
+        assert "ATTESTATION GATE BUDGET BREACH" not in errors
+        assert "Startup attestation complete" in infos

--- a/tests/ciris_engine/logic/services/infrastructure/authentication/test_attestation_gate_does_not_race_degrade.py
+++ b/tests/ciris_engine/logic/services/infrastructure/authentication/test_attestation_gate_does_not_race_degrade.py
@@ -16,23 +16,27 @@ no UI and no way into the setup wizard.
 """
 
 import asyncio
+from typing import Dict
 
 import pytest
 
 from ciris_engine.logic.services.infrastructure.authentication.attestation.verifier_runner import (
     attestation_deadline_seconds,
+    startup_attestation_budget_seconds,
 )
 from ciris_engine.logic.services.infrastructure.authentication.service import (
     ATTESTATION_GATE_GRACE_SECONDS,
     AuthenticationService,
     _attestation_gate_deadline,
 )
+from ciris_engine.schemas.services.attestation import AttestationGateOutcome
 
 
 def test_gate_deadline_outlasts_the_runner_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
     """The whole defect in one assertion."""
     monkeypatch.delenv("CIRIS_STARTUP_ATTESTATION_BUDGET_SECONDS", raising=False)
-    assert _attestation_gate_deadline() > attestation_deadline_seconds(), (
+    budget = startup_attestation_budget_seconds()
+    assert _attestation_gate_deadline(budget) > attestation_deadline_seconds(), (
         "the gate must not expire while the runner is still producing the "
         "degraded result it was told to wait for"
     )
@@ -48,9 +52,9 @@ def test_gate_deadline_tracks_a_late_budget_override(monkeypatch: pytest.MonkeyP
     mobile_main sets during startup — the Android log read 'exceeded the 20s
     budget' on a runtime that had explicitly asked for 45."""
     monkeypatch.setenv("CIRIS_STARTUP_ATTESTATION_BUDGET_SECONDS", "45")
-    assert _attestation_gate_deadline() == 45.0 + ATTESTATION_GATE_GRACE_SECONDS
+    assert _attestation_gate_deadline(startup_attestation_budget_seconds()) == 45.0 + ATTESTATION_GATE_GRACE_SECONDS
     monkeypatch.setenv("CIRIS_STARTUP_ATTESTATION_BUDGET_SECONDS", "7")
-    assert _attestation_gate_deadline() == 7.0 + ATTESTATION_GATE_GRACE_SECONDS
+    assert _attestation_gate_deadline(startup_attestation_budget_seconds()) == 7.0 + ATTESTATION_GATE_GRACE_SECONDS
 
 
 class _Svc:
@@ -59,7 +63,7 @@ class _Svc:
     def __init__(self, task: asyncio.Task, started_at: float) -> None:
         self._attestation_task = task
         self._attestation_started_at = started_at
-        self._attestation_stage_timings: dict = {}
+        self._attestation_stage_timings: Dict[str, float] = {}
         self._attestation_slo_breach_logged = False
 
     # The real reporter, so the stand-in exercises the shipped logging path.
@@ -134,3 +138,51 @@ async def test_slow_but_successful_attestation_is_not_an_error(
 
     await AuthenticationService.await_attestation_ready(svc)  # must not raise
     assert svc._attestation_slo_breach_logged, "a breach must still be reported"
+
+
+def test_a_short_explicit_budget_is_honoured_exactly(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Refresh and audit paths pass budgets as short as 0.05s. They are not
+    racing the runner's degrade, so the grace must not silently stretch them
+    to the global deadline — a caller asking for 0.1s must not wait ~25s."""
+    monkeypatch.delenv("CIRIS_STARTUP_ATTESTATION_BUDGET_SECONDS", raising=False)
+    for short in (0.05, 0.1, 0.5):
+        assert _attestation_gate_deadline(short) == short
+
+
+@pytest.mark.asyncio
+async def test_breach_outcome_is_reported_to_the_caller(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The gate no longer raises, so the outcome is the ONLY channel telling
+    the runtime to dump receipts. Without it the wedged-verifier case logs
+    'complete' and files nothing."""
+    monkeypatch.setenv("CIRIS_STARTUP_ATTESTATION_BUDGET_SECONDS", "1")
+
+    async def _never_finishes_in_time() -> str:
+        await asyncio.sleep(30)
+        return "late"
+
+    loop = asyncio.get_event_loop()
+    task = loop.create_task(_never_finishes_in_time())
+    svc = _Svc(task, loop.time() - 600)
+
+    outcome = await AuthenticationService.await_attestation_ready(svc)
+    assert outcome is AttestationGateOutcome.SLO_BREACH_PENDING
+    assert outcome.is_breach()
+
+    task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_clean_run_reports_ready() -> None:
+    """A healthy attestation must not look like a breach."""
+
+    async def _done() -> str:
+        return "ok"
+
+    loop = asyncio.get_event_loop()
+    task = loop.create_task(_done())
+    await task
+    svc = _Svc(task, loop.time())
+
+    outcome = await AuthenticationService.await_attestation_ready(svc)
+    assert outcome is AttestationGateOutcome.READY
+    assert not outcome.is_breach()

--- a/tests/ciris_engine/logic/services/infrastructure/authentication/test_attestation_gate_does_not_race_degrade.py
+++ b/tests/ciris_engine/logic/services/infrastructure/authentication/test_attestation_gate_does_not_race_degrade.py
@@ -1,0 +1,136 @@
+"""The processor gate must outlast the degrade it is waiting for.
+
+verifier_runner already promises that an attestation is always produced within
+the budget: it bounds its own run at ``attestation_deadline_seconds()`` and
+hands back a degraded ``level=0, binary=FAIL`` result rather than hanging. The
+gate in ``await_attestation_ready`` exists to wait for exactly that result.
+
+Both used to be bounded by the SAME budget from (within milliseconds of) the
+same instant, so the gate expired while the runner was still assembling its
+degraded result — and lost the race every time.
+
+Field report (2.9.37, Windows 11 / py3.14): one ``ciris_verify_tree`` call,
+``elapsed=20.0s`` dead on the budget, ``attestation_task_done: False``,
+``stage_timings_seconds: {}``. The runtime aborted 22 seconds after boot, with
+no UI and no way into the setup wizard.
+"""
+
+import asyncio
+
+import pytest
+
+from ciris_engine.logic.services.infrastructure.authentication.attestation.verifier_runner import (
+    attestation_deadline_seconds,
+)
+from ciris_engine.logic.services.infrastructure.authentication.service import (
+    ATTESTATION_GATE_GRACE_SECONDS,
+    AuthenticationService,
+    _attestation_gate_deadline,
+)
+
+
+def test_gate_deadline_outlasts_the_runner_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The whole defect in one assertion."""
+    monkeypatch.delenv("CIRIS_STARTUP_ATTESTATION_BUDGET_SECONDS", raising=False)
+    assert _attestation_gate_deadline() > attestation_deadline_seconds(), (
+        "the gate must not expire while the runner is still producing the "
+        "degraded result it was told to wait for"
+    )
+
+
+def test_grace_is_enough_to_assemble_a_result() -> None:
+    """Grace covers result assembly + cache population, not a slow verifier."""
+    assert ATTESTATION_GATE_GRACE_SECONDS >= 1.0
+
+
+def test_gate_deadline_tracks_a_late_budget_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Read at call time. A value frozen at import discards the override
+    mobile_main sets during startup — the Android log read 'exceeded the 20s
+    budget' on a runtime that had explicitly asked for 45."""
+    monkeypatch.setenv("CIRIS_STARTUP_ATTESTATION_BUDGET_SECONDS", "45")
+    assert _attestation_gate_deadline() == 45.0 + ATTESTATION_GATE_GRACE_SECONDS
+    monkeypatch.setenv("CIRIS_STARTUP_ATTESTATION_BUDGET_SECONDS", "7")
+    assert _attestation_gate_deadline() == 7.0 + ATTESTATION_GATE_GRACE_SECONDS
+
+
+class _Svc:
+    """Minimal stand-in carrying only what await_attestation_ready touches."""
+
+    def __init__(self, task: asyncio.Task, started_at: float) -> None:
+        self._attestation_task = task
+        self._attestation_started_at = started_at
+        self._attestation_stage_timings: dict = {}
+        self._attestation_slo_breach_logged = False
+
+    # The real reporter, so the stand-in exercises the shipped logging path.
+    _log_attestation_slo_breach = AuthenticationService._log_attestation_slo_breach
+
+
+@pytest.mark.asyncio
+async def test_a_late_degrade_is_still_delivered(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A runner that degrades just past the budget must still be observed.
+
+    This is Francesco's boot: the result lands microseconds after the budget.
+    The old gate raised at exactly 20.0s and threw that result away.
+    """
+    monkeypatch.setenv("CIRIS_STARTUP_ATTESTATION_BUDGET_SECONDS", "1")
+    delivered = []
+
+    async def _degrades_just_past_the_budget() -> str:
+        await asyncio.sleep(1.05)  # budget is 1.0s — lands inside the grace
+        delivered.append("degraded-result")
+        return "degraded-result"
+
+    loop = asyncio.get_event_loop()
+    task = loop.create_task(_degrades_just_past_the_budget())
+    svc = _Svc(task, loop.time())
+
+    await AuthenticationService.await_attestation_ready(svc)  # must not raise
+
+    assert delivered == ["degraded-result"], "the gate discarded a result that did arrive"
+
+
+@pytest.mark.asyncio
+async def test_breach_does_not_poison_later_callers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A breach must not be permanent for the process.
+
+    ``remaining`` is measured from task-creation time, so once elapsed passed
+    the deadline every later caller computed ``max(0.0, ...) == 0.0`` and timed
+    out instantly. batch_context calls this same method per thought, so one
+    slow boot meant the agent could never think again.
+    """
+    monkeypatch.setenv("CIRIS_STARTUP_ATTESTATION_BUDGET_SECONDS", "1")
+
+    async def _never_finishes_in_time() -> str:
+        await asyncio.sleep(30)
+        return "late"
+
+    loop = asyncio.get_event_loop()
+    task = loop.create_task(_never_finishes_in_time())
+    svc = _Svc(task, loop.time() - 600)  # deadline long gone
+
+    # Every subsequent caller degrades quietly rather than raising.
+    for _ in range(3):
+        await AuthenticationService.await_attestation_ready(svc)
+
+    task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_slow_but_successful_attestation_is_not_an_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A slow filesystem does not make the tree hash wrong."""
+    monkeypatch.setenv("CIRIS_STARTUP_ATTESTATION_BUDGET_SECONDS", "1")
+
+    async def _done() -> str:
+        return "ok"
+
+    loop = asyncio.get_event_loop()
+    task = loop.create_task(_done())
+    await task
+    svc = _Svc(task, loop.time())
+    svc._attestation_stage_timings = {"run_attestation_total_seconds": 99.0}
+
+    await AuthenticationService.await_attestation_ready(svc)  # must not raise
+    assert svc._attestation_slo_breach_logged, "a breach must still be reported"

--- a/tests/services/infrastructure/test_attestation_refresh.py
+++ b/tests/services/infrastructure/test_attestation_refresh.py
@@ -14,6 +14,8 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
+from ciris_engine.schemas.services.attestation import AttestationGateOutcome
+
 from ciris_engine.schemas.services.attestation import AttestationResult
 
 # This file tests the real bodies of run_startup_attestation and
@@ -698,7 +700,7 @@ class TestStartupAttestationBudget:
         assert svc._attestation_task.done()
 
     @pytest.mark.asyncio
-    async def test_fast_path_raises_when_completed_run_exceeded_budget(self):
+    async def test_fast_path_reports_when_completed_run_exceeded_budget(self):
         """Codex P1: a caller arriving AFTER the task already finished
         must still see the budget breach. Without this check, a 20s
         attestation that completed before the gate ran would silently
@@ -725,8 +727,10 @@ class TestStartupAttestationBudget:
             "function_integrity": "verified",
         }
 
-        with pytest.raises(RuntimeError, match="completed but exceeded"):
-            await svc.await_attestation_ready(budget_seconds=15.0)
+        # Reported, not raised: the attestation SUCCEEDED, it was merely slow,
+        # and a slow filesystem does not make the tree hash wrong.
+        outcome = await svc.await_attestation_ready(budget_seconds=15.0)
+        assert outcome is AttestationGateOutcome.SLO_BREACH_COMPLETED
 
     @pytest.mark.asyncio
     async def test_fast_path_passes_when_completed_run_within_budget(self):
@@ -768,7 +772,7 @@ class TestStartupAttestationBudget:
         await svc.await_attestation_ready(budget_seconds=15.0)
 
     @pytest.mark.asyncio
-    async def test_raises_runtime_error_on_budget_breach(self):
+    async def test_reports_breach_outcome_on_budget_overshoot(self):
         """A task that exceeds the budget raises RuntimeError with the
         contract message — not a TimeoutError or a silent stall."""
         svc = self._make_bare_service()
@@ -782,9 +786,14 @@ class TestStartupAttestationBudget:
         svc._attestation_task = asyncio.create_task(slow_attestation())
 
         # Use a tiny budget so the test stays fast. The behavior under 15s
-        # and 0.1s is identical — both surface a RuntimeError on overshoot.
-        with pytest.raises(RuntimeError, match=r"exceeded the .* budget"):
-            await svc.await_attestation_ready(budget_seconds=0.1)
+        # and 0.1s is identical — both surface the breach as an outcome.
+        #
+        # Not a raise: raising was permanent for the process, because
+        # `remaining` is measured from task-creation time, so every later
+        # caller — batch_context included, per thought — then computed
+        # max(0.0, ...) == 0.0 and failed instantly.
+        outcome = await svc.await_attestation_ready(budget_seconds=0.1)
+        assert outcome is AttestationGateOutcome.SLO_BREACH_PENDING
 
         # Clean up the lingering task to keep the test loop tidy.
         svc._attestation_task.cancel()
@@ -796,7 +805,7 @@ class TestStartupAttestationBudget:
             pass
 
     @pytest.mark.asyncio
-    async def test_budget_message_names_verifier_as_owner(self):
+    async def test_budget_message_names_verifier_as_owner(self, caplog):
         """The error message must point at the verifier as the thing to
         fix, not at the budget itself. This is the "do not raise the
         budget" load-bearing assertion."""
@@ -809,16 +818,14 @@ class TestStartupAttestationBudget:
         svc._attestation_started_at = loop.time()
         svc._attestation_task = asyncio.create_task(slow_attestation())
 
-        try:
+        with caplog.at_level("WARNING"):
             await svc.await_attestation_ready(budget_seconds=0.05)
-        except RuntimeError as exc:
-            msg = str(exc)
-            assert "verifier" in msg.lower(), msg
-            assert "budget" in msg.lower(), msg
-            # No "increase the timeout" framing.
-            assert "raise the budget" in msg.lower() or "investigate" in msg.lower(), msg
-        else:  # pragma: no cover
-            pytest.fail("await_attestation_ready did not raise on overshoot")
+
+        msg = "\n".join(r.getMessage() for r in caplog.records if r.levelname == "WARNING")
+        assert "verifier" in msg.lower(), msg
+        assert "budget" in msg.lower() or "deadline" in msg.lower(), msg
+        # No "increase the timeout" framing.
+        assert "raise the budget" in msg.lower() or "investigate" in msg.lower(), msg
 
         svc._attestation_task.cancel()
         try:
@@ -845,8 +852,8 @@ class TestStartupAttestationBudget:
         svc._attestation_task = asyncio.create_task(slow_attestation())
 
         gate_start = loop.time()
-        with pytest.raises(RuntimeError, match="budget"):
-            await svc.await_attestation_ready(budget_seconds=0.5)
+        outcome = await svc.await_attestation_ready(budget_seconds=0.5)
+        assert outcome is AttestationGateOutcome.SLO_BREACH_PENDING
         gate_elapsed = loop.time() - gate_start
         # Only ~0.1s remained when the gate ran. Generous upper bound for
         # CI jitter, but well below the 0.5s caller-time budget.
@@ -878,8 +885,8 @@ class TestStartupAttestationBudget:
         svc._attestation_started_at = loop.time() - 1.0
         svc._attestation_task = asyncio.create_task(slow_attestation())
 
-        with pytest.raises(RuntimeError, match="budget"):
-            await svc.await_attestation_ready(budget_seconds=0.1)
+        outcome = await svc.await_attestation_ready(budget_seconds=0.1)
+        assert outcome is AttestationGateOutcome.SLO_BREACH_PENDING
 
         svc._attestation_task.cancel()
         try:
@@ -904,10 +911,7 @@ class TestStartupAttestationBudget:
         svc._attestation_started_at = loop.time()
         svc._attestation_task = asyncio.create_task(slow_attestation())
 
-        try:
-            await svc.await_attestation_ready(budget_seconds=0.05)
-        except RuntimeError:
-            pass
+        await svc.await_attestation_ready(budget_seconds=0.05)
 
         assert not svc._attestation_task.done(), (
             "Gate must not cancel the in-flight attestation task on a budget "


### PR DESCRIPTION
## The report

Francesco's 2.9.37 on **Windows 11 / Python 3.14** died 22 seconds after boot — no UI, no setup wizard, no way in. The whole log spans `17:05:06` → `17:05:28`.

```
17:05:09.555  [tree_verify] ciris_verify_tree(project=ciris-agent,
              root=C:\Users\franc\...\site-packages, version=2.9.37, ...)
              <- never returns
17:05:28.094  ATTESTATION GATE BUDGET BREACH
                exception_message: Startup attestation exceeded the 20s budget (elapsed=20.0s)
                attestation_task_done:  False
                stage_timings_seconds:  {}
17:05:28.698  [EXIT] CIRIS agent exiting cleanly
```

Exactly one `tree_verify` line — it went in and never came out. `stage_timings_seconds: {}` because that dict is only written *after* `run_attestation()` returns.

## The bug: the gate was racing the degrade it was waiting for

`verifier_runner` already promises that *"an attestation is always produced within the budget"* — it bounds its own run at `attestation_deadline_seconds()` and hands back a degraded `level=0, binary=FAIL` result rather than hanging.

The processor gate in `await_attestation_ready` exists to wait for that result. But both were bounded by the **same** budget, measured from within milliseconds of the **same** instant. The gate expired while the runner was still assembling its result — and lost every time. `elapsed=20.0s` is the budget dead on, with the task not yet done.

## Worse: the breach was permanent for the process

`remaining` is measured from task-creation time:

```python
remaining = max(0.0, budget_seconds - elapsed)
```

Once elapsed passed the budget, every later caller got `0.0` and timed out instantly. `batch_context` calls this same method **per thought**, so one slow boot meant the agent could never think again — even after the attestation succeeded a second later.

## The fix

1. **The gate waits `attestation_deadline_seconds() + 5s grace`**, so the runner's bounded degrade can land. This is not more budget for a slow verifier: past deadline+grace the runner's *own* timeout has failed, which is a different bug and is reported as one.

2. **A breach is reported, not raised.** A slow filesystem does not make the tree hash wrong. Warned once, then DEBUG — per-thought callers land here too and would otherwise bury the one that matters.

3. **The processor starts degraded rather than aborting**, with the receipts dump unchanged.

## Why this is not a security regression

The gate is a **latency pre-warm, not the enforcement point**. `batch_context` blocks on the same `await_attestation_ready()` and refuses to build a thought without an attestation result:

```python
if attestation_result is None:
    raise RuntimeError("CRITICAL: No attestation result available ...")
```

So nothing runs unattested either way. Starting degraded costs first-thought latency; aborting cost the whole application. The 20s budget is unchanged and still loud when blown.

## Tests

New `test_attestation_gate_does_not_race_degrade.py` (6 cases) locks:
- the gate deadline strictly outlasts the runner deadline — the defect in one assertion
- a degrade landing just past the budget is still delivered (fails under the old code)
- a breach does not poison later callers
- slow-but-successful is reported, not raised
- the deadline still tracks a late `CIRIS_STARTUP_ATTESTATION_BUDGET_SECONDS` override

`test_attestation_gate.py` updated to the new contract — receipts assertions unchanged, `pytest.raises` wrappers removed.

748 passed across `tests/ciris_engine/logic/runtime/`, `tests/ciris_engine/logic/services/infrastructure/`, and `test_batch_context.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N1ugR27TCMG2ZWQK6H8knJ