### PR TITLE
fix(tools): define _gate_verdict, clear 10 undefined names, and make F821 block

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,6 +83,29 @@ repos:
             | apps/android/wheels/.*\.whl
           )$
 
+  # UNDEFINED NAMES - BLOCKING. Narrow on purpose.
+  #
+  # The general ruff hook below is `stages: [manual]`, so it never runs in the
+  # normal flow — which is how `_gate_verdict()` reached main as a CALL WITH NO
+  # DEFINITION and sat there five releases. It lived on an error path, so it only
+  # fired when something else broke, and then the diagnostic meant to explain that
+  # failure raised NameError instead. Nine more of the same class were found
+  # alongside it — including a bare `os` in grace.py (the pre-commit gatekeeper
+  # itself) and `max_attempts`/`retry_delay` in qa_runner's retry path.
+  #
+  # F821 ONLY, and NO --fix: an undefined name is not a style opinion, it is code
+  # that cannot run, so it blocks. Keeping the rule narrow stops this becoming a
+  # lint-churn gate people learn to skip. `tests/` is excluded for now — it still
+  # carries 14 of these; add it once cleared, since a linter that skips tests is
+  # blind exactly where fixtures hide.
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.8
+    hooks:
+      - id: ruff
+        alias: ruff-undefined-names
+        name: ruff (F821 undefined names — blocking)
+        args: ['--select', 'F821', '--no-fix']
+        files: '^(ciris_engine|ciris_adapters|tools)/.*\.py$'
   # Quality checks - Run but don't block (Grace will report)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.4.8

--- a/tools/dev/grace.py
+++ b/tools/dev/grace.py
@@ -7,6 +7,7 @@ Tracks your natural rhythm, preserves context across breaks, and
 suggests appropriate tasks based on time, energy, and commitments.
 """
 
+import os
 import json
 import subprocess
 import sys

--- a/tools/dev/register_discord_adapter.py
+++ b/tools/dev/register_discord_adapter.py
@@ -8,6 +8,7 @@ This script:
 3. Registers a Discord adapter with the bot token and channel IDs
 """
 
+from typing import Optional
 import os
 import sys
 from pathlib import Path

--- a/tools/ops/register_discord_adapter.py
+++ b/tools/ops/register_discord_adapter.py
@@ -8,6 +8,7 @@ This script:
 3. Registers a Discord adapter with the bot token and channel IDs
 """
 
+from typing import Optional
 import os
 import sys
 from pathlib import Path

--- a/tools/qa_runner/modules/llm_matrix/probes.py
+++ b/tools/qa_runner/modules/llm_matrix/probes.py
@@ -19,7 +19,10 @@ from __future__ import annotations
 
 import json
 import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+
+if TYPE_CHECKING:  # annotation-only; `from __future__ import annotations` defers it
+    from ciris_engine.logic.adapters.api.routes.setup.models import LLMValidationResponse
 
 from .dimensions import OVER_CAP_MAX_TOKENS, OVER_CAP_PROMPT, PROBE_MAX_TOKENS, PROBE_PROMPT, ProviderSpec
 from .product_bridge import (

--- a/tools/qa_runner/modules/mobile/test_cases.py
+++ b/tools/qa_runner/modules/mobile/test_cases.py
@@ -474,6 +474,21 @@ def connect_test_server(
     return None
 
 
+def _identity_failure(step: str, detail: str) -> TestReport:
+    """Failure report for the identity-preservation check in test_app_launch.
+
+    Module-level and self-contained: the callers of the two existing `fail`
+    closures cannot see them from here, which is exactly how a `NameError` came
+    to sit on this branch.
+    """
+    return TestReport(
+        name="test_app_launch",
+        result=TestResult.FAILED,
+        duration=0.0,
+        message=f"[{step}] {detail}",
+    )
+
+
 def test_app_launch(adb: ADBHelper, ui: UIAutomator, config: dict) -> TestReport:
     """
     Test: App launches successfully.
@@ -554,7 +569,14 @@ def test_app_launch(adb: ADBHelper, ui: UIAutomator, config: dict) -> TestReport
                 if key_after and key_after == key_before:
                     print(f"  [2/5] Identity restored — key_id={key_after} UNCHANGED")
                 else:
-                    return fail(
+                    # `fail(...)` here referenced a helper that does not exist in
+                    # this function — the two `def fail` in this module are local
+                    # to test_setup_wizard and one other. Reaching this branch
+                    # raised NameError instead of reporting the identity loss it
+                    # had just correctly detected, so the diagnostic destroyed
+                    # itself at the moment it fired. Same class as the
+                    # `_gate_verdict()` call in web_ui/__main__.py.
+                    return _identity_failure(
                         "preserve_identity",
                         f"identity NOT preserved: key_id was {key_before or '(none)'}, "
                         f"is now {key_after or '(none)'}. A re-minted agent is re-admitted at "

--- a/tools/qa_runner/modules/mobile/test_runner.py
+++ b/tools/qa_runner/modules/mobile/test_runner.py
@@ -634,7 +634,7 @@ def main():
         test_email=args.email,
         llm_api_key=args.llm_key or "",
         llm_provider=args.llm_provider,
-        llm_model=args.llm_model or TestConfig.llm_model,
+        llm_model=args.llm_model or MobileTestConfig.llm_model,
         output_dir=args.output_dir,
         save_screenshots=not args.no_screenshots,
         save_logcat=not args.no_logcat,

--- a/tools/qa_runner/modules/web_ui/__main__.py
+++ b/tools/qa_runner/modules/web_ui/__main__.py
@@ -511,6 +511,43 @@ class DesktopAppTestRunner:
     # we entered a key, the registered handler is stale, full stop.
     _BLANK_KEY_MESSAGE = "Enter an API key"
 
+    async def _gate_verdict(self) -> str:
+        """Whatever the app says about the AGENT/NODE gate, for the no-AI-screen error.
+
+        THIS WAS A CALL WITH NO DEFINITION. Added in 2.9.42 on an error path that
+        only runs when the AI screen is missing, so it never executed — until a
+        client bump made an earlier step fail, and then the diagnostic built to
+        explain the failure raised
+
+            NameError: name '_gate_verdict' is not defined
+
+        replacing the explanation with a stack trace at exactly the moment it was
+        needed. An error path that never runs is not a diagnostic; it is a second
+        failure waiting for the first.
+
+        Best-effort by construction: a build exposing no gate surface must still
+        get the surrounding message, so this says so rather than raising.
+        """
+        try:
+            elements = await self.helper.get_elements()
+        except Exception as exc:  # noqa: BLE001
+            return f"          (could not read the UI tree: {type(exc).__name__})\n"
+
+        prefixes = ("txt_gate", "txt_client_mode", "txt_node", "txt_agent_mode", "txt_mode")
+        lines = [
+            f"          {e.test_tag} = {e.text.strip()[:110]}"
+            for e in elements
+            if getattr(e, "text", None)
+            and e.text.strip()
+            and any(e.test_tag.startswith(pfx) for pfx in prefixes)
+        ]
+        if not lines:
+            return (
+                "          (the app exposed no gate/clientMode surface — either this "
+                "build predates it,\n           or the screen never rendered)\n"
+            )
+        return "\n".join(sorted(lines)) + "\n"
+
     async def _llm_verdict_texts(self) -> dict:
         """testTag -> text for the AI step's verdict surfaces (txt_llm_*)."""
         assert self.helper is not None
@@ -895,7 +932,7 @@ class DesktopAppTestRunner:
                     "No AI screen. This build is the AGENT and MUST offer LLM "
                     "configuration.\n"
                     "        The app's own verdict:\n"
-                    + _gate_verdict()
+                    + await self._gate_verdict()
                     + "        AGENT requires folded && reachable && !veto. folded and "
                     "reachable come from the NODE\n"
                     "        (CIRIS_NODE_URL, :4243 `agent` block); role and services "

--- a/tools/qa_runner/runner.py
+++ b/tools/qa_runner/runner.py
@@ -2328,7 +2328,7 @@ class QARunner:
                             break  # Success, exit retry loop
                         else:
                             # Real error - endpoint might not exist or server error
-                            if attempt == max_attempts - 1:
+                            if attempt == self.config.retry_count - 1:
                                 # Last attempt, fail the test
                                 if self.config.verbose:
                                     self.console.print(f"[red][FAIL] {test.name}: {error_msg[:100]}[/red]")
@@ -2341,11 +2341,11 @@ class QARunner:
                                 }
                             else:
                                 # Not last attempt, wait and retry
-                                time.sleep(retry_delay)
+                                time.sleep(self.config.retry_delay)
                                 continue
                     except Exception as e:
                         # Non-WebSocket error
-                        if attempt == max_attempts - 1:
+                        if attempt == self.config.retry_count - 1:
                             return False, {
                                 "success": False,
                                 "error": f"Unexpected error: {str(e)[:200]}",
@@ -2353,7 +2353,7 @@ class QARunner:
                                 "attempts": attempt + 1,
                             }
                         else:
-                            time.sleep(retry_delay)
+                            time.sleep(self.config.retry_delay)
                             continue
                 elif test.method == "CUSTOM":
                     # Custom method handler for special tests like streaming verification


### PR DESCRIPTION
Found while adopting ciris-client 0.5.197 (#1132). That adoption is blocked on a client regression (CIRISClient#30), but **these bugs are ours and are real on any client version**, so they ship separately.

## The one that started it

`_gate_verdict()` has been a **call with no definition since 2.9.42**. It sits on the "No AI screen" error path, so it never executed — until the client bump made an earlier step fail, and then the diagnostic built to explain that failure raised:

```
NameError: name '_gate_verdict' is not defined
```

**An error path that never runs isn't a diagnostic; it's a second failure waiting for the first.**

## Why nothing caught it

ruff is configured and `F821` is exactly this rule — but the hook is `stages: [manual]`, so it never runs. Running it by hand found **nine more of the same class**:

| file | undefined |
|---|---|
| `tools/dev/grace.py` | `os` — in the pre-commit gatekeeper itself |
| `tools/qa_runner/runner.py` ×4 | `max_attempts`, `retry_delay` — would NameError on the first retry instead of retrying |
| `tools/qa_runner/modules/mobile/test_cases.py` | `fail` — the two `def fail` are local to *other* functions, so the identity check destroyed its own report as it fired |
| `tools/qa_runner/modules/mobile/test_runner.py` | `TestConfig` (long since `MobileTestConfig`) |
| `tools/{dev,ops}/register_discord_adapter.py` | `Optional` |
| `tools/qa_runner/modules/llm_matrix/probes.py` | annotation-only → now under `TYPE_CHECKING` |

Several are error and retry paths — code that only runs when something has already gone wrong, which is why they survived.

## Made enforceable, narrowly

A blocking hook runs `ruff --select F821 --no-fix` over `ciris_engine/`, `ciris_adapters/`, `tools/` — now clean. Not the full rule set, no autofix: an undefined name isn't a style opinion, it's code that cannot run, and a narrow gate doesn't become lint churn people learn to skip.

Verified both directions: fails a file containing an undefined name, passes the tree as it stands.

**`tests/` is deliberately not covered** — it still carries 14. Left as follow-up rather than widening this PR, but worth doing: a linter that skips tests is blind exactly where fixtures hide.

Client pin stays at **0.5.196**. 497 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JJy1BhjJKoRi6615eZHYzm