### PR TITLE
fix(interactive_config): one spelling per axis, and the keys now do something

### DIFF
--- a/ciris_adapters/a2a/configurable.py
+++ b/ciris_adapters/a2a/configurable.py
@@ -89,7 +89,7 @@ class A2AConfigurableAdapter:
                     "step_type": "input",
                     "title": "Performance Settings (Optional)",
                     "description": "Configure timeout and performance options",
-                    "optional": True,
+                    "required": False,
                     "fields": [
                         {
                             "name": "timeout",

--- a/ciris_adapters/a2a/manifest.json
+++ b/ciris_adapters/a2a/manifest.json
@@ -57,7 +57,6 @@
         "title": "Performance Settings",
         "description": "Configure timeout and performance options",
         "required": false,
-        "optional": true,
         "fields": [
           {
             "name": "timeout",

--- a/ciris_adapters/ciris_accord_metrics/manifest.json
+++ b/ciris_adapters/ciris_accord_metrics/manifest.json
@@ -96,7 +96,7 @@
         "step_type": "input",
         "title": "Early Warning System (Optional)",
         "description": "Help improve the CIRIS Early Warning System by sharing optional context about your deployment. This enables correlation analysis to detect emerging risks across the CIRIS network. All fields are optional and anonymous.",
-        "optional": true,
+        "required": false,
         "fields": [
           {
             "name": "deployment_region",
@@ -167,7 +167,7 @@
         "step_type": "input",
         "title": "Advanced Configuration",
         "description": "Configure the CIRISLens endpoint and batching behavior (most users can skip this)",
-        "optional": true,
+        "required": false,
         "fields": [
           {
             "name": "endpoint_url",

--- a/ciris_adapters/external_data_sql/manifest.json
+++ b/ciris_adapters/external_data_sql/manifest.json
@@ -60,6 +60,11 @@
         "title": "Select Database Type",
         "description": "Choose the type of SQL database you want to connect to",
         "options_method": "get_config_options",
+        "fields": [
+          {
+            "name": "dialect"
+          }
+        ],
         "required": true
       },
       {
@@ -69,14 +74,14 @@
         "description": "Enter the path to your SQLite database file",
         "fields": [
           {
-            "field_id": "database_path",
+            "name": "database_path",
             "label": "Database File Path",
             "type": "string",
             "placeholder": "/path/to/database.db",
             "required": true
           },
           {
-            "field_id": "connector_id",
+            "name": "connector_id",
             "label": "Connector ID",
             "type": "string",
             "placeholder": "my_sqlite_db",
@@ -97,42 +102,42 @@
         "description": "Enter connection details for your database server",
         "fields": [
           {
-            "field_id": "host",
+            "name": "host",
             "label": "Host",
             "type": "string",
             "placeholder": "localhost",
             "required": true
           },
           {
-            "field_id": "port",
+            "name": "port",
             "label": "Port",
             "type": "number",
             "placeholder": "5432",
             "required": false
           },
           {
-            "field_id": "database",
+            "name": "database",
             "label": "Database Name",
             "type": "string",
             "placeholder": "mydb",
             "required": true
           },
           {
-            "field_id": "user",
+            "name": "user",
             "label": "Username",
             "type": "string",
             "placeholder": "dbuser",
             "required": true
           },
           {
-            "field_id": "password",
+            "name": "password",
             "label": "Password",
             "type": "password",
             "placeholder": "••••••••",
             "required": true
           },
           {
-            "field_id": "connector_id",
+            "name": "connector_id",
             "label": "Connector ID",
             "type": "string",
             "placeholder": "my_database",
@@ -153,14 +158,14 @@
         "description": "Configure privacy schema for GDPR/DSAR compliance",
         "fields": [
           {
-            "field_id": "privacy_schema_path",
+            "name": "privacy_schema_path",
             "label": "Privacy Schema File Path",
             "type": "string",
             "placeholder": "/path/to/privacy_schema.yaml",
             "required": false
           }
         ],
-        "optional": true,
+        "required": false,
         "depends_on": ["select_dialect"]
       },
       {
@@ -177,7 +182,7 @@
         "step_type": "confirm",
         "title": "Test Connection",
         "description": "Test the database connection before applying configuration",
-        "optional": true,
+        "required": false,
         "action": "test_connection"
       },
       {

--- a/ciris_adapters/home_assistant/manifest.json
+++ b/ciris_adapters/home_assistant/manifest.json
@@ -100,7 +100,7 @@
         "description": "Choose which cameras to use for event detection (optional)",
         "options_method": "get_config_options",
         "depends_on": ["oauth"],
-        "optional": true
+        "required": false
       },
       {
         "step_id": "confirm",

--- a/ciris_adapters/mcp_client/configurable.py
+++ b/ciris_adapters/mcp_client/configurable.py
@@ -111,7 +111,7 @@ class MCPClientConfigurableAdapter:
                     "step_type": "select",
                     "title": "Select Transport Type",
                     "description": "Choose how to connect to the MCP server",
-                    "field_name": "transport",
+                    "fields": [{"name": "transport"}],
                     "required": True,
                 },
                 {
@@ -127,7 +127,7 @@ class MCPClientConfigurableAdapter:
                     "step_type": "input",
                     "title": "Security Settings (Optional)",
                     "description": "Configure security and rate limiting",
-                    "optional": True,
+                    "required": False,
                     "fields": [
                         {
                             "name": "max_calls_per_minute",
@@ -150,7 +150,7 @@ class MCPClientConfigurableAdapter:
                     "step_type": "select",
                     "title": "Select Bus Bindings",
                     "description": "Choose which CIRIS buses to bind this server to",
-                    "field_name": "enabled_buses",
+                    "fields": [{"name": "enabled_buses"}],
                     "multiple": True,
                     "required": True,
                 },

--- a/ciris_adapters/mcp_client/manifest.json
+++ b/ciris_adapters/mcp_client/manifest.json
@@ -92,7 +92,7 @@
         "title": "Select Transport Type",
         "description": "Choose how to connect to the MCP server",
         "options_method": "get_config_options",
-        "field_name": "transport",
+        "fields": [{"name": "transport"}],
         "required": true
       },
       {
@@ -109,7 +109,7 @@
         "step_type": "input",
         "title": "Security Settings",
         "description": "Configure rate limiting and security options (optional)",
-        "optional": true,
+        "required": false,
         "fields": [
           {
             "name": "max_calls_per_minute",
@@ -135,7 +135,7 @@
         "title": "Select Bus Bindings",
         "description": "Choose which CIRIS buses to bind this server to",
         "options_method": "get_config_options",
-        "field_name": "enabled_buses",
+        "fields": [{"name": "enabled_buses"}],
         "multiple": true,
         "required": true
       },

--- a/ciris_adapters/mcp_server/manifest.json
+++ b/ciris_adapters/mcp_server/manifest.json
@@ -59,7 +59,7 @@
         "title": "Select Transport Type",
         "description": "Choose how the MCP server will communicate with clients",
         "options_method": "get_config_options",
-        "field_name": "transport_type",
+        "fields": [{"name": "transport_type"}],
         "required": true
       },
       {
@@ -116,8 +116,8 @@
         "title": "Authentication Method",
         "description": "Choose how clients will authenticate (optional)",
         "options_method": "get_config_options",
-        "field_name": "auth_method",
-        "optional": true,
+        "fields": [{"name": "auth_method"}],
+        "required": false,
         "default": "none"
       },
       {
@@ -134,11 +134,11 @@
             "required": true
           }
         ],
-        "depends_on": {
+        "condition": {
           "field": "auth_method",
           "values": ["api_key"]
         },
-        "optional": true
+        "required": false
       },
       {
         "step_id": "select_exposure",
@@ -146,7 +146,7 @@
         "title": "Select Features to Expose",
         "description": "Choose which CIRIS capabilities to make available via MCP",
         "options_method": "get_config_options",
-        "field_name": "exposure",
+        "fields": [{"name": "exposure"}],
         "multiple": true,
         "required": true
       },

--- a/ciris_adapters/mock_llm/manifest.json
+++ b/ciris_adapters/mock_llm/manifest.json
@@ -39,9 +39,9 @@
         "step_type": "input",
         "title": "Configure Response Delay",
         "description": "Set simulated API latency in milliseconds (0-60000)",
-        "field_name": "delay_ms",
+        "fields": [{"name": "delay_ms"}],
         "default": 100,
-        "optional": true,
+        "required": false,
         "validation": {
           "min": 0,
           "max": 60000
@@ -52,19 +52,19 @@
         "step_type": "select",
         "title": "Select Response Mode",
         "description": "Choose how the mock LLM generates responses",
-        "field_name": "response_mode",
+        "fields": [{"name": "response_mode"}],
         "options_method": "get_config_options",
         "default": "deterministic",
-        "optional": true
+        "required": false
       },
       {
         "step_id": "configure_failures",
         "step_type": "input",
         "title": "Configure Failure Rate",
         "description": "Probability of simulated failures for testing (0.0-1.0)",
-        "field_name": "failure_rate",
+        "fields": [{"name": "failure_rate"}],
         "default": 0.0,
-        "optional": true,
+        "required": false,
         "validation": {
           "min": 0.0,
           "max": 1.0

--- a/ciris_adapters/navigation/configurable.py
+++ b/ciris_adapters/navigation/configurable.py
@@ -210,7 +210,7 @@ class NavigationConfigurableAdapter:
                     "step_type": "input",
                     "title": "Configure User Agent",
                     "description": "Enter a user agent for OpenStreetMap API requests (required by OSM policy)",
-                    "field": "user_agent",
+                    "fields": [{"name": "user_agent"}],
                     "required": True,
                     "placeholder": "CIRIS/1.0 (your.email@example.com)",
                     "validation": {
@@ -223,9 +223,8 @@ class NavigationConfigurableAdapter:
                     "step_type": "select",
                     "title": "Configure Rate Limiting",
                     "description": "Select how long to wait between API requests (OSM recommends 1+ seconds)",
-                    "field": "rate_limit_seconds",
+                    "fields": [{"name": "rate_limit_seconds"}],
                     "required": False,
-                    "optional": True,
                     "options_method": "get_config_options",
                 },
                 {

--- a/ciris_adapters/reddit/manifest.json
+++ b/ciris_adapters/reddit/manifest.json
@@ -113,7 +113,7 @@
         "description": "Enter your Reddit OAuth app credentials from https://www.reddit.com/prefs/apps",
         "fields": [
           {
-            "field_id": "client_id",
+            "name": "client_id",
             "label": "Client ID",
             "description": "OAuth client ID from your Reddit app",
             "input_type": "text",
@@ -121,7 +121,7 @@
             "placeholder": "Enter your Reddit client ID"
           },
           {
-            "field_id": "client_secret",
+            "name": "client_secret",
             "label": "Client Secret",
             "description": "OAuth client secret from your Reddit app",
             "input_type": "password",
@@ -137,7 +137,7 @@
         "description": "Enter credentials for your Reddit bot account",
         "fields": [
           {
-            "field_id": "username",
+            "name": "username",
             "label": "Bot Username",
             "description": "Reddit bot account username",
             "input_type": "text",
@@ -145,7 +145,7 @@
             "placeholder": "Enter your bot username"
           },
           {
-            "field_id": "password",
+            "name": "password",
             "label": "Bot Password",
             "description": "Reddit bot account password",
             "input_type": "password",
@@ -162,7 +162,7 @@
         "description": "Reddit requires a unique User-Agent string for API requests",
         "fields": [
           {
-            "field_id": "user_agent",
+            "name": "user_agent",
             "label": "User-Agent",
             "description": "Unique User-Agent string (required by Reddit API)",
             "input_type": "text",
@@ -180,7 +180,7 @@
         "description": "Choose the primary subreddit for monitoring and interaction",
         "fields": [
           {
-            "field_id": "subreddit",
+            "name": "subreddit",
             "label": "Subreddit",
             "description": "Primary subreddit (without r/ prefix)",
             "input_type": "text",
@@ -190,7 +190,7 @@
           }
         ],
         "depends_on": ["user_agent"],
-        "optional": true
+        "required": false
       },
       {
         "step_id": "select_post_types",
@@ -199,7 +199,7 @@
         "description": "Choose which types of posts to monitor (optional)",
         "options_method": "get_config_options",
         "depends_on": ["user_agent"],
-        "optional": true
+        "required": false
       },
       {
         "step_id": "confirm",

--- a/ciris_adapters/sample_adapter/manifest.json
+++ b/ciris_adapters/sample_adapter/manifest.json
@@ -94,7 +94,7 @@
         "description": "Choose which discovered instance to use (single selection)",
         "depends_on": ["discover"],
         "multiple": false,
-        "optional": false,
+        "required": true,
         "_comment": "STEP TYPE: select (REQUIRED, SINGLE) - Shows discovered instances. User must select exactly one. Not optional, must complete."
       },
       {
@@ -104,7 +104,7 @@
         "description": "Optionally choose cameras to monitor",
         "depends_on": ["oauth"],
         "multiple": true,
-        "optional": true,
+        "required": false,
         "_comment": "STEP TYPE: select (OPTIONAL, MULTIPLE) - Can be skipped. If completed, user can select 0+ cameras. optional: true means step can be skipped entirely."
       },
       {
@@ -149,7 +149,7 @@
         "step_type": "input",
         "title": "Advanced Settings (Optional)",
         "description": "Configure advanced options (can be skipped)",
-        "optional": true,
+        "required": false,
         "fields": [
           {
             "name": "debug_mode",

--- a/ciris_engine/logic/adapters/api/routes/system/adapter_config.py
+++ b/ciris_engine/logic/adapters/api/routes/system/adapter_config.py
@@ -296,10 +296,10 @@ async def start_adapter_configuration(
         if not manifest:
             raise HTTPException(status_code=404, detail=f"Adapter '{adapter_type}' not found")
 
-        # Get current step (respects start_step_id if specified)
-        current_step = None
-        if manifest.steps and session.current_step_index < len(manifest.steps):
-            current_step = manifest.steps[session.current_step_index]
+        # Get current step (respects start_step_id, and skips steps whose
+        # `condition` does not hold -- through the service, so this is the
+        # SAME evaluator that execute_step uses, not a second one).
+        current_step = config_service.current_step(session)
 
         response = ConfigurationSessionResponse(
             session_id=session.session_id,
@@ -368,10 +368,8 @@ async def get_configuration_status(
         if not manifest:
             raise HTTPException(status_code=500, detail=f"Manifest for '{session.adapter_type}' not found")
 
-        # Get current step
-        current_step = None
-        if session.current_step_index < len(manifest.steps):
-            current_step = manifest.steps[session.current_step_index]
+        # Get current step, conditions evaluated (see start_configuration)
+        current_step = config_service.current_step(session)
 
         response = ConfigurationStatusResponse(
             session_id=session.session_id,
@@ -463,9 +461,8 @@ async def get_session_status(
         if manifest and manifest.steps:
             steps = manifest.steps
             total_steps = len(steps)
-            if session.current_step_index < len(steps):
-                # Use the ConfigurationStep directly from the manifest
-                current_step = steps[session.current_step_index]
+            # Through the service, conditions evaluated (see start_configuration)
+            current_step = config_service.current_step(session)
 
         response = ConfigurationSessionResponse(
             session_id=session.session_id,

--- a/ciris_engine/logic/adapters/api/routes/system/adapters.py
+++ b/ciris_engine/logic/adapters/api/routes/system/adapters.py
@@ -574,7 +574,8 @@ async def list_configurable_adapters(
                             step_type=step.step_type,
                             title=step.title,
                             description=step.description,
-                            optional=getattr(step, "optional", False),
+                            required=step.required,
+                            optional=not step.required,
                         )
                         for step in manifest.steps
                     ],
@@ -689,7 +690,8 @@ async def list_loadable_adapters(
                             step_type=step.step_type,
                             title=step.title,
                             description=step.description,
-                            optional=getattr(step, "optional", False),
+                            required=step.required,
+                            optional=not step.required,
                         )
                         for step in manifest.steps
                     ]

--- a/ciris_engine/logic/adapters/api/routes/system/schemas.py
+++ b/ciris_engine/logic/adapters/api/routes/system/schemas.py
@@ -266,7 +266,11 @@ class ConfigStepInfo(BaseModel):
     step_type: str = Field(..., description="Type of step (discovery, oauth, select, confirm)")
     title: str = Field(..., description="Step title")
     description: str = Field(..., description="Step description")
-    optional: bool = Field(False, description="Whether this step is optional")
+    required: bool = Field(False, description="Whether this step is required")
+    # DERIVED, NEVER SET. Kept on the wire for any consumer that still reads it,
+    # but computed from `required` so the two cannot disagree -- which is the
+    # whole reason the manifest schema no longer has both.
+    optional: bool = Field(True, description="DEPRECATED: derived as `not required`; read `required`")
 
 
 class ConfigurableAdapterInfo(BaseModel):

--- a/ciris_engine/logic/services/runtime/adapter_configuration/service.py
+++ b/ciris_engine/logic/services/runtime/adapter_configuration/service.py
@@ -171,6 +171,11 @@ class AdapterConfigurationService:
             # Log count only to avoid exposing user-controlled key names
             logger.info(f"Pre-populated session with {len(existing_config)} existing config keys")
 
+        # THE FIRST STEP CAN BE CONDITIONAL TOO. Skip before anyone sees it --
+        # after existing_config is folded in, so a re-auth flow's condition can
+        # read what was configured last time.
+        self.skip_unsatisfied(session, self._adapter_manifests[adapter_type])
+
         self._sessions[session.session_id] = session
         logger.info(f"Started config session {session.session_id} for {adapter_type}")
         return session
@@ -190,6 +195,68 @@ class AdapterConfigurationService:
             if self._is_session_expired(session):
                 session.status = SessionStatus.EXPIRED
         return session
+
+    @staticmethod
+    def condition_holds(step: ConfigurationStep, collected: Dict[str, Any]) -> bool:
+        """Does this step's `condition` hold against what the session has collected?
+
+        THREE SHAPES, exhaustively -- the ones the tree actually writes:
+
+            {"field": "dialect", "equals": "sqlite"}
+            {"field": "dialect", "not_equals": "sqlite"}
+            {"field": "auth_method", "values": ["api_key"]}
+
+        A step with no condition always holds. A condition whose field has not
+        been collected yet does NOT hold: showing a step before the answer it
+        depends on exists would be asking a question out of order. `field` names
+        either an input field (stored under its name) or a select step (stored
+        under its step_id) -- both land in `collected_config` the same way.
+
+        Until this existed, `condition` was declared by manifests and evaluated
+        by nothing: external_data_sql showed BOTH its sqlite and its
+        server-connection steps to everyone (CIRISClient#39).
+        """
+        cond = step.condition
+        if not cond:
+            return True
+        field = cond.get("field")
+        if field is None or field not in collected:
+            return False
+        actual = collected[field]
+        if "equals" in cond:
+            return actual == cond["equals"]
+        if "not_equals" in cond:
+            return actual != cond["not_equals"]
+        if "values" in cond:
+            return actual in (cond["values"] or [])
+        # A predicate with no recognised operator is a manifest error, and a
+        # manifest error must not silently show or hide a step.
+        raise ValueError(f"step {step.step_id!r}: condition has no equals/not_equals/values: {cond}")
+
+    def skip_unsatisfied(self, session: AdapterConfigSession, config: InteractiveConfiguration) -> None:
+        """Advance past every step whose condition does not currently hold.
+
+        Called wherever a step is about to be PRESENTED -- on start, on
+        advance, and when status is read -- so a conditional step can never be
+        shown by one path and skipped by another.
+        """
+        steps = config.steps
+        while session.current_step_index < len(steps):
+            if self.condition_holds(steps[session.current_step_index], session.collected_config):
+                return
+            logger.info(
+                f"[CONDITION] Skipping step {steps[session.current_step_index].step_id!r}: "
+                f"condition not met"
+            )
+            session.current_step_index += 1
+
+    def current_step(self, session: AdapterConfigSession) -> Optional[ConfigurationStep]:
+        """The step to present now, with unsatisfied conditions skipped. None when done."""
+        config = self._adapter_manifests[session.adapter_type]
+        self.skip_unsatisfied(session, config)
+        if session.current_step_index >= len(config.steps):
+            return None
+        return config.steps[session.current_step_index]
 
     async def execute_step(
         self,
@@ -213,14 +280,19 @@ class AdapterConfigurationService:
             return StepResult(step_id="", success=False, error="Session expired")
 
         config = self._adapter_manifests[session.adapter_type]
-        if session.current_step_index >= len(config.steps):
+        step = self.current_step(session)
+        if step is None:
             return StepResult(step_id="", success=False, error="No more steps")
-
-        step = config.steps[session.current_step_index]
         adapter = self._adapter_instances[session.adapter_type]
 
         try:
             result = await self._execute_step_type(session, step, adapter, step_data)
+            # An advance may land on a step whose condition is now decidable
+            # and false; move past it so `next_step_index` names a step that
+            # will actually be shown.
+            if result.success and result.next_step_index is not None:
+                self.skip_unsatisfied(session, config)
+                result.next_step_index = session.current_step_index
             session.update()
             return result
         except Exception as e:
@@ -380,9 +452,21 @@ class AdapterConfigurationService:
         if selection == "skip":
             selection = ""
 
-        if selection is not None and (selection or getattr(step, "optional", False)):
+        # ONE AXIS. This read a retired `optional` key; a select step may be
+        # skipped with an empty selection iff it is not required.
+        if selection is not None and (selection or not step.required):
             # Advance: has selection, OR optional step with empty/skip selection
-            session.collected_config[step.step_id] = selection if selection else ""
+            value = selection if selection else ""
+            session.collected_config[step.step_id] = value
+            # A SELECT STEP WRITES THE FIELD IT DECLARES. Adapters read the
+            # declared name (`dialect`, `response_mode`, `auth_method`), and
+            # `condition` predicates name it too -- but only the step_id was
+            # ever stored, so external_data_sql's validate_config failed with
+            # "dialect is required" on a completed wizard and mock_llm's
+            # response_mode never reached the environment. The step_id key is
+            # kept for anything that reads it.
+            for f in step.fields or []:
+                session.collected_config[f.name] = value
             session.current_step_index += 1
             logger.info(
                 f"[SELECT STEP] Stored selection for {step.step_id} (value='{selection}'), advancing to step {session.current_step_index}"
@@ -416,11 +500,18 @@ class AdapterConfigurationService:
         if step.fields:
             for f in step.fields:
                 if f.required:
-                    field_key = f.name or f.field_id
-                    if field_key:
-                        required_fields.append(field_key)
+                    required_fields.append(f.name)
 
         missing_required = [field for field in required_fields if not step_data.get(field)]
+
+        # STEP-LEVEL `required` WAS DECORATIVE. Only field-level required was
+        # checked, so a step marked required with all-optional fields advanced
+        # on an empty form. A required step needs at least one answer.
+        if step.required and not any(step_data.values()):
+            logger.warning(f"[INPUT STEP] Step {step.step_id!r} is required and received no values")
+            return StepResult(
+                step_id=step.step_id, success=False, error=f"Step {step.step_id!r} is required"
+            )
 
         if missing_required:
             logger.warning(f"[INPUT STEP] Missing required fields: {missing_required}")

--- a/ciris_engine/logic/services/runtime/adapter_configuration/service.py
+++ b/ciris_engine/logic/services/runtime/adapter_configuration/service.py
@@ -224,9 +224,9 @@ class AdapterConfigurationService:
             return False
         actual = collected[field]
         if "equals" in cond:
-            return actual == cond["equals"]
+            return bool(actual == cond["equals"])
         if "not_equals" in cond:
-            return actual != cond["not_equals"]
+            return bool(actual != cond["not_equals"])
         if "values" in cond:
             return actual in (cond["values"] or [])
         # A predicate with no recognised operator is a manifest error, and a

--- a/ciris_engine/schemas/runtime/manifest.py
+++ b/ciris_engine/schemas/runtime/manifest.py
@@ -143,9 +143,13 @@ class AdapterDeviceAuthConfig(BaseModel):
 class ConfigurationFieldDefinition(BaseModel):
     """Definition of a field within an input step."""
 
-    # Field identification - supports both 'name' and 'field_id' patterns
-    name: Optional[str] = Field(None, description="Field name (alternative to field_id)")
-    field_id: Optional[str] = Field(None, description="Field identifier (alternative to name)")
+    # ONE KEY FOR THE FIELD'S IDENTITY. This carried `name` AND `field_id` as
+    # alternatives, both optional, so a field could have neither -- and 15 of
+    # 58 fields in the tree used one spelling while 43 used the other. Two
+    # spellings of one fact is how a reader ends up matching on the wrong one.
+    # `name` is required; `field_id` retires (migrated by
+    # tools/dev/migrate_interactive_config.py). CIRISClient#39.
+    name: str = Field(..., description="Field name -- the key this field writes")
     label: Optional[str] = Field(None, description="Human-readable label for the field")
 
     # Field type and input
@@ -164,6 +168,14 @@ class ConfigurationFieldDefinition(BaseModel):
 
     # Conditional display
     depends_on: Optional[Dict[str, Any]] = Field(None, description="Conditional display based on other fields")
+    # DECLARED BECAUSE THEY ARE USED. `options` is read by the client's
+    # ConfigFieldData; `sensitive` and `readonly` are written by manifests. With
+    # extra="allow" an undeclared key validates silently, and silence is how
+    # `field_id`, `field_name` and `optional` drifted in. The manifest lint
+    # rejects any key not declared here.
+    options: Optional[List[Any]] = Field(None, description="Static choices for a select-style field")
+    sensitive: bool = Field(False, description="Value is a secret: mask it, never log it")
+    readonly: bool = Field(False, description="Shown but not editable")
 
     model_config = ConfigDict(extra="allow", defer_build=True)  # Allow additional field-specific properties
 
@@ -203,24 +215,34 @@ class ConfigurationStep(BaseModel):
     )
     dynamic_fields: bool = Field(False, description="Whether fields are dynamically generated")
 
-    # Input step fields - simple single field (alternative to 'fields' list)
-    field: Optional[str] = Field(None, description="Single field name (simple input)")
-    field_name: Optional[str] = Field(None, description="Configuration field name for input/select steps")
+    # CONTENTS ARE ALWAYS `fields`. Three keys used to name what a step
+    # collects: `fields` (a list), `field_name` (one name, on select steps)
+    # and `field` (declared, used by nothing). A single field is a list of
+    # one, and a select step's output is a field like any other. `field` and
+    # `field_name` retire; the migration rewrites `field_name: x` as
+    # `fields: [{name: x}]`. CIRISClient#39.
     input_type: Optional[str] = Field(None, description="Input type (text, password, number)")
     placeholder: Optional[str] = Field(None, description="Placeholder text")
 
-    # Step requirements and flow control
+    # ONE AXIS, ONE KEY. This carried `required` AND `optional`, both
+    # defaulting to False, so a step with neither was "not required and not
+    # optional" -- a third state the schema permitted and no reader could act
+    # on. One step in the tree carried both. `optional` retires; absent means
+    # not required, and that is the only thing absence can mean. CIRISClient#39.
     required: bool = Field(False, description="Whether this step is required")
-    optional: bool = Field(False, description="Whether this step/field is optional")
     default: Optional[Any] = Field(None, description="Default value for the field")
     validation: Optional[Dict[str, Any]] = Field(None, description="Validation rules (e.g., min, max, pattern)")
 
-    # Dependencies - supports both list of step_ids and conditional dict
-    depends_on: Optional[Union[List[str], Dict[str, Any]]] = Field(
-        None, description="Step dependencies - list of step_ids or conditional dict"
+    # TWO CONCEPTS, TWO KEYS, EACH ONE SHAPE. `depends_on` is ORDERING: the
+    # step ids that must complete first. `condition` is DISPLAY: a predicate
+    # on a collected value. external_data_sql uses both on one step and
+    # means both. What drifted was `depends_on` also admitting a dict that
+    # nothing wrote -- one key, two shapes. It is a list now.
+    depends_on: Optional[List[str]] = Field(
+        None, description="Step ids that must complete before this one"
     )
     condition: Optional[Dict[str, Any]] = Field(
-        None, description="Condition for showing this step (e.g., {field: 'x', equals: 'y'})"
+        None, description="Predicate on a collected value for showing this step (e.g., {field: 'x', equals: 'y'})"
     )
 
     # Confirm step fields

--- a/tests/adapters/api/test_adapter_config_ownership.py
+++ b/tests/adapters/api/test_adapter_config_ownership.py
@@ -60,6 +60,9 @@ async def test_owner_is_allowed():
     manifest = MagicMock()
     manifest.steps = []
     config_service._adapter_manifests = {"discord": manifest}
+    # The route reads the current step THROUGH the service (conditions are
+    # evaluated there); an empty manifest has no current step.
+    config_service.current_step.return_value = None
 
     with patch.object(adapter_config, "get_adapter_config_service", return_value=config_service):
         result = await adapter_config.get_configuration_status(
@@ -77,6 +80,9 @@ async def test_setup_wizard_bypasses_ownership():
     manifest = MagicMock()
     manifest.steps = []
     config_service._adapter_manifests = {"discord": manifest}
+    # The route reads the current step THROUGH the service (conditions are
+    # evaluated there); an empty manifest has no current step.
+    config_service.current_step.return_value = None
 
     with patch.object(adapter_config, "get_adapter_config_service", return_value=config_service):
         result = await adapter_config.get_configuration_status(

--- a/tests/ciris_adapters/test_interactive_config_lint.py
+++ b/tests/ciris_adapters/test_interactive_config_lint.py
@@ -1,0 +1,195 @@
+"""
+Every `interactive_config` in the tree is a program in one small language.
+
+This is its compiler's front end: every key is one the schema declares, every
+axis has one spelling, every reference points at something that exists and
+comes earlier. A manifest that fails here would have rendered on the client
+as a step with no fields, a condition nothing evaluates, or a `required` that
+disagrees with an `optional` -- all of which shipped before this file existed
+(CIRISClient#39).
+
+The rules are checked against the DATA, not against a regex over the text, so
+a new manifest gets the same treatment as the migrated ones.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Set
+
+import pytest
+
+from ciris_engine.schemas.runtime.manifest import (
+    ConfigurationFieldDefinition,
+    ConfigurationStep,
+    InteractiveConfiguration,
+)
+
+REPO = Path(__file__).resolve().parents[2]
+MANIFESTS = sorted(REPO.glob("ciris_adapters/*/manifest.json"))
+
+# Retired spellings. Each was a second way to say something the schema already
+# said; the migration collapsed them and this keeps them out.
+RETIRED_STEP_KEYS = {"optional", "field", "field_name"}
+RETIRED_FIELD_KEYS = {"field_id"}
+
+# Documentation keys the language permits anywhere. Nothing reads them.
+DOC_KEYS = {"_comment"}
+
+STEP_KEYS = set(ConfigurationStep.model_fields) | DOC_KEYS
+FIELD_KEYS = set(ConfigurationFieldDefinition.model_fields) | DOC_KEYS
+IC_KEYS = set(InteractiveConfiguration.model_fields) | DOC_KEYS | {
+    # Top-level documentation blocks one manifest carries; harmless, unread.
+    "_step_types_reference",
+    "_field_types_reference",
+    # Where the configurable class lives, for loaders that need it.
+    "configurable_class",
+}
+
+# What each step type writes into collected_config besides its declared
+# fields. Mirrors AdapterConfigurationService; a condition may name these.
+IMPLICIT_WRITES = {
+    "discovery": {"base_url"},
+    "oauth": {"oauth_tokens", "base_url"},
+    "device_auth": {"oauth_tokens"},
+}
+
+CONDITION_OPERATORS = {"equals", "not_equals", "values"}
+
+
+def _load_migrator():
+    spec = importlib.util.spec_from_file_location(
+        "migrate_interactive_config", REPO / "tools" / "dev" / "migrate_interactive_config.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _configs() -> Iterator[tuple[Path, Dict[str, Any]]]:
+    for path in MANIFESTS:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        ic = data.get("interactive_config")
+        if ic:
+            yield path, ic
+
+
+CONFIGS = list(_configs())
+IDS = [p.parent.name for p, _ in CONFIGS]
+
+
+def test_the_language_is_in_use() -> None:
+    # If this ever drops to zero the rest of the file is vacuous.
+    assert len(CONFIGS) >= 20, [p.parent.name for p, _ in CONFIGS]
+
+
+@pytest.mark.parametrize(("path", "ic"), CONFIGS, ids=IDS)
+def test_validates_as_interactive_configuration(path: Path, ic: Dict[str, Any]) -> None:
+    InteractiveConfiguration.model_validate(ic)
+
+
+@pytest.mark.parametrize(("path", "ic"), CONFIGS, ids=IDS)
+def test_every_key_is_declared(path: Path, ic: Dict[str, Any]) -> None:
+    """extra="allow" means an undeclared key validates silently. Not here."""
+    problems: List[str] = []
+    for k in ic:
+        if k not in IC_KEYS:
+            problems.append(f"interactive_config.{k}")
+    for step in ic["steps"]:
+        for k in step:
+            if k in RETIRED_STEP_KEYS:
+                problems.append(f"{step['step_id']}.{k} is RETIRED -- run tools/dev/migrate_interactive_config.py")
+            elif k not in STEP_KEYS:
+                problems.append(f"{step['step_id']}.{k} is not a ConfigurationStep key")
+        for field in step.get("fields") or []:
+            fid = f"{step['step_id']}.fields[{field.get('name', '?')}]"
+            for k in field:
+                if k in RETIRED_FIELD_KEYS:
+                    problems.append(f"{fid}.{k} is RETIRED")
+                elif k not in FIELD_KEYS:
+                    problems.append(f"{fid}.{k} is not a ConfigurationFieldDefinition key")
+    assert not problems, "\n".join(problems)
+
+
+@pytest.mark.parametrize(("path", "ic"), CONFIGS, ids=IDS)
+def test_step_ids_are_unique_and_fields_are_named(path: Path, ic: Dict[str, Any]) -> None:
+    seen: Set[str] = set()
+    for step in ic["steps"]:
+        assert step["step_id"] not in seen, f"duplicate step_id {step['step_id']!r}"
+        seen.add(step["step_id"])
+        for field in step.get("fields") or []:
+            assert field.get("name"), f"{step['step_id']}: a field with no name writes nothing"
+
+
+@pytest.mark.parametrize(("path", "ic"), CONFIGS, ids=IDS)
+def test_references_point_backwards_at_things_that_exist(path: Path, ic: Dict[str, Any]) -> None:
+    """A step may depend on, or condition on, only what an EARLIER step produced.
+
+    `depends_on` names step_ids. `condition.field` names a key in
+    collected_config, which is: a field declared on any earlier step (select
+    steps write their declared field), or what a discovery/oauth step writes.
+    A forward or dangling reference is a step that can never be reached.
+    """
+    earlier_ids: Set[str] = set()
+    written: Set[str] = set()
+    problems: List[str] = []
+    for step in ic["steps"]:
+        sid = step["step_id"]
+        for dep in step.get("depends_on") or []:
+            if dep not in earlier_ids:
+                problems.append(f"{sid}.depends_on names {dep!r}, which is not an earlier step")
+        cond = step.get("condition")
+        if cond:
+            ops = CONDITION_OPERATORS & set(cond)
+            if len(ops) != 1:
+                problems.append(f"{sid}.condition needs exactly one of {sorted(CONDITION_OPERATORS)}, has {sorted(ops)}")
+            field = cond.get("field")
+            if field not in written:
+                problems.append(
+                    f"{sid}.condition reads {field!r}, which no earlier step writes "
+                    f"(written so far: {sorted(written)}) -- the step could never be shown"
+                )
+        earlier_ids.add(sid)
+        written |= {f["name"] for f in step.get("fields") or [] if f.get("name")}
+        written |= IMPLICIT_WRITES.get(step["step_type"], set())
+    assert not problems, "\n".join(problems)
+
+
+@pytest.mark.parametrize(("path", "ic"), CONFIGS, ids=IDS)
+def test_select_steps_declare_what_they_write(path: Path, ic: Dict[str, Any]) -> None:
+    """A select step with no declared field writes only its step_id.
+
+    That is allowed, but then nothing downstream may `condition` on a
+    friendlier name -- covered above. This documents which selects are
+    step_id-only so a new `condition` on one of them fails loudly there.
+    """
+    for step in ic["steps"]:
+        if step["step_type"] == "select":
+            fields = step.get("fields") or []
+            assert len(fields) <= 1, f"{step['step_id']}: a select writes ONE value; it declares {len(fields)} fields"
+
+
+def test_migration_is_a_fixed_point() -> None:
+    """Running the migrator over the tree changes nothing. `--check` for CI."""
+    mig = _load_migrator()
+    for path, _ in CONFIGS:
+        text = path.read_text(encoding="utf-8")
+        data = json.loads(text)
+        assert mig.migrate_manifest(data) == data, f"{path.parent.name}: migration is not applied"
+        assert mig.patch_text(text) == text, f"{path.parent.name}: text patch would change the file"
+
+
+def test_schema_has_one_key_per_axis() -> None:
+    """The three drifts, as schema facts, so they cannot come back."""
+    step = set(ConfigurationStep.model_fields)
+    field = set(ConfigurationFieldDefinition.model_fields)
+    assert "required" in step and "optional" not in step
+    assert "fields" in step and "field" not in step and "field_name" not in step
+    assert "name" in field and "field_id" not in field
+    assert ConfigurationFieldDefinition.model_fields["name"].is_required()
+    # depends_on is a list of step ids, nothing else
+    assert "List" in str(ConfigurationStep.model_fields["depends_on"].annotation)
+    assert "Dict" not in str(ConfigurationStep.model_fields["depends_on"].annotation)

--- a/tests/ciris_engine/logic/services/runtime/test_adapter_configuration.py
+++ b/tests/ciris_engine/logic/services/runtime/test_adapter_configuration.py
@@ -1453,3 +1453,216 @@ class TestDeviceAuthConfigSchema:
         assert step.device_auth_config is not None
         assert step.device_auth_config.provider_name == "CIRISPortal"
         assert step.device_auth_config.poll_interval == 10
+
+
+# ── the manifest language is ENFORCED, not merely parsed ─────────────────────
+#
+# `condition`, step-level `required`, and a select step's declared field were
+# all read by the schema and acted on by nothing (CIRISClient#39). These pin
+# the behaviour that gives the keys their meaning.
+
+
+def _sql_like_config() -> InteractiveConfiguration:
+    """external_data_sql's shape: one select, two mutually exclusive input steps."""
+    return InteractiveConfiguration(
+        required=True,
+        workflow_type="wizard",
+        steps=[
+            ConfigurationStep(
+                step_id="select_dialect",
+                step_type="select",
+                title="Dialect",
+                description="",
+                options_method="get_config_options",
+                fields=[{"name": "dialect"}],
+                required=True,
+            ),
+            ConfigurationStep(
+                step_id="connection_sqlite",
+                step_type="input",
+                title="SQLite",
+                description="",
+                fields=[{"name": "database_path", "required": True}],
+                condition={"field": "dialect", "equals": "sqlite"},
+            ),
+            ConfigurationStep(
+                step_id="connection_server",
+                step_type="input",
+                title="Server",
+                description="",
+                fields=[{"name": "host", "required": True}],
+                condition={"field": "dialect", "not_equals": "sqlite"},
+            ),
+            ConfigurationStep(
+                step_id="api_keys",
+                step_type="input",
+                title="Keys",
+                description="",
+                fields=[{"name": "api_keys"}],
+                condition={"field": "dialect", "values": ["mssql", "postgres"]},
+            ),
+            ConfigurationStep(step_id="confirm", step_type="confirm", title="Confirm", description=""),
+        ],
+        completion_method="apply_config",
+    )
+
+
+class TestConditionsAreEvaluated:
+    def setup_method(self) -> None:
+        self.service = AdapterConfigurationService()
+        self.adapter = MockConfigurableAdapter()
+        self.service.register_adapter_config("sql", _sql_like_config(), self.adapter)
+
+    @pytest.mark.asyncio
+    async def test_choosing_sqlite_shows_the_sqlite_step_and_skips_the_server_step(self) -> None:
+        session = await self.service.start_session("sql", "u")
+        result = await self.service.execute_step(session.session_id, {"selection": "sqlite"})
+        assert result.success
+        step = self.service.current_step(session)
+        assert step is not None and step.step_id == "connection_sqlite"
+        assert result.next_step_index == session.current_step_index
+
+        result = await self.service.execute_step(session.session_id, {"database_path": "/x.db"})
+        assert result.success
+        # connection_server (not_equals sqlite) and api_keys (values) both fail: land on confirm
+        step = self.service.current_step(session)
+        assert step is not None and step.step_id == "confirm", step.step_id
+
+    @pytest.mark.asyncio
+    async def test_choosing_postgres_skips_sqlite_and_shows_both_server_steps(self) -> None:
+        session = await self.service.start_session("sql", "u")
+        await self.service.execute_step(session.session_id, {"selection": "postgres"})
+        assert self.service.current_step(session).step_id == "connection_server"
+        await self.service.execute_step(session.session_id, {"host": "db"})
+        assert self.service.current_step(session).step_id == "api_keys"
+
+    @pytest.mark.asyncio
+    async def test_a_select_writes_the_field_it_declares(self) -> None:
+        # THE BUG. Adapters read `dialect`; only `select_dialect` was stored, so
+        # validate_config said "dialect is required" after a completed wizard.
+        session = await self.service.start_session("sql", "u")
+        await self.service.execute_step(session.session_id, {"selection": "sqlite"})
+        assert session.collected_config["dialect"] == "sqlite"
+        assert session.collected_config["select_dialect"] == "sqlite"  # kept for old readers
+
+    def test_a_condition_on_an_uncollected_field_does_not_hold(self) -> None:
+        # Showing a step before the answer it hangs on exists is asking out of
+        # order. The lint guarantees the field is written EARLIER, so in a
+        # well-formed manifest this only happens on start_step_id jumps.
+        step = _sql_like_config().steps[1]
+        assert self.service.condition_holds(step, {}) is False
+        assert self.service.condition_holds(step, {"dialect": "sqlite"}) is True
+        assert self.service.condition_holds(step, {"dialect": "mysql"}) is False
+
+    def test_the_three_operators_and_nothing_else(self) -> None:
+        mk = lambda cond: ConfigurationStep(step_id="s", step_type="input", title="", description="", condition=cond)
+        assert self.service.condition_holds(mk({"field": "a", "not_equals": 1}), {"a": 2})
+        assert not self.service.condition_holds(mk({"field": "a", "not_equals": 1}), {"a": 1})
+        assert self.service.condition_holds(mk({"field": "a", "values": [1, 2]}), {"a": 2})
+        assert not self.service.condition_holds(mk({"field": "a", "values": []}), {"a": 2})
+        assert self.service.condition_holds(mk(None), {})
+        with pytest.raises(ValueError):
+            # A predicate with no operator must not silently show OR hide.
+            self.service.condition_holds(mk({"field": "a", "matches": "x"}), {"a": "x"})
+
+    @pytest.mark.asyncio
+    async def test_a_conditional_first_step_is_skipped_on_start(self) -> None:
+        cfg = InteractiveConfiguration(
+            required=True,
+            workflow_type="wizard",
+            steps=[
+                ConfigurationStep(
+                    step_id="reauth_only",
+                    step_type="input",
+                    title="",
+                    description="",
+                    fields=[{"name": "token"}],
+                    condition={"field": "base_url", "equals": "https://old"},
+                ),
+                ConfigurationStep(step_id="confirm", step_type="confirm", title="", description=""),
+            ],
+            completion_method="apply_config",
+        )
+        self.service.register_adapter_config("re", cfg, self.adapter)
+        fresh = await self.service.start_session("re", "u")
+        assert fresh.current_step_index == 1, "no base_url collected: the conditional step must not be shown"
+        again = await self.service.start_session("re", "u", existing_config={"base_url": "https://old"})
+        assert again.current_step_index == 0, "existing_config is folded in BEFORE conditions are evaluated"
+
+    @pytest.mark.asyncio
+    async def test_status_and_execute_agree_on_the_current_step(self) -> None:
+        # One evaluator. The status route reads through current_step(); if it
+        # read the raw index it would report connection_server while execute
+        # was about to run confirm.
+        session = await self.service.start_session("sql", "u")
+        await self.service.execute_step(session.session_id, {"selection": "sqlite"})
+        await self.service.execute_step(session.session_id, {"database_path": "/x.db"})
+        raw = _sql_like_config().steps[session.current_step_index].step_id
+        assert raw == "confirm"
+        assert self.service.current_step(session).step_id == "confirm"
+
+
+class TestRequiredIsEnforced:
+    def setup_method(self) -> None:
+        self.service = AdapterConfigurationService()
+        self.adapter = MockConfigurableAdapter()
+
+    def _one_step(self, step: ConfigurationStep) -> None:
+        cfg = InteractiveConfiguration(
+            required=True,
+            workflow_type="wizard",
+            steps=[step, ConfigurationStep(step_id="confirm", step_type="confirm", title="", description="")],
+            completion_method="apply_config",
+        )
+        self.service.register_adapter_config("t", cfg, self.adapter)
+
+    @pytest.mark.asyncio
+    async def test_a_required_input_step_refuses_an_empty_form(self) -> None:
+        # Step-level `required` was decorative: only field-level was checked, so a
+        # required step whose fields are all optional advanced on {}.
+        self._one_step(
+            ConfigurationStep(
+                step_id="ua", step_type="input", title="", description="", required=True, fields=[{"name": "user_agent"}]
+            )
+        )
+        s = await self.service.start_session("t", "u")
+        r = await self.service.execute_step(s.session_id, {})
+        assert not r.success and "required" in (r.error or "")
+        assert s.current_step_index == 0
+        r = await self.service.execute_step(s.session_id, {"user_agent": "CIRIS/1.0"})
+        assert r.success and s.current_step_index == 1
+
+    @pytest.mark.asyncio
+    async def test_an_optional_input_step_advances_on_an_empty_form(self) -> None:
+        self._one_step(
+            ConfigurationStep(step_id="perf", step_type="input", title="", description="", fields=[{"name": "timeout"}])
+        )
+        s = await self.service.start_session("t", "u")
+        r = await self.service.execute_step(s.session_id, {})
+        assert r.success and s.current_step_index == 1
+
+    @pytest.mark.asyncio
+    async def test_a_select_is_skippable_iff_it_is_not_required(self) -> None:
+        self._one_step(
+            ConfigurationStep(
+                step_id="opt", step_type="select", title="", description="", options_method="get_config_options"
+            )
+        )
+        s = await self.service.start_session("t", "u")
+        r = await self.service.execute_step(s.session_id, {"selection": "skip"})
+        assert r.success and s.current_step_index == 1
+
+        self._one_step(
+            ConfigurationStep(
+                step_id="req",
+                step_type="select",
+                title="",
+                description="",
+                options_method="get_config_options",
+                required=True,
+            )
+        )
+        s = await self.service.start_session("t", "u")
+        r = await self.service.execute_step(s.session_id, {"selection": "skip"})
+        # Not advanced: the service falls through to "fetch options for display".
+        assert s.current_step_index == 0

--- a/tools/dev/migrate_interactive_config.py
+++ b/tools/dev/migrate_interactive_config.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Rewrite `interactive_config` steps to one key per axis (CIRISClient#39).
+
+    python3 tools/dev/migrate_interactive_config.py            # rewrite in place
+    python3 tools/dev/migrate_interactive_config.py --check    # exit 1 if any would change
+
+Five drifts, all structural -- in the schema, so every future step inherited
+them. Each rule below is a pure function so the edge cases can be tested:
+
+  optional/required   both defaulted False; a step with neither was a third
+                      state nobody could act on. -> `required` only.
+  field/field_name    three ways to name what a step collects; `field` was
+                      declared and used by nothing. -> `fields` only.
+  depends_on          admitted a dict nothing wrote. -> a list of step ids.
+  field_id/name       two spellings for a field's identity, 15 vs 43. -> `name`.
+
+IDEMPOTENT: running it twice changes nothing the second time, which is what
+lets `--check` guard CI.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def migrate_required(step: dict) -> dict:
+    """`optional`/`required` -> `required`. A step carrying both must agree."""
+    if "optional" not in step:
+        return step
+    opt = step.pop("optional")
+    if "required" in step:
+        if step["required"] == opt:
+            raise ValueError(
+                f"{step.get('step_id')}: optional={opt} and required={step['required']} "
+                f"contradict each other; fix the manifest by hand"
+            )
+        return step  # `required` already says it
+    step["required"] = not opt
+    return step
+
+
+def migrate_fields(step: dict) -> dict:
+    """`field_name` (and dead `field`) -> `fields: [{name}]`."""
+    step.pop("field", None)
+    if "field_name" not in step:
+        return step
+    name = step.pop("field_name")
+    if "fields" in step:
+        raise ValueError(f"{step.get('step_id')}: has both field_name and fields")
+    step["fields"] = [{"name": name}]
+    return step
+
+
+def migrate_depends_on(step: dict) -> dict:
+    """`depends_on` is ORDERING (a list of step ids). A dict there is a
+    DISPLAY PREDICATE in the wrong slot, and it moves to `condition`.
+
+    Exactly one existed: mcp_server/api_keys carried
+    `depends_on: {"field": "auth_method", "values": ["api_key"]}` -- "show this
+    step when auth_method is api_key". That is what `condition` is for. Its
+    `values` form (membership) is kept alongside condition's `equals` /
+    `not_equals`; they are all predicates on a collected value.
+    """
+    d = step.get("depends_on")
+    if isinstance(d, dict):
+        if "field" not in d:
+            raise ValueError(
+                f"{step.get('step_id')}: depends_on is a dict without `field`; "
+                f"cannot tell whether it is ordering or a predicate -- fix by hand"
+            )
+        if "condition" in step:
+            raise ValueError(f"{step.get('step_id')}: has a dict depends_on AND a condition")
+        step["condition"] = step.pop("depends_on")
+    return step
+
+
+def migrate_field_ids(step: dict) -> dict:
+    """Field-level `field_id` -> `name`."""
+    for f in step.get("fields") or []:
+        if isinstance(f, dict) and "field_id" in f:
+            fid = f.pop("field_id")
+            if "name" in f and f["name"] != fid:
+                raise ValueError(f"{step.get('step_id')}: field has name={f['name']} and field_id={fid}")
+            f["name"] = fid
+    return step
+
+
+def migrate_step(step: dict) -> dict:
+    for rule in (migrate_required, migrate_fields, migrate_depends_on, migrate_field_ids):
+        step = rule(step)
+    return step
+
+
+def migrate_manifest(data: dict) -> dict:
+    ic = data.get("interactive_config")
+    if isinstance(ic, dict):
+        ic["steps"] = [migrate_step(s) for s in ic.get("steps", [])]
+    return data
+
+
+def patch_text(before: str) -> str:
+    """Rewrite ONLY the lines that carry a retired key; every other byte stays.
+
+    WHY NOT RE-SERIALISE. 49 of the 64 manifests are hand-formatted with MIXED
+    styles inside one file -- some arrays inline, some expanded -- so no
+    emitter reproduces them, and the first cut of this migration rewrote 50
+    files to change 22. A diff nobody can review is a migration nobody can
+    verify, and "reviewable" is requirement 4 of the language it serves
+    (CIRISClient#39).
+
+    Each substitution is same-line and preserves indentation, spacing and the
+    trailing comma. All four retired keys occur ONLY inside interactive_config
+    steps (checked across every manifest), so nothing else can match.
+
+    THIS IS NOT THE SOURCE OF TRUTH. `migrate_manifest` is, and `main` refuses
+    to write any file where `json.loads(patch_text(x)) != migrate_manifest(x)`.
+    Two independent implementations must agree, or nothing happens.
+    """
+    import re
+
+    text = before
+    # optional -> required, in place. The sense inverts.
+    text = re.sub(r'"optional":\s*true', '"required": false', text)
+    text = re.sub(r'"optional":\s*false', '"required": true', text)
+    # A step that carried BOTH now has two adjacent `required` lines; keep the
+    # first, which was the original `required`. (One instance in the tree; the
+    # oracle check below catches any shape this misses.)
+    text = re.sub(
+        r'(\n[ \t]*"required":\s*(?:true|false),)\n[ \t]*"required":\s*(?:true|false),',
+        r"\1", text,
+    )
+    # field_name -> a one-field list, on the same line.
+    text = re.sub(r'"field_name":\s*("(?:[^"\\]|\\.)*")', r'"fields": [{"name": \1}]', text)
+    # A dict in the STEP-level ordering slot is a display predicate: rename the
+    # key only. Scoped to the step's own indentation, read from this file's
+    # `"step_id"` lines, because ConfigurationFieldDefinition legitimately has
+    # its own dict-shaped `depends_on` one level deeper -- mcp_server carries
+    # both on the same screen (line 137 is the step, 94 and 106 are fields),
+    # and a blind rename rewrote the fields too. The oracle caught it.
+    m = re.search(r'^([ \t]*)"step_id":', text, re.M)
+    if m:
+        indent = re.escape(m.group(1))
+        text = re.sub(rf'^({indent})"depends_on":(\s*)\{{', r'\1"condition":\2{', text, flags=re.M)
+    # field_id -> name.
+    text = re.sub(r'"field_id":', '"name":', text)
+    return text
+
+
+def main(argv: list[str]) -> int:
+    check = "--check" in argv
+    changed = []
+    for path in sorted((ROOT / "ciris_adapters").glob("*/manifest.json")):
+        before = path.read_text(encoding="utf-8")
+        original = json.loads(before)
+        oracle = migrate_manifest(json.loads(before))
+        if oracle == original:
+            continue  # nothing retired here; the file is not touched
+        after = patch_text(before)
+        # THE ORACLE. The text patch must produce exactly the data the
+        # data-level migration produces, or this refuses to write anything.
+        try:
+            patched = json.loads(after)
+        except json.JSONDecodeError as e:
+            raise SystemExit(f"{path}: text patch produced invalid JSON: {e}")
+        if patched != oracle:
+            raise SystemExit(
+                f"{path}: the text patch and the data migration disagree; "
+                f"refusing to write. Fix patch_text or migrate the file by hand."
+            )
+        if after != before:
+            changed.append(path.relative_to(ROOT))
+            if not check:
+                path.write_text(after, encoding="utf-8")
+    if check and changed:
+        print("::error::these manifests still carry a retired interactive_config key:")
+        for c in changed:
+            print(f"  {c}")
+        print("  Run tools/dev/migrate_interactive_config.py")
+        return 1
+    print(f"{'would change' if check else 'migrated'} {len(changed)} manifest(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## What

The adapter wizard language (`interactive_config`) had three structural drifts in its schema and three keys that were parsed and then ignored. This PR makes the schema say each thing one way, migrates the tree mechanically (9 manifests, +40/−41, oracle-verified, idempotent), and gives `condition`, step-level `required`, and a select step's declared field the behaviour their names promise. It is the CIRISAgent half of the design in CIRISClient#39.

## Schema — one spelling per axis

| axis | before | after |
|---|---|---|
| requiredness | `required` **and** `optional`, both default `False` → a step can be "neither" | `required` only |
| what a step writes | `fields` **or** `field` **or** `field_name` | `fields` only; a single field is a list of one |
| field identity | `name` **or** `field_id` | `name`, required |
| ordering / containment | `depends_on: List \| Dict`, plus `condition` | `depends_on: List[step_id]`; `condition` is the one predicate |
| undeclared but used | `options`, `sensitive`, `readonly` slipped through `extra="allow"` | declared on `ConfigurationFieldDefinition` |

`tools/dev/migrate_interactive_config.py` holds the data-level rules (the oracle) and a same-line text patch so the 49 mixed-style manifests keep their formatting; it refuses any file whose patched text does not parse to exactly what the oracle says. `--check` is a CI gate.

## Enforcement — the keys now do something

- **`condition` is evaluated.** Three shapes, exhaustively: `equals`, `not_equals`, `values`. One evaluator (`AdapterConfigurationService.current_step`) is used on start, on advance, and by all three status routes — so a conditional step can never be shown by one path and skipped by another. Before: `external_data_sql` showed *both* its SQLite and server-connection steps to everyone.
- **A select step writes the field it declares.** Adapters read the declared name (`dialect`, `response_mode`, `auth_method`); the engine only ever stored the `step_id`. So `external_data_sql.validate_config` failed with *"dialect is required"* after a completed wizard, `mock_llm`'s `response_mode` never reached the environment, and no `condition` could ever hold. The `step_id` key is kept for anything that reads it.
- **Step-level `required` blocks an empty submission.** Only field-level was checked; a required step with all-optional fields advanced on `{}`.
- Retired reads removed: `getattr(step, "optional")`, `f.name or f.field_id`. `ConfigStepInfo` carries `required`; `optional` stays on the wire, derived, so they cannot disagree.
- `external_data_sql/select_dialect` now declares `fields: [{name: dialect}]` — the lint caught that its two conditional steps read a field nothing wrote.

## Lint — `tests/ciris_adapters/test_interactive_config_lint.py`

113 checks over the 22 manifests: every key declared; no retired key; unique `step_id`s; every field named; `depends_on` names an **earlier** step; `condition.field` is **written** by an earlier step and carries exactly one operator; a select declares at most one field; the migration is a fixed point over the tree; the schema has one key per axis.

## Tests

- `test_adapter_configuration.py`: 65 → 75 (conditions shown/skipped per branch, uncollected field does not hold, three operators and nothing else, conditional first step on start with/without `existing_config`, status and execute agree, required input refuses `{}`, optional advances, select skippable iff not required, select writes its declared field).
- `tests/adapters/api/routes/system`: 130 passed. `tests/adapters` + touched `tests/ciris_adapters`: 415 passed after adapting two ownership-test mocks to the new seam (`config_service.current_step`).

## Client

No client change needed for this to land: CIRISClient maps steps through `mapConfigStep()` with null-tolerant reads of `required` and `fields`, renders select steps from `options_method` results rather than `fields`, and re-fetches the server's `current_step` on every advance — so skipped steps just arrive as the next step. The one visible effect is the step counter ("3 of 5") jumping when a step is skipped.

## Noted, not fixed here

- `mcp_server/manifest.json` declares `options_method: get_config_options` on three select steps but there is no configurable class under `ciris_adapters/mcp_server/` that implements it. The lint validates the manifest; it cannot see that nothing serves it.
- `get_config_schema()` in navigation / mcp_client / a2a duplicates the manifest inline and nothing calls it; migrated for consistency, but it should probably go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Db9uHKMfhnANvagjWSo59x
