### PR TITLE
2.11.1: memory composition, the resource monitor gives memory back, and the five-platform modular gate

### DIFF
--- a/.github/workflows/five-platform-modular-qa.yml
+++ b/.github/workflows/five-platform-modular-qa.yml
@@ -1,0 +1,960 @@
+# The five-platform gate, with the MODULAR QA RUNNER driving instead of the UI.
+#
+# WHY A SECOND FILE. five-platform-live-qa.yml asks the user's question: install
+# the artifact, drive the real UI, get an answer on screen. It proves the path a
+# human takes. It does NOT prove the API contract the client stands on -- auth,
+# agent, system, memory, audit, tools, telemetry -- on the backend a PHONE
+# actually runs: Chaquopy-embedded on Android, the BeeWare bundle on iOS, the
+# desktop app's embedded server on three desktops. Those backends differ from
+# `python main.py` on a Linux runner in allocator, libc, thread model, bundled
+# wheels and file layout, and until now every API-level assertion in this repo
+# ran against the Linux one only.
+#
+# So: the SAME bring-up as the gate -- the steps below through "Build + deploy
+# the iOS app" are copied from it verbatim, and a CI check should keep them so --
+# then `desktop-setup` completes the wizard through the real UI exactly as the
+# gate does, and from there the modular runner (`python -m tools.qa_runner`)
+# takes over against the backend the platform brought up, with --no-auto-start.
+#
+# WHAT MAKES IT A GATE RATHER THAN A REPORT:
+#   * the runner's incidents gate stays CLOSED-FAIL: each platform's
+#     incidents_latest.log is pulled from where that platform writes it
+#     (desktop: $CIRIS_HOME/logs; Android: run-as cat, mirrored every 3 s;
+#     iOS: the app container) and handed over with --incidents-log. A platform
+#     whose log cannot be found fails, it does not pass unchecked.
+#   * a module that cannot run on a platform fails that platform loudly
+#   * the run-without-AI pass is deliberately absent: a node-only install has
+#     no :8080 API for an API suite to talk to
+#
+# WHICH MODULES. Default is the API-only set. Modules that reach into the
+# server's SQLite file, spawn processes or read its log tree from the CWD
+# (setup, secrets_encryption, sql_external_data, multi_occurrence, mesh_repro,
+# handlers, identity_update, context_enrichment, accord, safety_*, he300) cannot
+# work against a backend on another device and are not in the default.
+
+name: Five-Platform Modular QA
+
+on:
+  workflow_dispatch:
+    inputs:
+      platforms:
+        description: "Subset to run (space-separated: linux macos windows android ios), or 'all'"
+        required: false
+        default: "all"
+        type: string
+      modules:
+        description: "QA runner modules to run against each platform's backend (space-separated)"
+        required: false
+        default: "auth agent system memory audit tools guidance telemetry extended_api"
+        type: string
+      use_live_key:
+        description: "Use the real OPENROUTER_API_KEY (off = mock LLM)"
+        required: false
+        default: true
+        type: boolean
+      client_preview_tag:
+        description: "CIRISClient PRERELEASE tag to test instead of the requirements.txt pin. Empty = the pin."
+        required: false
+        default: ""
+        type: string
+
+concurrency:
+  group: five-platform-modular-qa-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # THE iOS BUNDLE, BUILT ONCE. The simulator app needs frameworks for every
+  # native extension the embedded engine imports: the substrate (ciris_server,
+  # a fetch) and four third-party modules (a cross-build no runner had ever
+  # performed). refresh-ios-substrate.yml owns both on the macOS toolchain and
+  # hands the result back as an artifact; the macos-ios leg below downloads it
+  # before building the app (CIRISAgent#1135).
+  ios-bundle:
+    name: iOS bundle (substrate + simulator natives)
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.platforms == '' || inputs.platforms == 'all' || contains(inputs.platforms, 'ios') }}
+    # The reusable workflow declares write scopes for its push path; upload_only
+    # never pushes, so they go unused here, but a caller must still grant them.
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: ./.github/workflows/refresh-ios-substrate.yml
+    with:
+      target_branch: ${{ github.ref_name }}
+      libs: server
+      upload_only: true
+      always_upload: true
+      build_sim_natives: true
+    secrets: inherit
+
+  live-qa:
+    needs: [ios-bundle]
+    # ios-bundle failing (or skipped on a non-iOS dispatch) must not skip the
+    # gate: the mac leg falls back to fetching the substrate itself.
+    if: ${{ !cancelled() }}
+    name: ${{ matrix.label }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 75
+    strategy:
+      # NEVER fail-fast. The entire point is a five-way comparison; killing the
+      # matrix on the first red destroys the gallery that makes it reviewable.
+      fail-fast: false
+      matrix:
+        include:
+          - label: linux-android
+            os: ubuntu-latest
+            platforms: "linux android"
+          - label: macos-ios
+            # macos-15, NOT macos-14. The macos-14 image carries only Xcode 15.4,
+            # while Homebrew's xcodegen (2.45.4) emits pbxproj format 77:
+            #   xcodebuild: error: The project 'iosApp' cannot be opened because
+            #   it is in a future Xcode project file format (77)
+            # Pinning an older xcodegen would silence that, but it would also mean
+            # CI validated a toolchain nobody ships from. macos-15 carries Xcode 16
+            # and matches the generator, so the build here is the build that ships.
+            os: macos-15
+            platforms: "macos ios"
+          - label: windows
+            os: windows-latest
+            platforms: "windows"
+
+    env:
+      CIRIS_TEST_MODE: "true"
+      CIRIS_TESTING_MODE: "true"
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      # Every bring-up command's FULL stdout/stderr lands here, and the collect
+      # step uploads it unconditionally. A CI failure nobody can diagnose from
+      # the artifact costs a re-run with more logging to discover what the first
+      # run already knew.
+      CIRIS_QA_LOG_DIR: ${{ github.workspace }}/artifacts/cmdlogs
+      # Stage lines must carry the time they HAPPENED. Buffered, every "[n/5]"
+      # print of the iOS bring-up flushed together at the end -- all stamped
+      # 02:17:01, including "[5/5] Waiting ... (up to 120s)" -- so the job log
+      # could not place the launch against what os_log showed.
+      PYTHONUNBUFFERED: "1"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      # REFUSE TO TEST A SUBSTRATE THE PHONES WILL NOT RUN. requirements.txt is
+      # one of several ciris-server pin sites: apps/android/build.gradle installs
+      # its own exact pin into the APK, and the iOS bundle is refreshed from the
+      # requirements pin by a separate job. Bumping requirements.txt alone shipped
+      # 0.5.203 to the desktops and 0.5.199 to Android, and the Android leg then
+      # died on the bug 0.5.203 had fixed (run #34223901074) -- forty minutes to
+      # learn what this says in two seconds. The fix hint names the lockstep tool.
+      - name: Substrate pins agree (requirements.txt vs apps/android/build.gradle)
+        shell: bash
+        run: python3 tools/dev/check_version_alignment.py
+
+      # The desktop app ships as the uber-jar INSIDE the pinned ciris-client
+      # wheel and must land in ciris_engine/desktop_app/ BEFORE the wheel is
+      # built — that is what setup.py packages and what desktop_launcher.py
+      # globs at runtime.
+      - name: Vendor the CIRIS Desktop UberJar from the client wheel
+        shell: bash
+        env:
+          # Only needed on the preview path, where the wheels come from a
+          # CIRISClient release rather than PyPI. Same cross-repo public read the
+          # fetch_client_artifacts.py steps already do with this token.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          PREVIEW='${{ inputs.client_preview_tag }}'
+          REQUESTED='${{ inputs.platforms || 'all' }}'
+          MINE='${{ matrix.platforms }}'
+          # A PREVIEW NEED NOT COVER EVERY PLATFORM. This one ships no macosx
+          # wheel, and a `platforms: linux android` dispatch still boots the macOS
+          # runner (the per-leg filter lives further down, inside the run step), so
+          # the mac vendored a wheel for work it was never going to do and failed
+          # the job. If none of THIS runner's platforms were asked for, there is
+          # nothing to vendor. NOT a job-level `if`: the matrix context is not
+          # available there, which is what invalidated the workflow file in
+          # 0216ed4ad.
+          if [ -n "$PREVIEW" ] && [ "$REQUESTED" != "all" ]; then
+            wanted=0
+            for plat in $MINE; do
+              echo " $REQUESTED " | grep -q " $plat " && wanted=1
+            done
+            if [ "$wanted" = 0 ]; then
+              echo "no requested platform on this runner ($MINE); skipping the preview vendor"
+              exit 0
+            fi
+          fi
+          if [ -n "$PREVIEW" ]; then
+            # A preview build is a PRERELEASE on a non-`v<version>` tag whose version
+            # carries a PEP 440 local segment (0.5.208+preview.gNNNNNNN). PyPI refuses
+            # those by design, so `pip download ciris-client==` cannot reach it -- the
+            # wheels come from the release itself. Version is derived from the asset
+            # name rather than typed twice.
+            # ONE WHEEL, THE PLATFORM'S OWN. `--pattern 'ciris_client-*.whl'` pulls
+            # all of them (any + manylinux + win_amd64) and vendor_desktop_jar.py
+            # requires exactly one -- it extracts a PLATFORM-SPECIFIC uber-jar
+            # (CIRIS-linux-x64-*.jar), so "any of them" is not a valid answer. The
+            # pip path this replaces only ever downloads the wheel matching the
+            # host, and this must behave the same.
+            case "${RUNNER_OS}" in
+              Linux)   WHEEL_PAT='ciris_client-*manylinux*.whl' ;;
+              Windows) WHEEL_PAT='ciris_client-*win_amd64*.whl' ;;
+              macOS)   WHEEL_PAT='ciris_client-*macosx*.whl' ;;
+              *)       echo "::error::unknown RUNNER_OS ${RUNNER_OS}"; exit 1 ;;
+            esac
+            gh release download "$PREVIEW" --repo CIRISAI/CIRISClient \
+              --pattern "$WHEEL_PAT" --dir "${RUNNER_TEMP}/clientwheel" || {
+                echo "::error::$PREVIEW has no wheel matching $WHEEL_PAT — a preview that omits this platform cannot be tested on it"
+                exit 1
+              }
+            CLIENT_VERSION=$(ls "${RUNNER_TEMP}/clientwheel" | sed -n 's/^ciris_client-\(.*\)-py3-none-.*\.whl$/\1/p' | head -1)
+            [ -n "$CLIENT_VERSION" ] || { echo "::error::could not derive a version from $PREVIEW assets"; exit 1; }
+            echo "CIRIS_CLIENT_VERSION=$CLIENT_VERSION" >> "$GITHUB_ENV"
+            echo "CIRIS_CLIENT_RELEASE_TAG=$PREVIEW" >> "$GITHUB_ENV"
+            echo "::warning::TESTING A CLIENT PREVIEW: $CLIENT_VERSION from tag $PREVIEW, NOT the requirements.txt pin"
+          else
+            CLIENT_VERSION=$(grep -oE '^ciris-client==[0-9.]+' requirements.txt | cut -d= -f3)
+            python -m pip download "ciris-client==${CLIENT_VERSION}" --no-deps -d "${RUNNER_TEMP}/clientwheel"
+          fi
+          python3 tools/dev/vendor_desktop_jar.py "${RUNNER_TEMP}/clientwheel" ciris_engine/desktop_app "$CLIENT_VERSION"
+
+      # Install the WHEEL, not the checkout: `pip install .` exercises a source
+      # tree no user ever receives.
+      - name: Build and install the wheel
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip build
+          python -m build --wheel --outdir dist
+          python -m pip install "$(ls dist/*.whl | head -1)"
+          python -m pip install requests httpx
+          # The agent wheel Requires the PINNED client, so the line above just pulled
+          # it from PyPI. Put the preview back on top -- --no-deps so pip does not
+          # "fix" the deliberate mismatch by reinstalling the pin.
+          # Only where the vendor step actually fetched one: a subset dispatch
+          # (`platforms: linux android`) boots the macOS runner too, and its vendor
+          # step exits early with nothing in clientwheel/ -- expanding the glob
+          # there under `set -u` failed the job that was meant to be skipped.
+          if [ -n '${{ inputs.client_preview_tag }}' ]; then
+            preview_wheel=$(ls "${RUNNER_TEMP}"/clientwheel/ciris_client-*.whl 2>/dev/null | head -1 || true)
+            if [ -n "$preview_wheel" ]; then
+              python -m pip install --force-reinstall --no-deps "$preview_wheel"
+              python -c "import ciris_client, importlib.metadata as m; print('client in use:', m.version('ciris-client'))"
+            else
+              echo "no preview wheel vendored on this runner (no requested platform here); leaving the pinned client"
+            fi
+          fi
+
+      # ── Linux desktop needs a display. `/screenshot` is AWT Robot, which
+      # photographs a SCREEN; without one there is nothing to photograph and the
+      # app cannot start at all. Xvfb also isolates the capture, which is the
+      # mitigation CIRISAgent#1104 asks for.
+      - name: Start a virtual display (Linux only)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq xvfb
+          Xvfb :99 -screen 0 1600x1200x24 >/dev/null 2>&1 &
+          echo "DISPLAY=:99" >> "$GITHUB_ENV"
+
+      - name: Enable KVM for the Android emulator (Linux only)
+        if: contains(matrix.platforms, 'android')
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules >/dev/null
+          sudo udevadm control --reload-rules && sudo udevadm trigger --name-match=kvm
+
+      # DIAGNOSTIC ONLY — the bring-up boots its own simulator.
+      # An earlier version resolved and booted the UDID here with an inline
+      # python one-liner, which (a) duplicated logic that now lives in
+      # `_ios_pick_simulator` and (b) broke the YAML: its backslash continuation
+      # started at column 1, outside the block scalar. Listing what the runner
+      # has is still worth doing — when iOS fails, "which runtimes existed" is
+      # the first question, and it must be in the log before anything can fail.
+      - name: Show available iOS simulators
+        if: contains(matrix.platforms, 'ios')
+        continue-on-error: true
+        run: |
+          # The generator and the reader must agree on pbxproj format; when they
+          # do not, xcodebuild reports a version NUMBER and nothing about why.
+          echo "xcode:    $(xcodebuild -version | head -1)"
+          echo "selected: $(xcode-select -p)"
+          echo "xcodegen: $(xcodegen --version 2>/dev/null || echo "<not installed yet>")"
+          mkdir -p artifacts/cmdlogs
+          xcode-select -p | tee artifacts/cmdlogs/xcode-select.txt
+          xcrun simctl list devices available | tee artifacts/cmdlogs/simulators.txt
+
+      # The client xcframeworks are gitignored (~108 MB of another repo's build
+      # output), so a clean checkout cannot compile iOS. Same gap as the Android
+      # AAR that left v2.9.42 with no APK — CIRISClient#24 tracks it upstream.
+      - name: Fetch the client xcframeworks (iOS only)
+        # BOTH questions, because they are different: matrix.platforms says
+        # this RUNNER owns ios; inputs.platforms says whether the operator
+        # ASKED for it. Checking only the first meant a `platforms: linux`
+        # dispatch still ran this step — minutes of download, and a step that
+        # can fail the whole workflow — for a platform explicitly excluded.
+        # The subset check existed already, but only INSIDE the flow loop,
+        # long after this had run. Empty = schedule (no inputs) = full run.
+        if: >-
+          contains(matrix.platforms, 'ios')
+          && (inputs.platforms == '' || inputs.platforms == 'all'
+              || contains(inputs.platforms, 'ios'))
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 tools/fetch_client_artifacts.py --platform ios
+
+      # USE THE REAL BUILD SCRIPT. A hand-rolled `xcodebuild -scheme iosApp`
+      # produces a broken app: the .xcodeproj is GENERATED from project.yml by
+      # xcodegen, Resources.zip has to be rebuilt from the overlaid
+      # ciris_engine/ciris_verify sources, and prepare_python_bundle.sh lays down
+      # an ARCH-SPECIFIC Python bundle (simulator != device). This is the script
+      # that has been shipping to the App Store; CI must not maintain a second,
+      # subtly-different copy of it.
+      #
+      # It also installs and launches on the simulator. The bring-up below then
+      # re-launches with CIRIS_TEST_MODE (simctl only forwards env with the
+      # SIMCTL_CHILD_ prefix, which this script does not set), which is idempotent.
+      # ANDROID NEEDS AN EMULATOR THAT THE RUNNER DOES NOT SHIP.
+      # GitHub's ubuntu images carry the Android SDK but NOT the emulator package
+      # and NOT any system image, so bring-up died on
+      #   FileNotFoundError: /usr/local/lib/android/sdk/emulator/emulator
+      # and android has never once run in this gate — its tile has read
+      # "did not run" since the workflow was written.
+      # The APK links against the PUBLISHED client .aar — apps/settings.gradle.kts
+      # resolves it from a flatDir repository at android/libs, and nothing else
+      # puts it there. Only the iOS half was being fetched, so the android build
+      # had no client to link against at all.
+      # CHAQUOPY WANTS PYTHON 3.10 AT AN ABSOLUTE PATH.
+      #
+      # apps/android/build.gradle pins `buildPython "/usr/bin/python3.10"`, which
+      # does not exist on the runner, so the APK build died with
+      #   [/usr/bin/python3.10] is not a valid Python 3.10 command
+      # after the emulator had booted and the .aar had been fetched. build.yml's
+      # android-release job already solves this the same way; the gate was simply
+      # never given the step.
+      #
+      # update-environment: false is the important part. This job runs the QA
+      # runner on 3.12, and letting setup-python prepend 3.10 to PATH would swap
+      # the interpreter the wheel was installed for — fixing the APK build by
+      # breaking everything after it.
+      - name: Set up Python 3.10 for Chaquopy (Android only)
+        id: py310
+        if: >-
+          contains(matrix.platforms, 'android')
+          && (inputs.platforms == '' || inputs.platforms == 'all'
+              || contains(inputs.platforms, 'android'))
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+          update-environment: false
+
+      - name: Symlink python3.10 for Chaquopy (Android only)
+        if: >-
+          contains(matrix.platforms, 'android')
+          && (inputs.platforms == '' || inputs.platforms == 'all'
+              || contains(inputs.platforms, 'android'))
+        run: |
+          set -euo pipefail
+          PY='${{ steps.py310.outputs.python-path }}'
+          [ -n "$PY" ] || { echo '::error::setup-python reported no interpreter path'; exit 1; }
+          sudo ln -sf "$PY" /usr/bin/python3.10
+          # Assert the exact thing gradle will assert, here where it is legible.
+          /usr/bin/python3.10 --version
+
+      - name: Fetch the client .aar (Android only)
+        if: >-
+          contains(matrix.platforms, 'android')
+          && (inputs.platforms == '' || inputs.platforms == 'all'
+              || contains(inputs.platforms, 'android'))
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 tools/fetch_client_artifacts.py --platform android
+
+      - name: Install the Android emulator + system image
+        # BOTH questions, because they are different: matrix.platforms says
+        # this RUNNER owns android; inputs.platforms says whether the operator
+        # ASKED for it. Checking only the first meant a `platforms: linux`
+        # dispatch still ran this step — minutes of download, and a step that
+        # can fail the whole workflow — for a platform explicitly excluded.
+        # The subset check existed already, but only INSIDE the flow loop,
+        # long after this had run. Empty = schedule (no inputs) = full run.
+        if: >-
+          contains(matrix.platforms, 'android')
+          && (inputs.platforms == '' || inputs.platforms == 'all'
+              || contains(inputs.platforms, 'android'))
+        run: |
+          set -euo pipefail
+          SDK="${ANDROID_HOME:-/usr/local/lib/android/sdk}"
+          SDKMAN="$SDK/cmdline-tools/latest/bin/sdkmanager"
+          AVDMAN="$SDK/cmdline-tools/latest/bin/avdmanager"
+          # PIN THE AVD HOME. avdmanager writes to $ANDROID_AVD_HOME, else
+          # $ANDROID_SDK_HOME/.android/avd, else $HOME/.android/avd — and the
+          # emulator resolves that list independently. Leaving both to inference let
+          # them disagree: creation reported success and `-list-avds` came back
+          # empty, so bring-up failed with "no AVDs configured" for an AVD that had
+          # just been created somewhere else.
+          export ANDROID_AVD_HOME="$HOME/.android/avd"
+          mkdir -p "$ANDROID_AVD_HOME"
+          yes | "$SDKMAN" --licenses > /dev/null 2>&1 || true
+          # ~1500 lines of progress bar otherwise; keep the outcome, drop the bar.
+          "$SDKMAN" "platform-tools" "emulator" "$IMAGE" 2>&1 | grep -v "^\[" | tail -5
+          echo no | "$AVDMAN" create avd -n ciris_qa -k "$IMAGE" --force 2>&1 | grep -v "^\[" | tail -5
+
+          # PROVE THE AVD, NOT JUST THE BINARY.
+          #
+          # The previous version asserted `test -x emulator`, then ran `-list-avds`
+          # without looking at the result — so an empty list sailed through as
+          # success and surfaced two steps later as a bring-up error that said
+          # nothing about provisioning. A check whose output nobody reads is not a
+          # check.
+          test -x "$SDK/emulator/emulator" || { echo "::error::emulator still missing after install"; exit 1; }
+          AVDS=$("$SDK/emulator/emulator" -list-avds 2>/dev/null || true)
+          echo "AVD_HOME=$ANDROID_AVD_HOME"
+          echo "avds: ${AVDS:-<none>}"
+          echo "$AVDS" | grep -qx "ciris_qa" || {
+            echo "::error::ciris_qa was created but the emulator cannot see it"
+            ls -la "$ANDROID_AVD_HOME" 2>/dev/null || true
+            exit 1
+          }
+        env:
+          IMAGE: "system-images;android-34;google_apis;x86_64"
+
+
+      # MATERIALIZE THE iOS PYTHON BUNDLE IN THE RUNNER.
+      #
+      # The full build path calls prepare_python_bundle.sh, which copies the
+      # bundle out of a BeeWare app built by `briefcase build iOS`. That can
+      # never run here: `ios/` is untracked (git ls-files ios/ -> 0 files), so
+      # the briefcase project exists only on a machine someone has run
+      # `briefcase create` on. Every iOS run so far died on its absence.
+      #
+      # It does not have to. BOTH halves of what prepare would have produced are
+      # obtainable in-runner:
+      #
+      #   1. the stdlib and app packages ship INSIDE the tracked 28M
+      #      apps/ios/Resources.zip. `apps/ios/Resources/python` looks missing on
+      #      a clean checkout only because the EXTRACTED form is gitignored —
+      #      build.yml already extracts it exactly this way.
+      #
+      #   2. Python.xcframework is not in that zip; briefcase downloads it from
+      #      beeware/Python-Apple-support into its Support/ dir. Fetching the same
+      #      release asset directly gets the identical artifact with no briefcase
+      #      project involved.
+      #
+      # Both are asserted after the fact, because a missing bundle does not fail
+      # the build — it produces an app that installs and launches to nothing,
+      # which is the failure mode this whole gate exists to stop.
+      - name: Pull the iOS bundle built by ios-bundle
+        if: >-
+          contains(matrix.platforms, 'ios')
+          && (inputs.platforms == '' || inputs.platforms == 'all'
+              || contains(inputs.platforms, 'ios'))
+        # Uploaded with apps/ios/... paths, so the artifact root is apps/ios;
+        # extracting there restores app_packages_native_sim/ (simulator natives
+        # + substrate) and the rest in place.
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: ios-substrate-refresh
+          path: apps/ios
+
+      - name: Materialize the iOS Python bundle
+        # BOTH questions, because they are different: matrix.platforms says
+        # this RUNNER owns ios; inputs.platforms says whether the operator
+        # ASKED for it. Checking only the first meant a `platforms: linux`
+        # dispatch still ran this step — minutes of download, and a step that
+        # can fail the whole workflow — for a platform explicitly excluded.
+        # The subset check existed already, but only INSIDE the flow loop,
+        # long after this had run. Empty = schedule (no inputs) = full run.
+        if: >-
+          contains(matrix.platforms, 'ios')
+          && (inputs.platforms == '' || inputs.platforms == 'all'
+              || contains(inputs.platforms, 'ios'))
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Pinned: the stdlib in Resources.zip is python3.10, and a support
+          # package from another line would mismatch it at load time.
+          PY_TAG: "3.10-b14"
+          PY_ASSET: "Python-3.10-iOS-support.b14.tar.gz"
+        run: |
+          set -euo pipefail
+          mkdir -p apps/ios/Resources/app apps/ios/Frameworks
+          (cd apps/ios/Resources && unzip -qo ../Resources.zip)
+          test -d apps/ios/Resources/python \
+            || { echo "::error::Resources.zip carried no python/ — the bundle is not what this expects"; exit 1; }
+
+          if [ ! -d apps/ios/Frameworks/Python.xcframework ]; then
+            gh release download "$PY_TAG" --repo beeware/Python-Apple-support \
+              -p "$PY_ASSET" -O /tmp/pysupport.tar.gz
+            mkdir -p /tmp/pysupport
+            tar -xzf /tmp/pysupport.tar.gz -C /tmp/pysupport
+            XCF=$(find /tmp/pysupport -maxdepth 3 -name "Python.xcframework" -type d | head -1)
+            [ -n "$XCF" ] || { echo "::error::$PY_ASSET carried no Python.xcframework"; exit 1; }
+            cp -R "$XCF" apps/ios/Frameworks/
+          fi
+
+          # project.yml references this exact slice for the simulator build.
+          test -d "apps/ios/Frameworks/Python.xcframework/ios-arm64_x86_64-simulator" \
+            || { echo "::error::Python.xcframework has no simulator slice"; exit 1; }
+          echo "stdlib:  $(du -sh apps/ios/Resources/python | cut -f1)"
+          echo "support: $(du -sh apps/ios/Frameworks/Python.xcframework | cut -f1)"
+
+          # THE SUBSTRATE, SIMULATOR SLICE. app_packages_native_sim/ is
+          # gitignored -- it holds a 56 MB ciris_server/_native.abi3.so -- so it
+          # exists on a developer machine and never on a runner. Without it the
+          # embed phase reports "no app_packages_native_sim/" and `import
+          # ciris_server` cannot succeed on-simulator, which is the engine.
+          #
+          # ciris-server ships BOTH slices in its -ios.tar.gz release asset
+          # (ios-device/ and ios-simulator/, verified on v0.5.196), and
+          # update_substrate_libs already stages the simulator one here. So this
+          # is a fetch, not a build.
+          SIM_SO="apps/ios/app_packages_native_sim/ciris_server/_native.abi3.so"
+          if [ -f "$SIM_SO" ]; then
+            echo "substrate: provided by the ios-bundle artifact"
+          else
+            echo "substrate: ios-bundle artifact absent -- fetching directly"
+            python3 -m tools.update_substrate_libs --platform ios --lib server
+          fi
+          test -f "$SIM_SO" \
+            || { echo "::error::no simulator ciris_server at $SIM_SO (neither the ios-bundle artifact nor update_substrate_libs provided it)"; exit 1; }
+          if [ -f apps/ios/app_packages_native_sim/MANIFEST.txt ]; then
+            echo "--- simulator natives (from ios-bundle) ---"; cat apps/ios/app_packages_native_sim/MANIFEST.txt
+          fi
+          echo "substrate: $(du -sh apps/ios/app_packages_native_sim | cut -f1) (simulator ciris_server)"
+
+          # WHAT IS STILL MISSING, NAMED. The four third-party natives come from
+          # a briefcase simulator build no runner performs, and no wheel source
+          # exists for them: pydantic-core and cryptography publish no iOS
+          # wheels at all, aiohttp and cffi publish them only for cp313 while
+          # this embed is cp310. Say so here rather than letting the embed phase
+          # report it 200 lines later as a bare WARNING (CIRISAgent#1135).
+          for mod in pydantic_core cryptography aiohttp _cffi_backend; do
+            find apps/ios/app_packages_native_sim -path "*$mod*" -name "*.so" -print -quit 2>/dev/null | grep -q . \
+              || echo "::warning::iOS simulator native missing: $mod (CIRISAgent#1135) — the embedded engine will not import"
+          done
+
+      - name: Build + deploy the iOS app to the simulator
+        # BOTH questions, because they are different: matrix.platforms says
+        # this RUNNER owns ios; inputs.platforms says whether the operator
+        # ASKED for it. Checking only the first meant a `platforms: linux`
+        # dispatch still ran this step — minutes of download, and a step that
+        # can fail the whole workflow — for a platform explicitly excluded.
+        # The subset check existed already, but only INSIDE the flow loop,
+        # long after this had run. Empty = schedule (no inputs) = full run.
+        if: >-
+          contains(matrix.platforms, 'ios')
+          && (inputs.platforms == '' || inputs.platforms == 'all'
+              || contains(inputs.platforms, 'ios'))
+        id: iosbuild
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -o pipefail
+          mkdir -p artifacts/cmdlogs
+          brew install xcodegen 2>&1 | tail -2 || true
+          # --quick, BECAUSE CI HAS NO BRIEFCASE PROJECT. `ios/` is entirely
+          # untracked (0 files in git): the BeeWare app the full path wants exists
+          # only on a machine that has run `briefcase create/build iOS`, so
+          # prepare_python_bundle.sh can never succeed on a runner. The bundle CI
+          # needs is already on disk by here — fetched by fetch_client_artifacts.py
+          # above, as the script's own preflight confirms ("Resources: 46MB").
+          # --quick overlays the repo's live ciris_engine/ciris_adapters onto it,
+          # which is the part CI exists to test.
+          # --no-launch: install only. Launching here left the iOS app holding
+          # :8080/:9091 across the macOS desktop leg on the same loopback; the
+          # driver's ios-simulator-up launches it when the iOS leg starts.
+          bash apps/ios/scripts/rebuild_and_deploy.sh --quick --no-launch 2>&1 \
+            | tee artifacts/cmdlogs/ios-rebuild-and-deploy.log | tail -30
+          # Same locator the script uses — note -not -path Index.noindex, which a
+          # naive find picks up and then installs a stub that launches to nothing.
+          APP=$(find ~/Library/Developer/Xcode/DerivedData/iosApp-* \
+                -name "iosApp.app" -path "*Debug-iphonesimulator*" \
+                -not -path "*/Index.noindex/*" -type d 2>/dev/null | head -1)
+          echo "app=$APP" >> "$GITHUB_OUTPUT"
+          echo "built: ${APP:-<none>}"
+
+      - name: Run the modular QA runner against each platform's backend
+        id: qa
+        shell: bash
+        env:
+          USE_LIVE_KEY: ${{ (github.event_name == 'workflow_dispatch' && inputs.use_live_key == false) && '0' || '1' }}
+          REQUESTED: ${{ inputs.platforms || 'all' }}
+          MODULES: ${{ inputs.modules || 'auth agent system memory audit tools guidance telemetry extended_api' }}
+          IOS_APP: ${{ steps.iosbuild.outputs.app }}
+          # NOT interpolated into the script: a `run:` body containing any `${{ }}`
+          # is one expression capped at 21000 characters (see the gate).
+          MATRIX_PLATFORMS: ${{ matrix.platforms }}
+        run: |
+          set -uo pipefail
+          export ANDROID_AVD_HOME="$HOME/.android/avd"
+          mkdir -p artifacts/shots artifacts/logs artifacts/qa
+          overall=0
+
+          if [ -n "${GITHUB_STEP_SUMMARY:-}" ] && [ ! -s "${GITHUB_STEP_SUMMARY}" ]; then
+            {
+              echo "### Five-platform modular QA - failures by layer"
+              echo ""
+              echo "| platform | phase | layer | meaning | evidence |"
+              echo "|---|---|---|---|---|"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          for plat in $MATRIX_PLATFORMS; do
+            if [ "$REQUESTED" != "all" ] && ! echo " $REQUESTED " | grep -q " $plat "; then
+              echo "::notice::$plat not in requested subset — skipping"
+              continue
+            fi
+            case "$plat" in
+              linux|macos|windows) target=desktop ;;
+              *)                   target="$plat" ;;
+            esac
+            echo "::group::$plat ($target)"
+
+            llm_args="--mock-llm"
+            if [ "$USE_LIVE_KEY" = "1" ] && [ -n "${OPENROUTER_API_KEY:-}" ]; then
+              # Same pinned model as the gate, for the same reason (see there).
+              llm_args="--llm-provider openrouter --llm-key $OPENROUTER_API_KEY --llm-require-live-models --llm-model qwen/qwen3.6-35b-a3b"
+              echo "LLM: REAL key (live models required)"
+            else
+              echo "LLM: mock (no secret available)"
+            fi
+
+            # Tear down the previous platform first; its answer is binding (see the gate).
+            if ! python3 tools/dev/free_ports.py 8080 9091 8091 4242 4243 --timeout 30 --label teardown; then
+              overall=1
+              echo "::error::$plat: a listener from the previous platform survived teardown -- skipping $plat rather than testing it against a stale backend"
+              echo "::endgroup::"
+              continue
+            fi
+
+            export CIRIS_HOME="${RUNNER_TEMP}/ciris-$plat"
+            mkdir -p "$CIRIS_HOME" "artifacts/qa/$plat"
+
+            extra=""
+            [ "$target" = "desktop" ] && extra="--headless"
+            if [ "$target" = "ios" ]; then
+              if [ -z "${IOS_APP:-}" ]; then
+                echo "::error::ios: no simulator .app was built — skipping, and FAILING the job"
+                overall=1
+                echo "::endgroup::"
+                continue
+              fi
+              extra="$extra --ios-app-path $IOS_APP"
+            fi
+
+            # 1. BRING THE BACKEND UP THE WAY A USER DOES: the wizard through the
+            #    real UI. This is the one UI step kept, because it is how the
+            #    platform's own backend comes to exist with an admin we know.
+            if ! python -m tools.qa_runner.modules.web_ui desktop-setup \
+                --platform "$target" --launch $extra \
+                --username qaadmin --password "qa_test_password_12345" \
+                $llm_args \
+                --screenshot-on-success "artifacts/shots/$plat-setup.png" \
+                -v; then
+              overall=1
+              echo "::error::$plat setup failed -- no backend to run the suite against"
+              python3 tools/dev/diagnose_gate_failure.py --platform "$plat" --phase setup --logs artifacts artifacts/cmdlogs || true
+              echo "::endgroup::"
+              continue
+            fi
+
+            # 2. REACH THE BACKEND FROM THE HOST. desktop-setup removes its own adb
+            #    forwards on exit; the simulator shares host loopback; desktop is local.
+            if [ "$target" = "android" ]; then
+              ADB=$(command -v adb 2>/dev/null || echo "${ANDROID_HOME:-/usr/local/lib/android/sdk}/platform-tools/adb")
+              "$ADB" forward tcp:8080 tcp:8080 || { overall=1; echo "::error::android: adb forward 8080 failed"; echo "::endgroup::"; continue; }
+            fi
+            ok=0
+            for _ in $(seq 1 60); do
+              if curl -fsS -m 3 http://localhost:8080/v1/system/health >/dev/null 2>&1; then ok=1; break; fi
+              sleep 2
+            done
+            if [ "$ok" != 1 ]; then
+              overall=1
+              echo "::error::$plat backend not reachable on :8080 after setup -- suite not run"
+              python3 tools/dev/diagnose_gate_failure.py --platform "$plat" --phase reach --logs artifacts artifacts/cmdlogs || true
+              echo "::endgroup::"
+              continue
+            fi
+
+            # 3. WHERE THIS PLATFORM WRITES ITS INCIDENTS LOG. The runner's gate reads
+            #    it and FAILS CLOSED if it is missing -- we only say where, never whether.
+            inc=""; mirror_pid=""
+            case "$target" in
+              desktop)
+                inc="$CIRIS_HOME/logs/incidents_latest.log" ;;
+              android)
+                mkdir -p artifacts/logs/android
+                inc="artifacts/logs/android/incidents_latest.log"
+                pull_inc() { "$ADB" exec-out run-as ai.ciris.mobile.debug cat files/ciris/logs/incidents_latest.log > "$inc.tmp" 2>/dev/null && mv -f "$inc.tmp" "$inc"; }
+                pull_inc || true
+                ( while true; do sleep 3; pull_inc || true; done ) & mirror_pid=$! ;;
+              ios)
+                data=$(xcrun simctl get_app_container booted ai.ciris.mobile data 2>/dev/null || true)
+                [ -n "$data" ] && inc=$(find "$data" -name incidents_latest.log 2>/dev/null | head -1) ;;
+            esac
+            if [ -z "$inc" ] || [ ! -f "$inc" ]; then
+              echo "::warning::$plat no incidents log found at '${inc:-<none>}' -- the runner will refuse to certify this platform"
+              [ -n "$inc" ] || inc="artifacts/qa/$plat/incidents_latest.log.MISSING"
+            fi
+
+            # 4. THE SUITE, against the backend this platform brought up.
+            qa_rc=0
+            python -m tools.qa_runner $MODULES \
+              --no-auto-start --port 8080 \
+              --username qaadmin --password "qa_test_password_12345" \
+              --incidents-log "$inc" \
+              --proceed-anyway --json --report-dir "artifacts/qa/$plat" -v \
+              2>&1 | tee "artifacts/qa/$plat/runner.log"
+            qa_rc=${PIPESTATUS[0]}
+            [ -n "$mirror_pid" ] && { kill "$mirror_pid" 2>/dev/null || true; }
+            if [ "$qa_rc" != 0 ]; then
+              overall=1
+              echo "::error::$plat modular QA failed (rc=$qa_rc) -- see artifacts/qa/$plat/runner.log"
+              python3 tools/dev/diagnose_gate_failure.py --platform "$plat" --phase modular --logs artifacts "artifacts/qa/$plat" artifacts/cmdlogs || true
+            fi
+
+            # 5. VERDICT, in the shape the gallery already reads.
+            printf '{"platform":"%s","success":%s,"interact":%s,"traces":null,"suite":"modular","modules":"%s"}\n' \
+              "$plat" \
+              "$([ "$qa_rc" = 0 ] && echo true || echo false)" \
+              "$([ "$qa_rc" = 0 ] && echo true || echo false)" \
+              "$MODULES" \
+              > "artifacts/chat-$plat.json"
+
+            cp -r "$CIRIS_HOME/logs" "artifacts/logs/$plat" 2>/dev/null || true
+            cp /tmp/ciris_android_emulator.log "artifacts/cmdlogs/emulator-$plat.log" 2>/dev/null || true
+            echo "::endgroup::"
+          done
+          exit $overall
+
+      - name: Collect artifacts
+        if: always()
+        shell: bash
+        env:
+          MATRIX_PLATFORMS: ${{ matrix.platforms }}
+        run: |
+          set +e
+          mkdir -p artifacts/logs artifacts/cmdlogs
+          # SIMULATOR CRASH REPORTS. An iOS SIGABRT shows up in oslog as one launchd
+          # line ("exited due to SIGABRT … ran for 36620ms", run 34272658734) and
+          # the reason is in the .ips report macOS writes under DiagnosticReports,
+          # which nothing collected -- CIRISClient#50 was filed without it. Only
+          # reports from this job's window, so a runner's stale crashes stay out.
+          if [ "${RUNNER_OS}" = "macOS" ]; then
+            mkdir -p artifacts/cmdlogs/ios-crashes
+            # THE APP'S REPORT IS INSIDE THE DEVICE, not on the host. The first
+            # version searched only ~/Library/Logs/DiagnosticReports and collected
+            # exactly one file -- xcodebuild's own abort (run 34283596992) -- while
+            # the iosApp SIGABRT this exists for sat in the simulator container at
+            # ~/Library/Developer/CoreSimulator/Devices/<UDID>/data/Library/Logs/
+            # DiagnosticReports. Search both, and keep the process name in the
+            # filename so a host crash cannot be mistaken for the app's.
+            for root in "$HOME/Library/Logs/DiagnosticReports" \
+                        "$HOME/Library/Logs/CoreSimulator" \
+                        "$HOME/Library/Developer/CoreSimulator/Devices"; do
+              [ -d "$root" ] || continue
+              find "$root" -type f \( -name '*.ips' -o -name '*.crash' \) -mmin -240 \
+                -exec cp {} artifacts/cmdlogs/ios-crashes/ \; 2>/dev/null
+            done
+            n=$(ls artifacts/cmdlogs/ios-crashes 2>/dev/null | wc -l | tr -d ' ')
+            app=$(grep -l -i "iosApp\|ai.ciris.mobile" artifacts/cmdlogs/ios-crashes/* 2>/dev/null | wc -l | tr -d ' ')
+            echo "simulator crash reports collected: $n ($app naming the app)"
+          fi
+          # Agent + node logs per platform home.
+          for d in "${RUNNER_TEMP}"/ciris-*; do
+            [ -d "$d" ] || continue
+            name=$(basename "$d")
+            [ -d "$d/logs" ] && cp -r "$d/logs" "artifacts/logs/$name" 2>/dev/null
+            # .env carries secrets — ship the SHAPE, never the values, so a failed
+            # run stays diagnosable without leaking a key into a public artifact.
+            [ -f "$d/.env" ] && sed 's/=".*"/=<redacted>/' "$d/.env" > "artifacts/$name.env.shape.txt"
+          done
+          # THE CLIENT'S OWN LOG. A UI failure is undiagnosable without it: the
+          # agent and node both look healthy while the app renders the wrong
+          # surface, and "[gate] clientMode=…" exists only here.
+          #
+          # Run 3 collected ONLY ciris_desktop_setup.log — the setup phase's file —
+          # so when the interact gate found that the agent SPEAKs and the UI never
+          # renders the reply (CIRISAgent#1127), the client half of that story was
+          # missing from the artifact. Searching every plausible home and every
+          # phase, because the one log that matters is the one for the phase that
+          # failed.
+          # WINDOWS KEEPS IT SOMEWHERE UNIX PATHS DO NOT REACH. The desktop client
+          # writes to `C:\Users\RUNNER~1\AppData\Local\Temp\ciris_desktop_setup.log`
+          # — observed verbatim in the Windows job. `$TMPDIR` is unset there and
+          # `$LOCALAPPDATA` arrives as a BACKSLASH path that `find` cannot walk, so
+          # a Unix-shaped root list quietly collected nothing on the one platform
+          # whose client log we have actually needed.
+          #
+          # cygpath converts when present (git-bash on the Windows runner); the
+          # ${VAR//\\//} fallback covers a bash without it. `$TEMP`/`$TMP` are the
+          # Windows spellings of the same directory.
+          roots="${TMPDIR:-/tmp} ${RUNNER_TEMP} $HOME ."
+          for w in "${LOCALAPPDATA:-}" "${TEMP:-}" "${TMP:-}"; do
+            [ -n "$w" ] || continue
+            if command -v cygpath >/dev/null 2>&1; then
+              w=$(cygpath -u "$w" 2>/dev/null || echo "$w")
+            else
+              w="${w//\\//}"
+            fi
+            roots="$roots $w"
+          done
+          for d in $roots; do
+            [ -d "$d" ] || continue
+            # depth 3: AppData/Local/Temp sits three below $HOME on Windows.
+            find "$d" -maxdepth 3 -name 'ciris_desktop*.log' -newermt '-3 hours' \
+              -exec cp {} artifacts/ \; 2>/dev/null
+          done
+          echo "client-log search roots: $roots"
+          ls artifacts/ciris_desktop*.log 2>/dev/null || echo "NOTE: no desktop client log found — a UI failure will not be diagnosable"
+          # Android: the device's own logcat, which is where a Chaquopy or
+          # TestAutomationServer failure actually appears.
+          #
+          # GATED ON THIS RUNNER ACTUALLY HAVING ANDROID, and wrapped in a
+          # timeout. GitHub's macOS runners ship the Android SDK, so
+          # `command -v adb` succeeds there — and with no device attached, adb
+          # blocks starting its server. That hung this step for over an hour on
+          # macos-ios, burned the job timeout, and (worse) blocked the
+          # upload-artifact step behind it, so the macOS failure could not be
+          # diagnosed at all. A collect step must never be able to outlive the
+          # thing it is collecting for.
+          # The platform gate alone already excludes macos-ios (its
+          # MATRIX_PLATFORMS is "macos ios"), so `command -v adb` was never what
+          # kept adb off the macOS runner — and on the ubuntu runner adb is NOT
+          # on PATH: the emulator steps above reach it through
+          # $SDK/platform-tools. So the guard was false on the one runner that
+          # has a device, the block was skipped, and because the "unavailable"
+          # fallback lived INSIDE the guard, the absence was silent. Run
+          # 33704781359 lost the only log that could explain why Android's test
+          # server died right after answering /health with testMode=true.
+          #
+          # Resolve adb explicitly, and always leave a file saying why if we
+          # cannot: a missing diagnostic must never be indistinguishable from a
+          # diagnostic that was never attempted.
+          if [ "${MATRIX_PLATFORMS#*android}" != "$MATRIX_PLATFORMS" ]; then
+            ADB=$(command -v adb 2>/dev/null || echo "${ANDROID_HOME:-/usr/local/lib/android/sdk}/platform-tools/adb")
+            if [ -x "$ADB" ]; then
+              timeout 60 "$ADB" logcat -d > artifacts/logs/android-logcat.txt 2>/dev/null || \
+                echo "logcat unavailable (adb timed out or no device attached)" > artifacts/logs/android-logcat.txt
+            else
+              echo "logcat unavailable (no adb executable at '$ADB')" > artifacts/logs/android-logcat.txt
+              # THE RUNTIME LOGS GO TO FILES, not logcat: latest.log, incidents_latest.log and
+              # the Rust ciris-server.log* under files/ciris/logs in the app's data dir.
+              # Pulled HERE, in the always() collection step, because the per-platform
+              # block `continue`s on a setup/login failure before its post-chat section --
+              # a pull placed there ran only for legs that had already got past login
+              # (2026-09-04, run 33901202920: iOS failed at login, no app logs shipped).
+              if [ -x "$ADB" ]; then
+                mkdir -p artifacts/logs/android; n=0
+                for f in $("$ADB" exec-out run-as ai.ciris.mobile.debug sh -c 'ls files/ciris/logs 2>/dev/null' 2>/dev/null | tr -d '\r'); do
+                  case "$f" in *.log|*.log.*) "$ADB" exec-out run-as ai.ciris.mobile.debug cat "files/ciris/logs/$f" > "artifacts/logs/android/$f" 2>/dev/null && n=$((n+1)) ;; esac
+                done
+                echo "  pulled $n android log file(s) into artifacts/logs/android"
+                ls artifacts/logs/android/incidents_latest.log artifacts/logs/android/incidents_*.log >/dev/null 2>&1 || echo "::warning::android: no incidents log pulled from the device -- the agent-side story will be missing"
+              fi
+            fi
+          fi
+          # THE iOS APP LOGS, on every leg outcome: the runtime's files/ciris/logs plus
+          # the KMP bridge logs from the app container. _ios_diagnostics gathers them
+          # only when bring-up fails; here they ship whatever happened after.
+          if [ "${MATRIX_PLATFORMS#*ios}" != "$MATRIX_PLATFORMS" ]; then
+            data=$(xcrun simctl get_app_container booted ai.ciris.mobile data 2>/dev/null || true)
+            if [ -n "$data" ]; then
+              mkdir -p artifacts/logs/ios; n=0
+              while IFS= read -r f; do cp "$f" "artifacts/logs/ios/$(basename "$f")" 2>/dev/null && n=$((n+1)); done \
+                < <(find "$data" \( -name "*.log" -o -name "*.log.*" \) -type f -size -50M 2>/dev/null | grep -E "/ciris/logs/|kmp_[a-z]+\.log$" | head -40)
+              echo "  pulled $n ios log file(s) into artifacts/logs/ios"
+              ls artifacts/logs/ios/incidents_latest.log artifacts/logs/ios/incidents_*.log >/dev/null 2>&1 || echo "::warning::ios: no incidents log in the app container -- the agent-side story will be missing"
+            else
+              echo "  ios: no app container resolved (app not installed on the booted simulator?) -- no app logs"
+            fi
+          fi
+          # iOS: the SIMULATOR's own os_log for our bundle. Until now this was
+          # gathered only by _ios_diagnostics on the FAILURE path, so a run that
+          # failed its assertion while the app was technically alive produced no
+          # app-side output at all — which is the half you need when the question
+          # is "the agent replied, why did the screen not change".
+          if [ "${MATRIX_PLATFORMS#*ios}" != "$MATRIX_PLATFORMS" ] && command -v xcrun >/dev/null 2>&1; then
+            timeout 180 xcrun simctl spawn booted log show --last 15m --style syslog \
+              --predicate 'subsystem CONTAINS "ai.ciris" OR process CONTAINS "iosApp"' \
+              > artifacts/logs/ios-oslog.txt 2>/dev/null \
+              || echo "ios os_log unavailable (no booted simulator or log show timed out)" \
+                 > artifacts/logs/ios-oslog.txt
+          fi
+
+          # A MANIFEST, so a MISSING log is as visible as a present one. Every
+          # diagnosis this gate has needed so far turned on noticing that
+          # something was absent — the desktop client log, the chat JSON, the
+          # screenshot. An index makes absence legible without unpacking.
+          {
+            echo "# Five-Platform Live QA — collected artifacts"
+            echo "# runner=${MATRIX_PLATFORMS}  run=${GITHUB_RUN_ID:-local}"
+            echo
+            echo "## present"
+            find artifacts -type f -printf '%10s  %p\n' 2>/dev/null | sort -k2 \
+              || find artifacts -type f -exec ls -l {} \; 2>/dev/null | awk '{print $5"  "$9}'
+            echo
+            echo "## expected-but-absent"
+            for plat in ${MATRIX_PLATFORMS}; do
+              [ -f "artifacts/shots/$plat-setup.png" ] || echo "  shots/$plat-setup.png (no setup screenshot — did the app start at all?)"
+              [ -f "artifacts/shots/$plat.png" ]   || echo "  shots/$plat.png (no chat screenshot — did the flow reach the chat step?)"
+              [ -f "artifacts/chat-$plat.json" ]   || echo "  chat-$plat.json (no result — did the flow reach the chat step?)"
+              [ -d "artifacts/logs/ciris-$plat" ]  || echo "  logs/ciris-$plat/ (no agent logs — did the platform boot?)"
+              # The DEVICE-side log. Absent, an app that dies after coming up
+              # looks identical to one that never started — which is exactly
+              # the question Android posed in run 33704781359.
+              case "$plat" in
+                android) [ -f "artifacts/logs/android-logcat.txt" ] \
+                  || echo "  logs/android-logcat.txt (no device log — an app death cannot be diagnosed)" ;;
+                ios)     [ -f "artifacts/logs/ios-oslog.txt" ] \
+                  || echo "  logs/ios-oslog.txt (no simulator log — an app death cannot be diagnosed)" ;;
+              esac
+            done
+            ls artifacts/ciris_desktop*.log >/dev/null 2>&1 || echo "  ciris_desktop*.log (no CLIENT log — a UI failure cannot be diagnosed)"
+          } > artifacts/MANIFEST.txt 2>&1
+          cat artifacts/MANIFEST.txt
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: modular-qa-${{ matrix.label }}
+          path: artifacts
+          retention-days: 14
+
+  gallery:
+    name: Screenshot gallery
+    needs: live-qa
+    # ALWAYS. A gallery that only renders when everything passed is useless
+    # exactly when it is most needed — the red run is the one worth looking at.
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: incoming
+
+      - name: Build a self-contained gallery
+        run: |
+          python3 tools/dev/build_qa_gallery.py incoming \
+            --out gallery/index.html \
+            --summary "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: five-platform-modular-gallery
+          path: gallery
+          retention-days: 14

--- a/.github/workflows/memory-benchmark.yml
+++ b/.github/workflows/memory-benchmark.yml
@@ -154,12 +154,25 @@ jobs:
           # plateau in CI without burning the 60s of budget that pushed the
           # 25033091098 run past the 15-minute cap. Production weekly cron
           # gets the longer 90s window via workflow_dispatch when needed.
-          python3 -u tools/memory_benchmark.py --messages 1000 --adapter api --idle-seconds 30 | tee 1000msg.log || echo "1000-msg benchmark skipped"
+          # --composition attributes the plateau RSS to allocators and mappings
+          # instead of reporting a bare number. Between 2.10 and 2.11 this figure
+          # moved 317 MB -> 732 MB with nothing in CI able to say which allocator
+          # gained it; see tools/memory_composition.py.
+          python3 -u tools/memory_benchmark.py --messages 1000 --adapter api --idle-seconds 30 \
+            --composition --composition-json composition.json | tee 1000msg.log \
+            || echo "1000-msg benchmark skipped"
           if [ -f 1000msg.log ]; then
             echo '```' >> $GITHUB_STEP_SUMMARY
-            # Tail 30 lines instead of 20 so the failure-breakdown + idle
-            # summary lines both make it into the GitHub summary.
-            tail -30 1000msg.log >> $GITHUB_STEP_SUMMARY
+            # The composition report lands between the idle line and the results
+            # banner. Cut it out for the run summary -- which keeps the same last
+            # 30 lines it always showed, failure breakdown and idle included --
+            # and give it its own section below.
+            awk '/MEMORY COMPOSITION/{skip=1} /Shutting down server/{skip=0} !skip' 1000msg.log \
+              | tail -30 >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "### Resident memory composition" >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            awk '/MEMORY COMPOSITION/,/Shutting down server/' 1000msg.log >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
           fi
 
@@ -182,6 +195,7 @@ jobs:
             cold_start.log
             100msg.log
             1000msg.log
+            composition.json
           retention-days: 90
 
       - name: Capture upgrade-compat fixture (memory-burst)

--- a/apps/android/build.gradle
+++ b/apps/android/build.gradle
@@ -25,8 +25,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 36
-        versionCode 190
-        versionName "2.11.0"
+        versionCode 191
+        versionName "2.11.1"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/apps/android/src/main/kotlin/ai/ciris/mobile/PythonRuntimeService.kt
+++ b/apps/android/src/main/kotlin/ai/ciris/mobile/PythonRuntimeService.kt
@@ -5,6 +5,7 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
+import android.content.ComponentCallbacks2
 import android.content.Context
 import android.content.Intent
 import android.net.wifi.WifiManager
@@ -102,6 +103,43 @@ class PythonRuntimeService : Service(), DefaultLifecycleObserver {
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
+
+    /**
+     * The OS is asking for memory back. Until this override existed the answer
+     * was silence, and on a 2 GB phone silence is how a foreground service gets
+     * killed. The Python runtime releases what its allocators are holding
+     * (gc.collect + mallopt(M_PURGE)) and reports the result to its resource
+     * monitor; see mobile_main.on_trim_memory.
+     *
+     * Runs off the main thread: the release holds the GIL for ~100 ms on a
+     * loaded runtime, and onTrimMemory is delivered on the main thread.
+     */
+    override fun onTrimMemory(level: Int) {
+        super.onTrimMemory(level)
+        val name = when (level) {
+            ComponentCallbacks2.TRIM_MEMORY_COMPLETE -> "COMPLETE"
+            ComponentCallbacks2.TRIM_MEMORY_MODERATE -> "MODERATE"
+            ComponentCallbacks2.TRIM_MEMORY_BACKGROUND -> "BACKGROUND"
+            ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN -> "UI_HIDDEN"
+            ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL -> "RUNNING_CRITICAL"
+            ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW -> "RUNNING_LOW"
+            ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE -> "RUNNING_MODERATE"
+            else -> "LEVEL_$level"
+        }
+        if (!Python.isStarted()) {
+            Log.i(TAG, "onTrimMemory($name): Python not started, nothing to release")
+            return
+        }
+        serviceScope.launch {
+            try {
+                val summary = Python.getInstance().getModule("mobile_main")
+                    .callAttr("on_trim_memory", name).toString()
+                Log.w(TAG, "onTrimMemory($name): $summary")
+            } catch (e: Exception) {
+                Log.e(TAG, "onTrimMemory($name): release failed", e)
+            }
+        }
+    }
 
     override fun onDestroy() {
         super<Service>.onDestroy()

--- a/apps/android/src/main/python/mobile_main.py
+++ b/apps/android/src/main/python/mobile_main.py
@@ -20,6 +20,12 @@ import sys
 from pathlib import Path
 from typing import List, Optional, Tuple
 
+# Set once the runtime is up, so Android's memory-pressure callback -- which
+# arrives on whatever thread Chaquopy calls from -- can report into the running
+# resource monitor without holding a reference to anything else.
+_event_loop: Optional[asyncio.AbstractEventLoop] = None
+_runtime_ref = None
+
 # Constants to avoid string duplication (SonarCloud S1192)
 PYDANTIC_CORE_SO_PATTERN = "_pydantic_core*.so"
 
@@ -1032,6 +1038,9 @@ async def start_mobile_runtime():
         host="0.0.0.0",  # Bind all interfaces so browser OAuth can reach us
         port=8080,
     )
+    global _event_loop, _runtime_ref
+    _event_loop = asyncio.get_running_loop()
+    _runtime_ref = runtime
 
     # Initialize all services (22 services, buses, etc.)
     logger.info("Initializing CIRIS services...")
@@ -1100,6 +1109,39 @@ def clear_signing_key() -> bool:
     except Exception as e:
         logger.error(f"[clear_signing_key] Failed to clear signing key: {e}", exc_info=True)
         return False
+
+
+def on_trim_memory(level: str) -> str:
+    """Android asked for memory back (ComponentCallbacks2.onTrimMemory).
+
+    Called by PythonRuntimeService on a background thread. The release itself
+    is done right here, synchronously, on this thread: it must work even when
+    the event loop is wedged, and on a budget phone the alternative to
+    answering the OS is being killed by it. The running resource monitor is
+    told afterwards so the release shows in telemetry and the next limit check
+    sees the post-release figure. Works in run-without-AI too, where there is
+    no runtime to tell.
+    """
+    from ciris_engine.logic.utils.memory_release import release_memory
+
+    result = release_memory(trigger=f"host:{level}")
+    logger.warning(
+        "onTrimMemory(%s): rss %d -> %d MB, reclaimed %d MB via %s in %d ms",
+        level,
+        result.rss_before_mb,
+        result.rss_after_mb,
+        result.reclaimed_mb,
+        result.platform_call,
+        result.duration_ms,
+    )
+    loop, runtime = _event_loop, _runtime_ref
+    if loop is not None and runtime is not None and not loop.is_closed():
+        monitor = getattr(runtime, "resource_monitor_service", None) or getattr(
+            getattr(runtime, "service_initializer", None), "resource_monitor_service", None
+        )
+        if monitor is not None:
+            loop.call_soon_threadsafe(monitor.record_release, result)
+    return result.model_dump_json()
 
 
 def main():

--- a/apps/android/src/main/python/version.py
+++ b/apps/android/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.11.0"
+__version__ = "android-2.11.1"
 
 
 def get_version() -> str:

--- a/apps/ios/Resources/app/ciris_ios/kmp_main.py
+++ b/apps/ios/Resources/app/ciris_ios/kmp_main.py
@@ -247,6 +247,61 @@ def watchdog_thread_func():
     _watchdog_log.info("Watchdog thread exiting")
 
 
+# ---------------------------------------------------------------------------
+# Memory pressure: iOS asked for memory back
+# ---------------------------------------------------------------------------
+#
+# Swift has no direct call into Python here (PythonInit.runModule only), so it
+# speaks the same way the restart path does: a signal file, watched by a plain
+# thread. The release runs on that thread on purpose -- an iOS memory warning
+# is exactly when the event loop may be suspended -- and the running resource
+# monitor is told afterwards. Started before the run-without-AI branch so a
+# node-only install answers the OS too.
+
+
+def get_memory_pressure_signal_path() -> Path:
+    return _get_ciris_dir() / ".memory_pressure"
+
+
+def _memory_pressure_thread_func():
+    from ciris_engine.logic.utils.memory_release import release_memory
+
+    log = init_logging("kmp.memory")
+    path = get_memory_pressure_signal_path()
+    log.info(f"Memory pressure watcher started (signal: {path})")
+    while True:
+        time.sleep(1.0)
+        if not path.exists():
+            continue
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        try:
+            result = release_memory(trigger="host:ios_memory_warning")
+            log.warning(
+                f"iOS memory warning: rss {result.rss_before_mb} -> {result.rss_after_mb} MB, "
+                f"reclaimed {result.reclaimed_mb} MB via {result.platform_call} in {result.duration_ms} ms"
+            )
+            loop, runtime = _event_loop, _runtime_ref
+            if loop is not None and runtime is not None and not loop.is_closed():
+                monitor = getattr(runtime, "resource_monitor_service", None) or getattr(
+                    getattr(runtime, "service_initializer", None), "resource_monitor_service", None
+                )
+                if monitor is not None:
+                    loop.call_soon_threadsafe(monitor.record_release, result)
+        except Exception as e:
+            log.error(f"Memory release failed: {e}")
+
+
+def start_memory_pressure_thread():
+    import threading
+
+    thread = threading.Thread(target=_memory_pressure_thread_func, name="ciris-mem-pressure", daemon=True)
+    thread.start()
+    return thread
+
+
 def start_watchdog_thread():
     """Start the watchdog thread as a daemon."""
     import threading
@@ -527,6 +582,8 @@ def main():
     # restart loop, the runtime and the API adapter are never started. The
     # client talks to the node on :4243.
     from ciris_engine import node_only
+
+    start_memory_pressure_thread()
 
     _node_only = node_only.node_only_config()
     if _node_only is not None:

--- a/apps/ios/iosApp/Info.plist
+++ b/apps/ios/iosApp/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.11.0</string>
+	<string>2.11.1</string>
 	<key>CFBundleVersion</key>
-	<string>353</string>
+	<string>354</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/apps/ios/iosApp/PythonBridge.swift
+++ b/apps/ios/iosApp/PythonBridge.swift
@@ -357,6 +357,26 @@ import Compression
         NSLog("[PythonBridge] Wrote restart signal to \(signalPath)")
     }
 
+    /// iOS is asking for memory back. Same channel as the restart signal: a file
+    /// the Python side's memory-pressure thread polls once a second and acts on
+    /// without needing the event loop, which is often suspended at exactly this
+    /// moment. See kmp_main.start_memory_pressure_thread.
+    @objc public static func writeMemoryPressureSignal() {
+        let fm = FileManager.default
+        guard let documentsPath = fm.urls(for: .documentDirectory, in: .userDomainMask).first?.path else {
+            NSLog("[PythonBridge] ERROR: Could not get Documents directory")
+            return
+        }
+
+        let signalPath = "\(documentsPath)/ciris/.memory_pressure"
+        let cirisDir = "\(documentsPath)/ciris"
+        try? fm.createDirectory(atPath: cirisDir, withIntermediateDirectories: true)
+
+        let timestamp = "\(Date().timeIntervalSince1970)"
+        try? timestamp.write(toFile: signalPath, atomically: true, encoding: .utf8)
+        NSLog("[PythonBridge] Wrote memory pressure signal to \(signalPath)")
+    }
+
     /// Check if server ready signal exists (indicates server restarted successfully)
     @objc public static func checkServerReady() -> Bool {
         let fm = FileManager.default

--- a/apps/ios/iosApp/iosAppApp.swift
+++ b/apps/ios/iosApp/iosAppApp.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 @main
 struct iosAppApp: App {
@@ -29,6 +30,16 @@ struct iosAppApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                // A memory warning is the last thing iOS says before jetsam.
+                // Hand it to the Python runtime, which releases what its
+                // allocators are holding and reports the result to its
+                // resource monitor.
+                .onReceive(NotificationCenter.default.publisher(
+                    for: UIApplication.didReceiveMemoryWarningNotification
+                )) { _ in
+                    NSLog("[CIRIS] iOS memory warning received - asking the runtime to release")
+                    PythonBridge.writeMemoryPressureSignal()
+                }
         }
     }
 }

--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -6,11 +6,11 @@ from typing import List
 from ciris_engine.schemas.runtime.canonical_peer import CanonicalBootstrapPeer
 
 # Version information
-CIRIS_VERSION = "2.11.0-stable"
+CIRIS_VERSION = "2.11.1-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
 CIRIS_VERSION_MINOR = 11
-CIRIS_VERSION_PATCH = 0
+CIRIS_VERSION_PATCH = 1
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/ciris_engine/logic/adapters/api/routes/system/runtime.py
+++ b/ciris_engine/logic/adapters/api/routes/system/runtime.py
@@ -10,6 +10,7 @@ from typing import Annotated
 from fastapi import APIRouter, Body, Depends, HTTPException, Request
 
 from ciris_engine.schemas.api.responses import SuccessResponse
+from ciris_engine.schemas.services.resources_core import MemoryReleaseResult
 
 from ...constants import ERROR_RUNTIME_CONTROL_SERVICE_NOT_AVAILABLE
 from ...dependencies.auth import AuthContext, require_admin
@@ -37,6 +38,40 @@ router = APIRouter()
 
 # Valid cognitive states for transition
 VALID_COGNITIVE_STATES = {"WORK", "DREAM", "PLAY", "SOLITUDE"}
+
+
+@router.post(
+    "/runtime/memory/release",
+    responses={
+        500: {"description": "Memory release failed"},
+        503: {"description": "Resource monitor not available"},
+    },
+)
+async def release_memory(
+    request: Request,
+    auth: AuthAdminDep,
+) -> SuccessResponse[MemoryReleaseResult]:
+    """
+    Hand freed memory back to the operating system, now.
+
+    The same path the resource monitor takes when it crosses its own memory
+    threshold, and the path the phones take on an OS memory warning -- exposed
+    so an operator can trigger it and so the five-platform gate can prove the
+    chain works on every platform, not just the one it was measured on.
+
+    Requires ADMIN role.
+    """
+    monitor = getattr(request.app.state, "resource_monitor", None)
+    if monitor is None:
+        runtime = getattr(request.app.state, "runtime", None)
+        monitor = getattr(runtime, "resource_monitor_service", None)
+    if monitor is None:
+        raise HTTPException(status_code=503, detail="Resource monitor not available")
+    try:
+        result = await monitor.release_memory(trigger="api:admin")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    return SuccessResponse(data=result)
 
 
 @router.post(

--- a/ciris_engine/logic/services/infrastructure/resource_monitor/service.py
+++ b/ciris_engine/logic/services/infrastructure/resource_monitor/service.py
@@ -7,12 +7,13 @@ import shutil
 from collections import deque
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Callable, Deque, Dict, List, Optional, Tuple
+from typing import Awaitable, Callable, Deque, Dict, List, Optional, Tuple
 
 import psutil
 
 from ciris_engine.constants import SERVER_MINIMUM_DISK_BYTES
 from ciris_engine.logic.services.base_scheduled_service import BaseScheduledService
+from ciris_engine.logic.utils.memory_release import release_memory as _release_process_memory
 from ciris_engine.protocols.services.infrastructure.credit_gate import CreditGateProtocol
 from ciris_engine.protocols.services.infrastructure.resource_monitor import ResourceMonitorServiceProtocol
 from ciris_engine.protocols.services.lifecycle.time import TimeServiceProtocol
@@ -25,7 +26,13 @@ from ciris_engine.schemas.services.credit_gate import (
     CreditSpendRequest,
     CreditSpendResult,
 )
-from ciris_engine.schemas.services.resources_core import ResourceAction, ResourceBudget, ResourceLimit, ResourceSnapshot
+from ciris_engine.schemas.services.resources_core import (
+    MemoryReleaseResult,
+    ResourceAction,
+    ResourceBudget,
+    ResourceLimit,
+    ResourceSnapshot,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +41,9 @@ class ResourceSignalBus:
     """Simple signal bus for resource events."""
 
     def __init__(self) -> None:
-        self._handlers: Dict[str, List[Callable[[str, str], "asyncio.Future[None]"]]] = {
+        # Handlers are `async def (signal, resource)`; what register() receives is
+        # a coroutine function, i.e. a Callable returning an Awaitable, not a Future.
+        self._handlers: Dict[str, List[Callable[[str, str], Awaitable[None]]]] = {
             "throttle": [],
             "defer": [],
             "reject": [],
@@ -42,7 +51,7 @@ class ResourceSignalBus:
             "token_refreshed": [],  # ciris.ai token refresh signal
         }
 
-    def register(self, signal: str, handler: Callable[[str, str], "asyncio.Future[None]"]) -> None:
+    def register(self, signal: str, handler: Callable[[str, str], Awaitable[None]]) -> None:
         self._handlers.setdefault(signal, []).append(handler)
 
     async def emit(self, signal: str, resource: str) -> None:
@@ -92,6 +101,18 @@ class ResourceMonitorService(BaseScheduledService, ResourceMonitorServiceProtoco
         self._env_file_mtime: float = 0.0  # Last known .env modification time
         self._token_refresh_signal_mtime: float = 0.0  # Last signal file mtime we processed
         self._ciris_home: Optional[Path] = None  # Cached CIRIS_HOME path
+
+        # The monitor is its own first subscriber. Until it was, every
+        # throttle/defer/reject/shutdown it emitted went to an empty handler
+        # list: crossing the memory warning produced one log line and nothing
+        # else. Registering here, not in the initializer, means a monitor
+        # constructed anywhere -- tests, node-only, a future host -- is wired.
+        self._signal_counts: Dict[str, int] = {}
+        self._last_release: Optional[MemoryReleaseResult] = None
+        self._release_count = 0
+        self._released_total_mb = 0
+        for signal in ("throttle", "defer", "reject", "shutdown"):
+            self.signal_bus.register(signal, self._on_resource_signal)
 
     def get_service_type(self) -> ServiceType:
         """Get service type."""
@@ -214,6 +235,42 @@ class ResourceMonitorService(BaseScheduledService, ResourceMonitorServiceProtoco
             await self.signal_bus.emit("shutdown", resource)
         self._last_action_time[f"{resource}_{level}"] = current_time
 
+    async def _on_resource_signal(self, signal: str, resource: str) -> None:
+        """Built-in subscriber for the monitor's own signals.
+
+        Memory is the one resource where the right response is to *give some
+        back* rather than to do less: freed memory that the allocators are
+        holding is not ours to keep on a phone. Every other signal is counted so
+        an emit is never silent, and left for the processor to act on.
+        """
+        self._signal_counts[signal] = self._signal_counts.get(signal, 0) + 1
+        if resource == "memory_mb" and signal in ("throttle", "defer", "reject"):
+            await self.release_memory(trigger=f"resource_monitor:{signal}")
+
+    def record_release(self, result: MemoryReleaseResult) -> None:
+        """Fold a release into the monitor's state, wherever it was performed.
+
+        Host callbacks release on their own thread (the loop may be frozen
+        when the OS asks) and report here afterwards; the snapshot is updated
+        so the next limit check, and the next prompt's resource alert, see the
+        post-release number instead of a sample from before it.
+        """
+        self._last_release = result
+        self._release_count += 1
+        self._released_total_mb += max(0, result.reclaimed_mb)
+        self.snapshot.memory_mb = result.rss_after_mb
+        self.snapshot.memory_percent = min(100, self.snapshot.memory_mb * 100 // self.budget.memory_mb.limit)
+
+    async def release_memory(self, trigger: str = "manual") -> MemoryReleaseResult:
+        """Collect garbage and return the allocators' free pages to the OS."""
+        result = _release_process_memory(trigger)
+        self.record_release(result)
+        return result
+
+    async def handle_host_memory_pressure(self, level: str) -> MemoryReleaseResult:
+        """The host OS asked for memory. No cooldown: refusing is how a process gets killed."""
+        return await self.release_memory(trigger=f"host:{level}")
+
     async def _check_token_refresh_signal(self) -> None:
         """Check for token refresh signals from ciris.ai authentication.
 
@@ -248,10 +305,7 @@ class ResourceMonitorService(BaseScheduledService, ResourceMonitorServiceProtoco
             # Watch for the client's answer. Filenames come from the shared
             # handshake module so this side and the client cannot disagree
             # about which files the conversation uses.
-            from ciris_engine.logic.utils.token_handshake import (
-                CONFIG_RELOAD_SIGNAL_FILE,
-                ENV_FILE,
-            )
+            from ciris_engine.logic.utils.token_handshake import CONFIG_RELOAD_SIGNAL_FILE, ENV_FILE
 
             config_reload_file = self._ciris_home / CONFIG_RELOAD_SIGNAL_FILE
             env_file = self._ciris_home / ENV_FILE
@@ -391,7 +445,13 @@ class ResourceMonitorService(BaseScheduledService, ResourceMonitorServiceProtoco
             "thoughts_active": float(self.snapshot.thoughts_active),
             "warnings": float(len(self.snapshot.warnings)),
             "critical": float(len(self.snapshot.critical)),
+            # Memory give-back: proof the warning threshold does something.
+            "memory_release_count": float(self._release_count),
+            "memory_released_mb_total": float(self._released_total_mb),
+            "memory_last_release_mb": float(self._last_release.reclaimed_mb if self._last_release else 0),
         }
+        for signal, count in self._signal_counts.items():
+            metrics[f"resource_signal_{signal}_total"] = float(count)
 
         if self.credit_provider:
             metrics["credit_provider_enabled"] = 1.0

--- a/ciris_engine/logic/utils/memory_release.py
+++ b/ciris_engine/logic/utils/memory_release.py
@@ -1,0 +1,157 @@
+"""Hand freed memory back to the operating system.
+
+Freeing memory in Python, or in the Rust substrate folded into the process,
+does not return it to the OS: every allocator keeps what it was given and
+serves later requests from it. On a server that is a reasonable trade. On a
+2 GB phone it is the difference between shrinking when asked and being killed
+— at an 822 MB plateau, 347 MB of the agent's resident set was memory glibc
+had already been told was free (CIRISServer#577 has the measurement).
+
+This is the one place that knows how to ask each allocator for it back. It is
+deliberately a plain synchronous function with no dependency on the runtime:
+the host callbacks that need it most (Android onTrimMemory, the iOS watchdog
+thread) fire on foreign threads, sometimes while the event loop is frozen.
+
+Platform calls, each documented by its platform and verified against its
+header where one was available:
+
+  glibc   malloc_trim(0)                      walks every arena, MADV_DONTNEEDs
+                                              whole free pages — not just the top
+  Bionic  mallopt(M_PURGE_ALL) / mallopt(M_PURGE)
+                                              API 34 / API 28; unknown options are
+                                              a harmless no-op on older devices
+  Darwin  malloc_zone_pressure_relief(NULL, 0) what the OS itself calls on a
+                                              memory warning
+"""
+
+from __future__ import annotations
+
+import ctypes
+import gc
+import logging
+import os
+import sys
+import time
+from typing import Optional
+
+from ciris_engine.schemas.services.resources_core import MemoryReleaseResult
+
+logger = logging.getLogger(__name__)
+
+# Bionic mallopt options, from the NDK's <malloc.h>.
+_BIONIC_M_PURGE = -101  # API 28
+_BIONIC_M_PURGE_ALL = -104  # API 34
+
+_libc: Optional[ctypes.CDLL] = None
+_libc_failed = False
+
+
+def _is_android() -> bool:
+    # Kept local so this module stays importable before the engine is.
+    return bool(os.getenv("ANDROID_ROOT") or os.getenv("ANDROID_DATA") or hasattr(sys, "getandroidapilevel"))
+
+
+def _load_libc() -> Optional[ctypes.CDLL]:
+    global _libc, _libc_failed
+    if _libc is not None or _libc_failed:
+        return _libc
+    candidates: list[Optional[str]]
+    if _is_android():
+        candidates = ["libc.so"]
+    elif sys.platform.startswith("linux"):
+        candidates = ["libc.so.6"]
+    elif sys.platform in ("darwin", "ios"):
+        candidates = ["libSystem.B.dylib", None]
+    else:
+        candidates = []
+    for name in candidates:
+        try:
+            _libc = ctypes.CDLL(name)
+            return _libc
+        except OSError:
+            continue
+    _libc_failed = True
+    return None
+
+
+def rss_bytes() -> int:
+    """Resident set size of this process, cheaply, without psutil where possible."""
+    try:
+        with open("/proc/self/statm", encoding="utf-8") as handle:
+            return int(handle.read().split()[1]) * os.sysconf("SC_PAGE_SIZE")
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import psutil
+
+        return int(psutil.Process().memory_info().rss)
+    except Exception:
+        return 0
+
+
+def _platform_release() -> str:
+    """Ask the system allocator to return free pages. Never raises."""
+    libc = _load_libc()
+    if libc is None:
+        return "none"
+    try:
+        if _is_android():
+            if not hasattr(libc, "mallopt"):
+                return "unavailable:no mallopt"
+            libc.mallopt.argtypes = [ctypes.c_int, ctypes.c_int]
+            libc.mallopt.restype = ctypes.c_int
+            # Newest first; an unrecognised option returns 0 and does nothing.
+            if libc.mallopt(_BIONIC_M_PURGE_ALL, 0):
+                return "mallopt(M_PURGE_ALL)"
+            libc.mallopt(_BIONIC_M_PURGE, 0)
+            return "mallopt(M_PURGE)"
+        if sys.platform.startswith("linux"):
+            if not hasattr(libc, "malloc_trim"):
+                return "unavailable:no malloc_trim"
+            libc.malloc_trim.argtypes = [ctypes.c_size_t]
+            libc.malloc_trim.restype = ctypes.c_int
+            libc.malloc_trim(0)
+            return "malloc_trim"
+        if sys.platform in ("darwin", "ios"):
+            if not hasattr(libc, "malloc_zone_pressure_relief"):
+                return "unavailable:no malloc_zone_pressure_relief"
+            libc.malloc_zone_pressure_relief.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+            libc.malloc_zone_pressure_relief.restype = ctypes.c_size_t
+            libc.malloc_zone_pressure_relief(None, 0)
+            return "malloc_zone_pressure_relief"
+    except Exception as exc:  # an allocator call must never take the process down
+        return f"unavailable:{type(exc).__name__}"
+    return "none"
+
+
+def release_memory(trigger: str = "manual") -> MemoryReleaseResult:
+    """Collect garbage, then hand the allocators' free pages back to the OS.
+
+    Safe to call from any thread; holds the GIL for the duration of
+    gc.collect(), which on a loaded agent is on the order of 100 ms.
+    """
+    started = time.perf_counter()
+    before = rss_bytes()
+    collected = gc.collect()
+    call = _platform_release()
+    after = rss_bytes()
+    result = MemoryReleaseResult(
+        trigger=trigger,
+        platform_call=call,
+        rss_before_mb=before // (1024 * 1024),
+        rss_after_mb=after // (1024 * 1024),
+        reclaimed_mb=(before - after) // (1024 * 1024),
+        gc_collected=collected,
+        duration_ms=int((time.perf_counter() - started) * 1000),
+    )
+    logger.info(
+        "memory release (%s): rss %d -> %d MB, reclaimed %d MB via %s, gc freed %d objects, %d ms",
+        result.trigger,
+        result.rss_before_mb,
+        result.rss_after_mb,
+        result.reclaimed_mb,
+        result.platform_call,
+        result.gc_collected,
+        result.duration_ms,
+    )
+    return result

--- a/ciris_engine/protocols/services/infrastructure/resource_monitor.py
+++ b/ciris_engine/protocols/services/infrastructure/resource_monitor.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
         CreditSpendResult,
     )
     from ciris_engine.schemas.services.infrastructure.resource_monitor import ResourceBudget, ResourceSnapshot
+    from ciris_engine.schemas.services.resources_core import MemoryReleaseResult
 
 
 @runtime_checkable
@@ -63,6 +64,14 @@ class ResourceMonitorServiceProtocol(ServiceProtocol, Protocol):
         Returns:
             True if resource is available, False if would exceed warning threshold
         """
+        ...
+
+    async def release_memory(self, trigger: str = "manual") -> "MemoryReleaseResult":
+        """Collect garbage and return the allocators' free pages to the OS."""
+        ...
+
+    async def handle_host_memory_pressure(self, level: str) -> "MemoryReleaseResult":
+        """The host OS (Android onTrimMemory, iOS memory warning) asked for memory back."""
         ...
 
     async def check_credit(

--- a/ciris_engine/schemas/services/resources_core.py
+++ b/ciris_engine/schemas/services/resources_core.py
@@ -71,6 +71,29 @@ class ResourceBudget(BaseModel):
     model_config = ConfigDict(extra="forbid", defer_build=True)
 
 
+class MemoryReleaseResult(BaseModel):
+    """What one attempt to hand memory back to the OS actually did.
+
+    Emitted by `release_memory()` whether the trigger was the resource monitor
+    crossing its own threshold or the host OS asking (Android onTrimMemory,
+    iOS memory warning). `reclaimed_mb` can be negative: RSS is sampled live and
+    another thread may allocate between the two reads.
+    """
+
+    trigger: str = Field(description="Who asked: resource_monitor:<signal>, host:<level>, or manual")
+    platform_call: str = Field(
+        description="Allocator call made: malloc_trim, mallopt(M_PURGE), malloc_zone_pressure_relief, none, or unavailable:<why>"
+    )
+    rss_before_mb: int = Field(ge=0, description="Resident set before, in MB")
+    rss_after_mb: int = Field(ge=0, description="Resident set after, in MB")
+    reclaimed_mb: int = Field(description="rss_before_mb - rss_after_mb")
+    gc_collected: int = Field(ge=0, description="Unreachable objects gc.collect() found")
+    duration_ms: int = Field(ge=0, description="Wall time of the whole release")
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class ResourceSnapshot(BaseModel):
     """Current resource usage snapshot"""
 

--- a/tests/ciris_engine/logic/adapters/api/routes/system/test_runtime_memory_release.py
+++ b/tests/ciris_engine/logic/adapters/api/routes/system/test_runtime_memory_release.py
@@ -1,0 +1,92 @@
+"""POST /system/runtime/memory/release — the operator/QA trigger for the give-back chain."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from ciris_engine.logic.adapters.api.dependencies.auth import require_admin
+from ciris_engine.logic.adapters.api.routes.system.runtime import router
+from ciris_engine.schemas.services.resources_core import MemoryReleaseResult
+
+
+def _result(trigger: str = "api:admin") -> MemoryReleaseResult:
+    return MemoryReleaseResult(
+        trigger=trigger,
+        platform_call="malloc_trim",
+        rss_before_mb=800,
+        rss_after_mb=520,
+        reclaimed_mb=280,
+        gc_collected=12,
+        duration_ms=21,
+    )
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(router, prefix="/system")
+    app.dependency_overrides[require_admin] = lambda: MagicMock()
+    app.state.runtime = None
+    return app
+
+
+def test_release_uses_the_monitor_on_app_state(app: FastAPI):
+    monitor = MagicMock()
+    monitor.release_memory = AsyncMock(return_value=_result())
+    app.state.resource_monitor = monitor
+
+    response = TestClient(app).post("/system/runtime/memory/release")
+
+    assert response.status_code == 200, response.text
+    data = response.json()["data"]
+    assert data["reclaimed_mb"] == 280
+    assert data["platform_call"] == "malloc_trim"
+    monitor.release_memory.assert_awaited_once_with(trigger="api:admin")
+
+
+def test_release_falls_back_to_the_runtime_service(app: FastAPI):
+    monitor = MagicMock()
+    monitor.release_memory = AsyncMock(return_value=_result())
+    app.state.resource_monitor = None
+    app.state.runtime = MagicMock(resource_monitor_service=monitor)
+
+    response = TestClient(app).post("/system/runtime/memory/release")
+
+    assert response.status_code == 200, response.text
+    monitor.release_memory.assert_awaited_once()
+
+
+def test_release_is_503_without_a_monitor(app: FastAPI):
+    app.state.resource_monitor = None
+    app.state.runtime = None
+
+    response = TestClient(app).post("/system/runtime/memory/release")
+
+    assert response.status_code == 503
+
+
+def test_release_is_not_swallowed_by_the_generic_runtime_action_route(app: FastAPI):
+    """`/runtime/{action}` must not capture `/runtime/memory/release` and 400 it."""
+    monitor = MagicMock()
+    monitor.release_memory = AsyncMock(return_value=_result())
+    app.state.resource_monitor = monitor
+
+    response = TestClient(app).post("/system/runtime/memory/release")
+
+    assert response.status_code == 200, response.text
+
+
+def test_release_requires_admin():
+    """Without the admin dependency satisfied the handler is never reached."""
+    app = FastAPI()
+    app.include_router(router, prefix="/system")
+    monitor = MagicMock()
+    monitor.release_memory = AsyncMock(return_value=_result())
+    app.state.resource_monitor = monitor
+
+    response = TestClient(app).post("/system/runtime/memory/release")
+
+    assert response.status_code != 200, response.text
+    monitor.release_memory.assert_not_awaited()

--- a/tests/ciris_engine/logic/adapters/api/routes/system/test_runtime_memory_release.py
+++ b/tests/ciris_engine/logic/adapters/api/routes/system/test_runtime_memory_release.py
@@ -90,3 +90,14 @@ def test_release_requires_admin():
 
     assert response.status_code != 200, response.text
     monitor.release_memory.assert_not_awaited()
+
+
+def test_release_failure_is_a_500_with_the_reason(app: FastAPI):
+    monitor = MagicMock()
+    monitor.release_memory = AsyncMock(side_effect=RuntimeError("allocator exploded"))
+    app.state.resource_monitor = monitor
+
+    response = TestClient(app).post("/system/runtime/memory/release")
+
+    assert response.status_code == 500
+    assert "allocator exploded" in response.json()["detail"]

--- a/tests/ciris_engine/logic/services/infrastructure/test_resource_monitor.py
+++ b/tests/ciris_engine/logic/services/infrastructure/test_resource_monitor.py
@@ -259,15 +259,20 @@ async def test_resource_monitor_cooldown(resource_monitor, signal_bus):
     resource_monitor.budget.memory_mb.cooldown_seconds = 1
     resource_monitor.budget.memory_mb.action = ResourceAction.DEFER
 
-    # Exceed critical threshold multiple times quickly
-    resource_monitor.snapshot.memory_mb = 3841  # Exceeds critical (3840)
+    # The monitor now acts on its own memory signal: the built-in handler
+    # releases and writes the post-release RSS back into the snapshot. This
+    # test is about the cooldown, not the release, so re-assert the
+    # over-critical reading before every check rather than assume it persists.
+    over_critical = resource_monitor.budget.memory_mb.critical + 1
 
     # First check should emit signal
+    resource_monitor.snapshot.memory_mb = over_critical
     await resource_monitor._check_limits()
     initial_count = len(emitted_signals)
     assert initial_count == 1  # Should have one signal
 
     # Immediate second check should not emit due to cooldown
+    resource_monitor.snapshot.memory_mb = over_critical
     await resource_monitor._check_limits()
     assert len(emitted_signals) == initial_count
 
@@ -275,6 +280,7 @@ async def test_resource_monitor_cooldown(resource_monitor, signal_bus):
     await asyncio.sleep(1.1)
 
     # Now should emit again
+    resource_monitor.snapshot.memory_mb = over_critical
     await resource_monitor._check_limits()
     assert len(emitted_signals) > initial_count
 
@@ -1580,3 +1586,111 @@ async def test_billing_provider_handle_check_network_error():
         assert "TIMEOUT" in (result.reason or "")
     finally:
         await provider.stop()
+
+
+# ---------------------------------------------------------------------------
+# Memory give-back: the monitor is its own first subscriber
+# ---------------------------------------------------------------------------
+
+from ciris_engine.logic.services.infrastructure.resource_monitor import service as _rm_service
+from ciris_engine.schemas.services.resources_core import MemoryReleaseResult
+
+
+def _fake_release(calls):
+    def fake(trigger: str) -> MemoryReleaseResult:
+        calls.append(trigger)
+        return MemoryReleaseResult(
+            trigger=trigger,
+            platform_call="malloc_trim",
+            rss_before_mb=900,
+            rss_after_mb=600,
+            reclaimed_mb=300,
+            gc_collected=42,
+            duration_ms=7,
+        )
+
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_memory_defer_actually_releases_memory(resource_monitor, monkeypatch):
+    """Crossing the memory threshold must do more than log: the built-in
+    handler releases, and the snapshot reflects the post-release figure so the
+    next check and the next prompt alert are not judged on a stale sample."""
+    calls: list = []
+    monkeypatch.setattr(_rm_service, "_release_process_memory", _fake_release(calls))
+
+    resource_monitor.budget.memory_mb.action = ResourceAction.DEFER
+    resource_monitor.snapshot.memory_mb = resource_monitor.budget.memory_mb.critical + 1
+    await resource_monitor._check_limits()
+
+    assert calls == ["resource_monitor:defer"]
+    assert resource_monitor.snapshot.memory_mb == 600
+    metrics = resource_monitor._collect_custom_metrics()
+    assert metrics["memory_release_count"] == 1.0
+    assert metrics["memory_released_mb_total"] == 300.0
+    assert metrics["memory_last_release_mb"] == 300.0
+    assert metrics["resource_signal_defer_total"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_non_memory_signals_are_counted_but_do_not_release(resource_monitor, monkeypatch):
+    calls: list = []
+    monkeypatch.setattr(_rm_service, "_release_process_memory", _fake_release(calls))
+
+    resource_monitor.snapshot.tokens_used_hour = resource_monitor.budget.tokens_hour.critical + 1
+    await resource_monitor._check_limits()
+
+    assert calls == []
+    metrics = resource_monitor._collect_custom_metrics()
+    assert metrics["resource_signal_defer_total"] == 1.0
+    assert metrics["memory_release_count"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_shutdown_signal_on_memory_does_not_release(resource_monitor, monkeypatch):
+    calls: list = []
+    monkeypatch.setattr(_rm_service, "_release_process_memory", _fake_release(calls))
+
+    resource_monitor.budget.memory_mb.action = ResourceAction.SHUTDOWN
+    resource_monitor.snapshot.memory_mb = resource_monitor.budget.memory_mb.critical + 1
+    await resource_monitor._check_limits()
+
+    assert calls == []
+    assert (resource_monitor._collect_custom_metrics())["resource_signal_shutdown_total"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_host_memory_pressure_bypasses_cooldown(resource_monitor, monkeypatch):
+    """When the OS asks twice in a row, we release twice. The 60 s cooldown
+    protects against our own re-emits, never against the host."""
+    calls: list = []
+    monkeypatch.setattr(_rm_service, "_release_process_memory", _fake_release(calls))
+
+    await resource_monitor.handle_host_memory_pressure("RUNNING_CRITICAL")
+    await resource_monitor.handle_host_memory_pressure("COMPLETE")
+
+    assert calls == ["host:RUNNING_CRITICAL", "host:COMPLETE"]
+    assert (resource_monitor._collect_custom_metrics())["memory_release_count"] == 2.0
+
+
+@pytest.mark.asyncio
+async def test_record_release_accepts_a_release_done_elsewhere(resource_monitor):
+    """Host callbacks release on their own thread and report in afterwards."""
+    result = MemoryReleaseResult(
+        trigger="host:ios_memory_warning",
+        platform_call="malloc_zone_pressure_relief",
+        rss_before_mb=700,
+        rss_after_mb=500,
+        reclaimed_mb=200,
+        gc_collected=0,
+        duration_ms=3,
+    )
+    resource_monitor.record_release(result)
+    assert resource_monitor.snapshot.memory_mb == 500
+    assert (resource_monitor._collect_custom_metrics())["memory_released_mb_total"] == 200.0
+
+
+def test_monitor_is_subscribed_to_its_own_signals(resource_monitor, signal_bus):
+    for signal in ("throttle", "defer", "reject", "shutdown"):
+        assert resource_monitor._on_resource_signal in signal_bus._handlers[signal], signal

--- a/tests/ciris_engine/logic/utils/test_memory_release.py
+++ b/tests/ciris_engine/logic/utils/test_memory_release.py
@@ -75,3 +75,157 @@ def test_release_memory_survives_a_failing_allocator_call(monkeypatch):
     monkeypatch.setattr(memory_release, "_load_libc", lambda: BrokenLibc())
     result = memory_release.release_memory(trigger="manual")
     assert result.platform_call.startswith("unavailable:")
+
+
+# ---------------------------------------------------------------------------
+# Platform dispatch. These exercise the *choice* of allocator call with fake
+# libc objects; the real calls are covered by the glibc test above and, for the
+# phones, by the five-platform gates.
+# ---------------------------------------------------------------------------
+
+
+class _FakeLibc:
+    """Records mallopt/trim/relief calls; `symbols` controls what exists."""
+
+    def __init__(self, symbols, mallopt_results=None):
+        self._symbols = set(symbols)
+        self.calls = []
+        self._mallopt_results = list(mallopt_results or [])
+
+    def __getattr__(self, name):
+        if name not in self._symbols:
+            raise AttributeError(name)
+        fake = self
+
+        class _Fn:
+            argtypes = None
+            restype = None
+
+            def __call__(self, *args):
+                fake.calls.append((name, args))
+                if name == "mallopt" and fake._mallopt_results:
+                    return fake._mallopt_results.pop(0)
+                return 0
+
+        return _Fn()
+
+
+def _use(monkeypatch, libc, *, platform="linux", android=False):
+    monkeypatch.setattr(memory_release.sys, "platform", platform)
+    monkeypatch.setattr(memory_release, "_is_android", lambda: android)
+    monkeypatch.setattr(memory_release, "_load_libc", lambda: libc)
+
+
+def test_android_prefers_purge_all_when_the_device_has_it(monkeypatch):
+    libc = _FakeLibc({"mallopt"}, mallopt_results=[1])
+    _use(monkeypatch, libc, android=True)
+    assert memory_release._platform_release() == "mallopt(M_PURGE_ALL)"
+    assert libc.calls == [("mallopt", (memory_release._BIONIC_M_PURGE_ALL, 0))]
+
+
+def test_android_falls_back_to_purge_on_older_api_levels(monkeypatch):
+    """M_PURGE_ALL is API 34; an older Bionic returns 0 and we try M_PURGE (API 28)."""
+    libc = _FakeLibc({"mallopt"}, mallopt_results=[0, 1])
+    _use(monkeypatch, libc, android=True)
+    assert memory_release._platform_release() == "mallopt(M_PURGE)"
+    assert [c[1][0] for c in libc.calls] == [memory_release._BIONIC_M_PURGE_ALL, memory_release._BIONIC_M_PURGE]
+
+
+def test_android_without_mallopt_reports_unavailable(monkeypatch):
+    _use(monkeypatch, _FakeLibc(set()), android=True)
+    assert memory_release._platform_release() == "unavailable:no mallopt"
+
+
+def test_darwin_uses_malloc_zone_pressure_relief(monkeypatch):
+    libc = _FakeLibc({"malloc_zone_pressure_relief"})
+    _use(monkeypatch, libc, platform="darwin")
+    assert memory_release._platform_release() == "malloc_zone_pressure_relief"
+    assert libc.calls[0][0] == "malloc_zone_pressure_relief"
+
+
+def test_ios_is_darwin_for_this_purpose(monkeypatch):
+    _use(monkeypatch, _FakeLibc({"malloc_zone_pressure_relief"}), platform="ios")
+    assert memory_release._platform_release() == "malloc_zone_pressure_relief"
+
+
+def test_darwin_without_the_symbol_reports_unavailable(monkeypatch):
+    _use(monkeypatch, _FakeLibc(set()), platform="darwin")
+    assert memory_release._platform_release() == "unavailable:no malloc_zone_pressure_relief"
+
+
+def test_linux_without_malloc_trim_reports_unavailable(monkeypatch):
+    _use(monkeypatch, _FakeLibc(set()), platform="linux")
+    assert memory_release._platform_release() == "unavailable:no malloc_trim"
+
+
+def test_no_libc_at_all_is_none(monkeypatch):
+    _use(monkeypatch, None, platform="linux")
+    assert memory_release._platform_release() == "none"
+
+
+def test_load_libc_tries_each_candidate_and_remembers_failure(monkeypatch):
+    attempts = []
+
+    def fake_cdll(name):
+        attempts.append(name)
+        raise OSError("nope")
+
+    monkeypatch.setattr(memory_release.ctypes, "CDLL", fake_cdll)
+    monkeypatch.setattr(memory_release, "_libc", None)
+    monkeypatch.setattr(memory_release, "_libc_failed", False)
+    monkeypatch.setattr(memory_release, "_is_android", lambda: False)
+    monkeypatch.setattr(memory_release.sys, "platform", "darwin")
+    assert memory_release._load_libc() is None
+    assert attempts == ["libSystem.B.dylib", None]
+    # Second call must not retry: a failed dlopen is not going to start working.
+    assert memory_release._load_libc() is None
+    assert attempts == ["libSystem.B.dylib", None]
+
+
+def test_load_libc_picks_bionic_name_on_android(monkeypatch):
+    seen = []
+    monkeypatch.setattr(memory_release.ctypes, "CDLL", lambda name: seen.append(name) or object())
+    monkeypatch.setattr(memory_release, "_libc", None)
+    monkeypatch.setattr(memory_release, "_libc_failed", False)
+    monkeypatch.setattr(memory_release, "_is_android", lambda: True)
+    assert memory_release._load_libc() is not None
+    assert seen == ["libc.so"]
+
+
+def test_rss_bytes_falls_back_to_psutil_without_procfs(monkeypatch):
+    """No /proc (macOS, Windows) -> psutil. psutil itself reads /proc on Linux,
+    so the fallback is proven with a fake module rather than by starving open()."""
+    import builtins
+    import sys
+    import types
+
+    real_open = builtins.open
+
+    def no_procfs(path, *a, **k):
+        if str(path).startswith("/proc/"):
+            raise OSError("no procfs")
+        return real_open(path, *a, **k)
+
+    fake_psutil = types.ModuleType("psutil")
+    fake_psutil.Process = lambda: types.SimpleNamespace(memory_info=lambda: types.SimpleNamespace(rss=123456789))
+    monkeypatch.setattr(builtins, "open", no_procfs)
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+    assert memory_release.rss_bytes() == 123456789
+
+
+def test_rss_bytes_is_zero_when_nothing_can_answer(monkeypatch):
+    import builtins
+    import sys
+
+    monkeypatch.setattr(builtins, "open", lambda *a, **k: (_ for _ in ()).throw(OSError("no procfs")))
+    monkeypatch.setitem(sys.modules, "psutil", None)  # import psutil -> ImportError
+    assert memory_release.rss_bytes() == 0
+
+
+def test_is_android_detection_reads_the_environment(monkeypatch):
+    monkeypatch.delenv("ANDROID_ROOT", raising=False)
+    monkeypatch.delenv("ANDROID_DATA", raising=False)
+    monkeypatch.delattr(memory_release.sys, "getandroidapilevel", raising=False)
+    assert memory_release._is_android() is False
+    monkeypatch.setenv("ANDROID_DATA", "/data")
+    assert memory_release._is_android() is True

--- a/tests/ciris_engine/logic/utils/test_memory_release.py
+++ b/tests/ciris_engine/logic/utils/test_memory_release.py
@@ -1,0 +1,77 @@
+"""The release path has to be shown to release, not just to run."""
+
+import ctypes
+import sys
+
+import pytest
+
+from ciris_engine.logic.utils import memory_release
+from ciris_engine.schemas.services.resources_core import MemoryReleaseResult
+
+
+def _is_glibc_linux() -> bool:
+    if not sys.platform.startswith("linux") or memory_release._is_android():
+        return False
+    try:
+        ctypes.CDLL("libc.so.6").gnu_get_libc_version
+        return True
+    except (OSError, AttributeError):
+        return False
+
+
+def test_release_memory_returns_typed_result():
+    result = memory_release.release_memory(trigger="manual")
+    assert isinstance(result, MemoryReleaseResult)
+    assert result.trigger == "manual"
+    assert result.duration_ms >= 0
+    assert result.gc_collected >= 0
+    if _is_glibc_linux():
+        assert result.platform_call == "malloc_trim"
+
+
+@pytest.mark.skipif(not _is_glibc_linux(), reason="exercises glibc's malloc_trim specifically")
+def test_release_memory_reclaims_fragmented_free_heap():
+    """Freeing every other small block leaves the heap fragmented: glibc's own
+    free() only trims the top, so nothing comes back on its own. malloc_trim
+    MADV_DONTNEEDs the whole pages inside those free chunks. If this test
+    fails to reclaim, the platform call is not doing its job.
+    """
+    libc = ctypes.CDLL("libc.so.6")
+    libc.malloc.restype = ctypes.c_void_p
+    libc.malloc.argtypes = [ctypes.c_size_t]
+    libc.free.argtypes = [ctypes.c_void_p]
+
+    block = 16 * 1024
+    count = 8192  # 128 MB total, 64 MB of it freed below
+    blocks = [libc.malloc(block) for _ in range(count)]
+    for ptr in blocks:
+        ctypes.memset(ptr, 1, block)  # touch, so the pages are actually resident
+    for ptr in blocks[::2]:
+        libc.free(ptr)
+
+    result = memory_release.release_memory(trigger="test")
+    assert result.platform_call == "malloc_trim"
+    assert result.reclaimed_mb >= 20, f"expected a real reclaim from 64 MB of fragmented free heap, got {result}"
+
+    for ptr in blocks[1::2]:
+        libc.free(ptr)
+
+
+def test_release_memory_is_safe_on_an_unknown_platform(monkeypatch):
+    monkeypatch.setattr(memory_release.sys, "platform", "win32")
+    monkeypatch.setattr(memory_release, "_libc", None)
+    monkeypatch.setattr(memory_release, "_libc_failed", False)
+    monkeypatch.setattr(memory_release, "_is_android", lambda: False)
+    result = memory_release.release_memory(trigger="manual")
+    assert result.platform_call == "none"
+    assert result.gc_collected >= 0
+
+
+def test_release_memory_survives_a_failing_allocator_call(monkeypatch):
+    class BrokenLibc:
+        def __getattr__(self, name):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(memory_release, "_load_libc", lambda: BrokenLibc())
+    result = memory_release.release_memory(trigger="manual")
+    assert result.platform_call.startswith("unavailable:")

--- a/tests/tools/qa_runner/test_incidents_log_override.py
+++ b/tests/tools/qa_runner/test_incidents_log_override.py
@@ -1,0 +1,54 @@
+"""`--incidents-log` says where to look; it never says whether to look."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.qa_runner.config import QAConfig
+from tools.qa_runner.runner import QARunner
+
+
+def _runner(tmp_path: Path, explicit: Path | None) -> QARunner:
+    runner = QARunner.__new__(QARunner)  # no __init__: we only need the path logic
+    runner.config = QAConfig(incidents_log_path=explicit, report_dir=tmp_path)
+    runner.console = MagicMock()
+    runner.server_manager = MagicMock(database_backend="sqlite")
+    return runner
+
+
+def test_explicit_path_wins_over_backend_default(tmp_path):
+    explicit = tmp_path / "pulled" / "incidents_latest.log"
+    assert _runner(tmp_path, explicit)._incidents_log_path() == explicit
+
+
+def test_without_override_the_backend_default_is_unchanged(tmp_path):
+    assert _runner(tmp_path, None)._incidents_log_path() == Path("logs/sqlite/incidents_latest.log")
+
+
+def test_missing_explicit_file_still_fails_closed(tmp_path):
+    runner = _runner(tmp_path, tmp_path / "nope" / "incidents_latest.log")
+    runner._startup_incidents_position = 0
+    assert runner._has_incidents_occurred() is True
+    assert getattr(runner, "_incidents_unverifiable", False) is True
+
+
+def test_present_clean_explicit_file_passes(tmp_path):
+    log = tmp_path / "incidents_latest.log"
+    log.write_text("2026-09-09 INFO nothing to see\n")
+    runner = _runner(tmp_path, log)
+    runner._startup_incidents_position = 0
+    assert runner._has_incidents_occurred() is False
+
+
+def test_error_after_baseline_in_explicit_file_is_detected(tmp_path):
+    """The override must not weaken the gate: an ERROR written after the
+    baseline still fails the run, and is reported as found, not unverifiable."""
+    log = tmp_path / "incidents_latest.log"
+    log.write_text("2026-09-09 INFO boot\n")
+    runner = _runner(tmp_path, log)
+    runner._startup_incidents_position = log.stat().st_size
+    with log.open("a") as handle:
+        handle.write("2026-09-09 ERROR something broke during the test\n")
+    assert runner._has_incidents_occurred() is True
+    assert getattr(runner, "_incidents_unverifiable", False) is False

--- a/tests/tools/test_five_platform_workflow_parity.py
+++ b/tests/tools/test_five_platform_workflow_parity.py
@@ -1,0 +1,37 @@
+"""The modular gate's bring-up must stay byte-identical to the UI gate's.
+
+The modular workflow exists to swap ONLY what drives the platform. If its
+emulator/simulator/desktop bring-up drifts from the gate's, a red on one and a
+green on the other stops meaning anything about the product.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+GATE = ROOT / ".github/workflows/five-platform-live-qa.yml"
+MODULAR = ROOT / ".github/workflows/five-platform-modular-qa.yml"
+
+
+def _bring_up(path: Path, driving_step: str) -> str:
+    text = path.read_text()
+    start = text.index("\njobs:\n") + 1
+    end = text.index(driving_step)
+    # Per-line rstrip: the repo's trailing-whitespace hook normalizes whichever
+    # file is touched next, and a byte of trailing space is not bring-up drift.
+    return "\n".join(line.rstrip() for line in text[start:end].splitlines())
+
+
+def test_bring_up_is_identical():
+    gate = _bring_up(GATE, "      - name: Run the shared flow on each platform this runner owns")
+    modular = _bring_up(MODULAR, "      - name: Run the modular QA runner against each platform's backend")
+    assert gate == modular, "bring-up drifted between the two five-platform workflows; regenerate or fix both"
+
+
+def test_modular_driving_step_has_no_inline_expressions():
+    """A run: body containing any ${{ }} is one expression capped at 21000 chars."""
+    text = MODULAR.read_text()
+    start = text.index("      - name: Run the modular QA runner against each platform's backend")
+    end = text.index("      - name: Collect artifacts", start)
+    step = text[start:end]
+    run_body = step[step.index("        run: |") :]
+    assert "${{" not in run_body

--- a/tools/memory_benchmark.py
+++ b/tools/memory_benchmark.py
@@ -15,6 +15,7 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Optional
 
 
 def format_size(size: float) -> str:
@@ -339,6 +340,36 @@ def verify_task_processing(
     return False, task_complete_count, speak_count
 
 
+def dump_composition(pid: int, json_path: Optional[str] = None) -> None:
+    """Print what the resident set is actually made of.
+
+    Imported lazily so the benchmark keeps working if the tool is absent, and
+    never fatal: a failed introspection must not fail a memory run.
+    """
+    print("\n[composition] attributing resident memory...")
+    try:
+        # This file is usually run as a script, so `tools` is not importable as
+        # a package -- load the sibling module by path instead of by name.
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "memory_composition", Path(__file__).parent / "memory_composition.py"
+        )
+        if spec is None or spec.loader is None:
+            raise ImportError("cannot locate tools/memory_composition.py")
+        memory_composition = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(memory_composition)
+
+        report = memory_composition.collect(pid, probe=True, trim=True)
+        print(memory_composition.render(report))
+        if json_path:
+            with open(json_path, "w", encoding="utf-8") as handle:
+                json.dump(report, handle, indent=2, sort_keys=True)
+            print(f"  wrote {json_path}")
+    except Exception as exc:
+        print(f"  composition failed: {exc}")
+
+
 def main(
     messages: int = 100,
     adapter: str = "api",
@@ -346,6 +377,8 @@ def main(
     concurrency: int = 20,
     verify_audit: bool = False,
     idle_seconds: int = 0,
+    composition: bool = False,
+    composition_json: Optional[str] = None,
 ) -> int:
     """Run memory benchmark with N messages."""
     print("=" * 70)
@@ -362,6 +395,15 @@ def main(
     # Benchmarks measure per-task throughput, so bypass the channel-level task-append
     # coalescing in BaseObserver. See ciris_engine/logic/adapters/base_observer.py.
     env.setdefault("CIRIS_DISABLE_TASK_APPEND", "1")
+
+    if composition:
+        # Arming is purely a launch-time concern: putting tools/memprobe on
+        # PYTHONPATH makes `site` import its sitecustomize, which registers a
+        # SIGUSR1 handler.  No engine code is involved and nothing changes when
+        # the flag is off.
+        probe_dir = project_root / "tools" / "memprobe"
+        env["CIRIS_MEMPROBE"] = "1"
+        env["PYTHONPATH"] = os.pathsep.join(filter(None, [str(probe_dir), env.get("PYTHONPATH", "")]))
 
     cmd = [
         sys.executable,
@@ -486,6 +528,11 @@ def main(
                     f"delta={last - first:+.1f}MB plateau={'yes' if stable else 'no'}"
                 )
 
+        # Composition is taken last, at the plateau, because that is the number
+        # the resource budget is judged against.
+        if composition:
+            dump_composition(pid, composition_json)
+
     except Exception as e:
         print(f"  ERROR: {e}")
     finally:
@@ -553,6 +600,19 @@ def parse_args() -> argparse.Namespace:
             "drains and RAM plateaus. Default 0 (matches old behavior)."
         ),
     )
+    parser.add_argument(
+        "--composition",
+        action="store_true",
+        help=(
+            "At the end of the run, attribute resident memory to allocators and "
+            "mappings (see tools/memory_composition.py). Arms the in-process probe."
+        ),
+    )
+    parser.add_argument(
+        "--composition-json",
+        default=None,
+        help="Write the composition report here as JSON",
+    )
     return parser.parse_args()
 
 
@@ -566,5 +626,7 @@ if __name__ == "__main__":
             concurrency=max(1, args.concurrency),
             verify_audit=args.verify_audit,
             idle_seconds=max(0, args.idle_seconds),
+            composition=args.composition,
+            composition_json=args.composition_json,
         )
     )

--- a/tools/memory_benchmark.py
+++ b/tools/memory_benchmark.py
@@ -171,8 +171,9 @@ async def send_messages(
     so a CI summary can show *why* messages failed instead of just the
     aggregate count.
     """
-    import httpx
     from collections import Counter
+
+    import httpx
 
     queue: asyncio.Queue[int] = asyncio.Queue()
     for i in range(messages):
@@ -521,7 +522,7 @@ def main(
                 last = idle_samples[-1][1]
                 peak = max(s[1] for s in idle_samples)
                 # Plateau = last 10% of samples agree within 1 MB
-                tail = idle_samples[-max(1, len(idle_samples) // 10):]
+                tail = idle_samples[-max(1, len(idle_samples) // 10) :]
                 stable = (max(s[1] for s in tail) - min(s[1] for s in tail)) < 1.0
                 print(
                     f"  Idle: first={first:.1f}MB peak={peak:.1f}MB final={last:.1f}MB "

--- a/tools/memory_composition.py
+++ b/tools/memory_composition.py
@@ -1,0 +1,503 @@
+"""Answer *what* a CIRIS process's resident memory is made of, not just how much.
+
+`tools/memory_benchmark.py` reports a single RSS number.  When that number moved
+from 317 MB to 732 MB between releases there was nothing in the repo that could
+say which allocator the extra bytes belonged to, so this exists.
+
+Two halves, because no single vantage point sees everything:
+
+* **Out of process** (this module, always available): `/proc/PID/smaps` attributes
+  every resident page to a mapping, which cleanly separates file-backed images --
+  the .so files, whose 82 MB on disk cost only what is actually touched -- from
+  anonymous memory, which is heap.  `/proc/PID/task/*/comm` names every OS thread,
+  which is how a native runtime's worker pool announces itself.
+* **In process** (`tools/memprobe/`, opt-in): pymalloc and glibc each account for
+  their own arenas and neither is visible to the other from outside.  Pass
+  `--probe` to SIGUSR1 the target and fold its report in.
+
+Usage:
+    python3 -m tools.memory_composition --pid 12345
+    python3 -m tools.memory_composition --pid 12345 --probe --json out.json
+
+To make `--probe` work, the target must have been started with the probe armed:
+    PYTHONPATH=tools/memprobe CIRIS_MEMPROBE=1 python main.py --adapter api
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import sys
+import time
+from collections import Counter, defaultdict
+from typing import Any, Dict, List, Optional, Tuple
+
+MIB = 1048576.0
+KIB = 1024.0
+
+# glibc reserves a 64 MiB region per secondary arena (HEAP_MAX_SIZE on 64-bit)
+# and mprotects only the committed prefix, so an arena appears in smaps as a
+# small rw-p mapping followed by a large ---p one, together 64 MiB and aligned.
+GLIBC_ARENA_RESERVE_KB = 64 * 1024
+# A pthread stack is an ordinary anonymous mapping, distinguishable only by the
+# PROT_NONE guard page glibc places immediately below it.
+MAX_GUARD_KB = 64
+
+
+# --------------------------------------------------------------------------
+# /proc readers
+# --------------------------------------------------------------------------
+
+
+def read_smaps_rollup(pid: int) -> Dict[str, int]:
+    """Kernel-computed totals for the whole address space, in kB."""
+    out: Dict[str, int] = {}
+    try:
+        with open(f"/proc/{pid}/smaps_rollup", encoding="utf-8") as handle:
+            for line in handle:
+                if ":" not in line:
+                    continue
+                key, _, value = line.partition(":")
+                value = value.strip()
+                if value.endswith("kB"):
+                    out[key.strip()] = int(value[:-2].strip())
+    except OSError:
+        pass
+    return out
+
+
+def read_status(pid: int) -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    try:
+        with open(f"/proc/{pid}/status", encoding="utf-8") as handle:
+            for line in handle:
+                key, _, value = line.partition(":")
+                value = value.strip()
+                if value.endswith("kB"):
+                    out[key] = int(value[:-2].strip())
+                elif key in ("Threads", "Name"):
+                    out[key] = int(value) if value.isdigit() else value
+    except OSError:
+        pass
+    return out
+
+
+def read_smaps(pid: int) -> List[Dict[str, Any]]:
+    """One entry per mapping, carrying the fields that matter for attribution."""
+    wanted = ("Size", "Rss", "Pss", "Private_Dirty", "Private_Clean", "Shared_Dirty", "Anonymous", "Swap")
+    mappings: List[Dict[str, Any]] = []
+    current: Optional[Dict[str, Any]] = None
+    try:
+        with open(f"/proc/{pid}/smaps", encoding="utf-8") as handle:
+            for line in handle:
+                if "-" in line[:20] and " " in line and ":" not in line.split()[0]:
+                    parts = line.split(maxsplit=5)
+                    if len(parts) >= 5 and "-" in parts[0]:
+                        if current is not None:
+                            mappings.append(current)
+                        start, _, end = parts[0].partition("-")
+                        current = {
+                            "range": parts[0],
+                            "start": int(start, 16),
+                            "end": int(end, 16),
+                            "perms": parts[1],
+                            "path": parts[5].strip() if len(parts) > 5 else "",
+                        }
+                        continue
+                if current is None:
+                    continue
+                key, _, value = line.partition(":")
+                if key in wanted:
+                    current[key] = int(value.strip()[:-2].strip())
+    except OSError:
+        return []
+    if current is not None:
+        mappings.append(current)
+    return mappings
+
+
+def read_thread_comms(pid: int) -> Counter:
+    names: Counter = Counter()
+    task_dir = f"/proc/{pid}/task"
+    try:
+        for tid in os.listdir(task_dir):
+            try:
+                with open(os.path.join(task_dir, tid, "comm"), encoding="utf-8") as handle:
+                    names[handle.read().strip()] += 1
+            except OSError:
+                continue
+    except OSError:
+        pass
+    return names
+
+
+# --------------------------------------------------------------------------
+# Classification
+# --------------------------------------------------------------------------
+
+
+def classify(mapping: Dict[str, Any]) -> Tuple[str, str]:
+    """Return (class, label) for one mapping, ignoring its neighbours."""
+    path = mapping.get("path", "")
+
+    if path == "[heap]":
+        return "brk-heap", "[heap] main arena"
+    if path == "[stack]":
+        return "stack", "[stack] main"
+    if path.startswith("[") and path.endswith("]"):
+        return "kernel", path
+    if not path:
+        return "anon", "anon >=4M (large)" if mapping.get("Size", 0) >= 4096 else "anon <4M (small)"
+
+    base = os.path.basename(path)
+    if ".so" in base:
+        return "lib", base
+    if base.endswith((".db", ".db-wal", ".db-shm", ".sqlite", ".sqlite3")):
+        return "sqlite", base
+    if path.startswith("/memfd:") or path.startswith("/dev/shm"):
+        return "shm", base
+    if path.startswith("/dev/"):
+        return "dev", base
+    return "file", base
+
+
+def refine_anonymous(mappings: List[Dict[str, Any]]) -> None:
+    """Re-label anonymous mappings using their neighbours.
+
+    Size alone is not enough and guessing from it is actively wrong: a worker
+    thread's 8 MiB stack and a worker thread's 8 MiB malloc are the same size.
+    What separates them is layout -- glibc puts a PROT_NONE guard page directly
+    below every pthread stack, and reserves each secondary arena as one 64 MiB
+    aligned span whose untouched tail stays PROT_NONE.  Both are unambiguous in
+    the mapping list and neither is visible from a single entry.
+    """
+    ordered = sorted(mappings, key=lambda m: m.get("start", 0))
+    for index, mapping in enumerate(ordered):
+        if mapping.get("path") or mapping.get("_class") != "anon":
+            continue
+        perms = mapping.get("perms", "")
+        size_kb = mapping.get("Size", 0)
+        prev = ordered[index - 1] if index > 0 else None
+        nxt = ordered[index + 1] if index + 1 < len(ordered) else None
+
+        if perms.startswith("rw"):
+            # glibc secondary arena: committed prefix of a 64 MiB aligned span.
+            if (
+                nxt is not None
+                and not nxt.get("path")
+                and nxt.get("perms", "").startswith("---")
+                and nxt.get("start") == mapping.get("end")
+                and size_kb + nxt.get("Size", 0) == GLIBC_ARENA_RESERVE_KB
+                and mapping.get("start", 1) % (GLIBC_ARENA_RESERVE_KB * 1024) == 0
+            ):
+                mapping["_label"] = "glibc secondary arena (committed)"
+                nxt["_label"] = "glibc secondary arena (reserve)"
+                nxt["_class"] = "anon"
+                continue
+            # pthread stack: guard page directly below.
+            if (
+                prev is not None
+                and not prev.get("path")
+                and prev.get("perms", "").startswith("---")
+                and prev.get("end") == mapping.get("start")
+                and prev.get("Size", 0) <= MAX_GUARD_KB
+                and mapping.get("_label") != "glibc secondary arena (committed)"
+            ):
+                mapping["_class"] = "stack"
+                mapping["_label"] = "thread stack"
+                prev["_class"] = "stack"
+                prev["_label"] = "thread stack guard"
+
+
+def aggregate(mappings: List[Dict[str, Any]]) -> Dict[str, Any]:
+    for mapping in mappings:
+        klass, label = classify(mapping)
+        mapping["_class"] = klass
+        mapping["_label"] = label
+    refine_anonymous(mappings)
+
+    by_class: Dict[str, Dict[str, int]] = defaultdict(lambda: {"count": 0, "size_kb": 0, "rss_kb": 0, "dirty_kb": 0})
+    by_label: Dict[str, Dict[str, int]] = defaultdict(lambda: {"count": 0, "size_kb": 0, "rss_kb": 0, "dirty_kb": 0})
+    anon_size_hist: Counter = Counter()
+
+    for mapping in mappings:
+        klass = mapping["_class"]
+        label = mapping["_label"]
+        size_kb = mapping.get("Size", 0)
+        rss_kb = mapping.get("Rss", 0)
+        dirty_kb = mapping.get("Private_Dirty", 0) + mapping.get("Shared_Dirty", 0)
+        for bucket, key in ((by_class, klass), (by_label, f"{klass}:{label}")):
+            bucket[key]["count"] += 1
+            bucket[key]["size_kb"] += size_kb
+            bucket[key]["rss_kb"] += rss_kb
+            bucket[key]["dirty_kb"] += dirty_kb
+        if klass == "anon":
+            anon_size_hist[size_kb] += 1
+
+    return {
+        "by_class": dict(by_class),
+        "by_label": dict(by_label),
+        "anon_size_hist_kb": dict(anon_size_hist.most_common()),
+        "mapping_count": len(mappings),
+    }
+
+
+# --------------------------------------------------------------------------
+# In-process probe
+# --------------------------------------------------------------------------
+
+
+def trigger_probe(pid: int, out_path: str, timeout: float = 30.0) -> Optional[Dict[str, Any]]:
+    """SIGUSR1 the target and wait for it to drop a report.
+
+    The probe writes to a `.partial` file and renames, so seeing the path at all
+    means the JSON is complete.
+    """
+    before = os.path.getmtime(out_path) if os.path.exists(out_path) else 0.0
+    try:
+        os.kill(pid, signal.SIGUSR1)
+    except OSError as exc:
+        print(f"  probe: cannot signal pid {pid}: {exc}", file=sys.stderr)
+        return None
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if os.path.exists(out_path) and os.path.getmtime(out_path) > before:
+            try:
+                with open(out_path, encoding="utf-8") as handle:
+                    return json.load(handle)
+            except (OSError, ValueError):
+                pass
+        time.sleep(0.25)
+    print(f"  probe: no report at {out_path} within {timeout:.0f}s", file=sys.stderr)
+    return None
+
+
+# --------------------------------------------------------------------------
+# Reporting
+# --------------------------------------------------------------------------
+
+
+def _mb(kb: float) -> float:
+    return kb / KIB
+
+
+def render(report: Dict[str, Any], top: int = 20) -> str:
+    lines: List[str] = []
+    rollup = report["rollup"]
+    status = report["status"]
+    agg = report["mappings"]
+    rss_kb = rollup.get("Rss", status.get("VmRSS", 0))
+
+    def pct(kb: float) -> str:
+        return f"{(kb / rss_kb * 100):5.1f}%" if rss_kb else "    - "
+
+    lines.append("=" * 74)
+    lines.append(f"MEMORY COMPOSITION - pid {report['pid']} ({status.get('Name', '?')})")
+    lines.append("=" * 74)
+    lines.append(f"  RSS                {_mb(rss_kb):9.1f} MB     PSS {_mb(rollup.get('Pss', 0)):9.1f} MB")
+    lines.append(
+        f"  Private_Dirty      {_mb(rollup.get('Private_Dirty', 0)):9.1f} MB"
+        f"     Swap {_mb(rollup.get('Swap', 0)):8.1f} MB"
+    )
+    lines.append(
+        f"  Anonymous          {_mb(rollup.get('Anonymous', 0)):9.1f} MB"
+        f"     VmSize {_mb(status.get('VmSize', 0)):9.1f} MB (virtual)"
+    )
+    lines.append(f"  OS threads         {status.get('Threads', 0):9d}        mappings {agg['mapping_count']:6d}")
+
+    lines.append("")
+    lines.append("-- resident by class ------------------------------------------------------")
+    lines.append(f"  {'class':<14} {'RSS MB':>9} {'  %':>6} {'mapped MB':>10} {'touched':>8} {'n':>6}")
+    for klass, vals in sorted(agg["by_class"].items(), key=lambda kv: -kv[1]["rss_kb"]):
+        touched = (vals["rss_kb"] / vals["size_kb"] * 100) if vals["size_kb"] else 0.0
+        lines.append(
+            f"  {klass:<14} {_mb(vals['rss_kb']):9.1f} {pct(vals['rss_kb']):>6} "
+            f"{_mb(vals['size_kb']):10.1f} {touched:7.1f}% {vals['count']:6d}"
+        )
+
+    lines.append("")
+    lines.append(f"-- top {top} mappings by RSS " + "-" * 43)
+    lines.append(f"  {'label':<44} {'RSS MB':>9} {'mapped MB':>10}")
+    ranked = sorted(agg["by_label"].items(), key=lambda kv: -kv[1]["rss_kb"])[:top]
+    for label, vals in ranked:
+        lines.append(f"  {label[:44]:<44} {_mb(vals['rss_kb']):9.1f} {_mb(vals['size_kb']):10.1f}")
+
+    lines.append("")
+    lines.append("-- OS threads by name -----------------------------------------------------")
+    for name, count in report["threads"].items():
+        lines.append(f"  {name:<40} {count:6d}")
+
+    probe = report.get("probe")
+    if probe:
+        lines.append("")
+        lines.append("-- allocators (in-process) ------------------------------------------------")
+        glibc = probe.get("glibc_malloc", {})
+        if glibc.get("arenas") is not None:
+            lines.append(
+                f"  glibc malloc   arenas={glibc['arenas']:<4d} "
+                f"from OS {glibc['system_current_bytes'] / MIB:9.1f} MB"
+            )
+            lines.append(
+                f"                 in use  {glibc['in_use_bytes'] / MIB:9.1f} MB     "
+                f"free but retained {glibc['free_bytes'] / MIB:9.1f} MB ({glibc['retention_ratio'] * 100:.1f}%)"
+            )
+            lines.append(f"                 mmapped {glibc['mmapped_bytes'] / MIB:9.1f} MB  ({glibc['mmapped_count']} blocks)")
+        pym = probe.get("pymalloc", {})
+        if pym.get("available"):
+            allocated = pym.get("bytes_in_allocated_blocks", 0)
+            arena_total = pym.get("arena_total_bytes", 0)
+            lines.append(
+                f"  pymalloc       arenas={pym.get('arena_count', 0):<4d} "
+                f"reserved {arena_total / MIB:9.1f} MB"
+            )
+            lines.append(
+                f"                 in use  {allocated / MIB:9.1f} MB     "
+                f"free in arenas    {(arena_total - allocated) / MIB:9.1f} MB"
+            )
+        census = probe.get("gc", {})
+        if census.get("available"):
+            lines.append(
+                f"  python objects {census['tracked_objects']:>9,d} tracked   "
+                f"shallow {census['shallow_bytes_total'] / MIB:9.1f} MB"
+            )
+        tasks = probe.get("asyncio", {})
+        if tasks.get("available"):
+            lines.append(f"  asyncio tasks  {tasks.get('count', 0):>9,d}")
+
+        lines.append("")
+        lines.append("-- reconciliation ---------------------------------------------------------")
+        file_kb = sum(
+            vals["rss_kb"] for klass, vals in agg["by_class"].items() if klass in ("lib", "file", "sqlite", "shm", "dev")
+        )
+        pym_kb = pym.get("arena_total_bytes", 0) / KIB if pym.get("available") else 0
+        glibc_use_kb = glibc.get("in_use_bytes", 0) / KIB
+        glibc_free_kb = glibc.get("free_bytes", 0) / KIB
+        # Allocations above the mmap threshold bypass the arenas entirely, so
+        # they are absent from `system current` and have to be added back.
+        glibc_mmap_kb = glibc.get("mmapped_bytes", 0) / KIB
+        stack_kb = agg["by_class"].get("stack", {}).get("rss_kb", 0)
+        accounted = file_kb + pym_kb + glibc_use_kb + glibc_free_kb + glibc_mmap_kb + stack_kb
+        lines.append(f"  file-backed images (touched)     {_mb(file_kb):9.1f} MB {pct(file_kb)}")
+        lines.append(f"  pymalloc arenas (python objects) {_mb(pym_kb):9.1f} MB {pct(pym_kb)}")
+        lines.append(f"  glibc arenas, in use             {_mb(glibc_use_kb):9.1f} MB {pct(glibc_use_kb)}")
+        lines.append(f"  glibc arenas, free not returned  {_mb(glibc_free_kb):9.1f} MB {pct(glibc_free_kb)}")
+        lines.append(f"  glibc mmapped blocks (large)     {_mb(glibc_mmap_kb):9.1f} MB {pct(glibc_mmap_kb)}")
+        lines.append(f"  thread stacks                    {_mb(stack_kb):9.1f} MB {pct(stack_kb)}")
+        lines.append(f"  {'-' * 60}")
+        lines.append(f"  accounted                        {_mb(accounted):9.1f} MB {pct(accounted)}")
+        lines.append(f"  residual (RSS - accounted)       {_mb(rss_kb - accounted):9.1f} MB {pct(rss_kb - accounted)}")
+        lines.append("  note: allocator figures are bytes held from the OS, which for a")
+        lines.append("  demand-paged region can exceed what is resident -- expect a small")
+        lines.append("  negative residual rather than an exact sum.")
+
+    trim_result = report.get("trim")
+    if trim_result and trim_result.get("available"):
+        after = report.get("after_trim", {}).get("rollup", {})
+        lines.append("")
+        lines.append("-- malloc_trim (what is reclaimable in place) -----------------------------")
+        lines.append(f"  RSS before                       {trim_result['rss_before_bytes'] / MIB:9.1f} MB")
+        lines.append(f"  RSS after                        {trim_result['rss_after_bytes'] / MIB:9.1f} MB")
+        lines.append(
+            f"  reclaimed                        {trim_result['reclaimed_bytes'] / MIB:9.1f} MB "
+            f"in {trim_result['seconds']:.2f}s"
+        )
+        if after:
+            lines.append(f"  (smaps confirms                  {_mb(after.get('Rss', 0)):9.1f} MB)")
+
+    lines.append("=" * 74)
+    return "\n".join(lines)
+
+
+def trigger_trim(pid: int, out_path: str, timeout: float = 60.0) -> Optional[Dict[str, Any]]:
+    """SIGUSR2 the target to run malloc_trim, and read back what it reclaimed."""
+    path = f"{out_path}.trim"
+    before = os.path.getmtime(path) if os.path.exists(path) else 0.0
+    try:
+        os.kill(pid, signal.SIGUSR2)
+    except OSError as exc:
+        print(f"  trim: cannot signal pid {pid}: {exc}", file=sys.stderr)
+        return None
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if os.path.exists(path) and os.path.getmtime(path) > before:
+            try:
+                with open(path, encoding="utf-8") as handle:
+                    return json.load(handle)
+            except (OSError, ValueError):
+                pass
+        time.sleep(0.25)
+    print(f"  trim: no result at {path} within {timeout:.0f}s", file=sys.stderr)
+    return None
+
+
+def collect(pid: int, probe: bool = False, probe_out: Optional[str] = None, trim: bool = False) -> Dict[str, Any]:
+    mappings = read_smaps(pid)
+    report: Dict[str, Any] = {
+        "schema": "ciris-memory-composition/1",
+        "pid": pid,
+        "timestamp": time.time(),
+        "rollup": read_smaps_rollup(pid),
+        "status": read_status(pid),
+        "mappings": aggregate(mappings),
+        "threads": dict(read_thread_comms(pid).most_common()),
+    }
+    if probe:
+        path = probe_out or f"/tmp/ciris_memprobe.{pid}.json"
+        report["probe"] = trigger_probe(pid, path)
+        if trim:
+            # Measured last: trimming changes the process, so everything above
+            # describes the untouched steady state.
+            report["trim"] = trigger_trim(pid, path)
+            report["after_trim"] = {
+                "rollup": read_smaps_rollup(pid),
+                "mappings": aggregate(read_smaps(pid)),
+            }
+    return report
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--pid", type=int, required=True, help="target process")
+    parser.add_argument("--probe", action="store_true", help="SIGUSR1 the target for allocator detail")
+    parser.add_argument("--probe-out", default=None, help="path the probe writes to")
+    parser.add_argument(
+        "--trim",
+        action="store_true",
+        help="after reporting, run malloc_trim in the target and measure what it gives back",
+    )
+    parser.add_argument("--json", dest="json_path", default=None, help="also write the raw report here")
+    parser.add_argument("--top", type=int, default=20, help="mappings to list")
+    parser.add_argument(
+        "--max-rss-mb",
+        type=float,
+        default=None,
+        help="exit non-zero if RSS exceeds this, for use as a regression gate",
+    )
+    args = parser.parse_args(argv)
+
+    if not os.path.exists(f"/proc/{args.pid}"):
+        print(f"no such process: {args.pid}", file=sys.stderr)
+        return 2
+
+    report = collect(args.pid, probe=args.probe, probe_out=args.probe_out, trim=args.trim)
+    print(render(report, top=args.top))
+
+    if args.json_path:
+        with open(args.json_path, "w", encoding="utf-8") as handle:
+            json.dump(report, handle, indent=2, sort_keys=True)
+        print(f"\nwrote {args.json_path}")
+
+    if args.max_rss_mb is not None:
+        rss_mb = report["rollup"].get("Rss", report["status"].get("VmRSS", 0)) / KIB
+        if rss_mb > args.max_rss_mb:
+            print(f"\nFAIL: RSS {rss_mb:.1f} MB exceeds budget {args.max_rss_mb:.1f} MB")
+            return 1
+        print(f"\nOK: RSS {rss_mb:.1f} MB within budget {args.max_rss_mb:.1f} MB")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/memory_composition.py
+++ b/tools/memory_composition.py
@@ -353,14 +353,15 @@ def render(report: Dict[str, Any], top: int = 20) -> str:
                 f"                 in use  {glibc['in_use_bytes'] / MIB:9.1f} MB     "
                 f"free but retained {glibc['free_bytes'] / MIB:9.1f} MB ({glibc['retention_ratio'] * 100:.1f}%)"
             )
-            lines.append(f"                 mmapped {glibc['mmapped_bytes'] / MIB:9.1f} MB  ({glibc['mmapped_count']} blocks)")
+            lines.append(
+                f"                 mmapped {glibc['mmapped_bytes'] / MIB:9.1f} MB  ({glibc['mmapped_count']} blocks)"
+            )
         pym = probe.get("pymalloc", {})
         if pym.get("available"):
             allocated = pym.get("bytes_in_allocated_blocks", 0)
             arena_total = pym.get("arena_total_bytes", 0)
             lines.append(
-                f"  pymalloc       arenas={pym.get('arena_count', 0):<4d} "
-                f"reserved {arena_total / MIB:9.1f} MB"
+                f"  pymalloc       arenas={pym.get('arena_count', 0):<4d} " f"reserved {arena_total / MIB:9.1f} MB"
             )
             lines.append(
                 f"                 in use  {allocated / MIB:9.1f} MB     "
@@ -383,7 +384,9 @@ def render(report: Dict[str, Any], top: int = 20) -> str:
             return f"  {label:<32} {_mb(kb):9.1f} MB {pct(kb)}"
 
         file_kb = sum(
-            vals["rss_kb"] for klass, vals in agg["by_class"].items() if klass in ("lib", "file", "sqlite", "shm", "dev")
+            vals["rss_kb"]
+            for klass, vals in agg["by_class"].items()
+            if klass in ("lib", "file", "sqlite", "shm", "dev")
         )
         pym_kb = pym.get("arena_total_bytes", 0) / KIB if pym.get("available") else 0
         glibc_use_kb = (glibc.get("in_use_bytes") or 0) / KIB

--- a/tools/memory_composition.py
+++ b/tools/memory_composition.py
@@ -335,9 +335,18 @@ def render(report: Dict[str, Any], top: int = 20) -> str:
         lines.append("")
         lines.append("-- allocators (in-process) ------------------------------------------------")
         glibc = probe.get("glibc_malloc", {})
-        if glibc.get("arenas") is not None:
+        flavor = glibc.get("flavor", "glibc")
+        if not glibc.get("available", glibc.get("arenas") is not None):
+            if glibc.get("reason"):
+                lines.append(f"  system malloc  UNREADABLE: {glibc['reason']}")
+                lines.append(f"                 {glibc.get('xml_head', '')[:120]!r}")
+        elif glibc.get("system_current_bytes") is None:
+            # Bionic states allocated bytes only.
+            lines.append(f"  {flavor} malloc  heaps={glibc['arenas']:<4d} in use {glibc['in_use_bytes'] / MIB:9.1f} MB")
+            lines.append(f"                 retention not reported by this allocator; see residual below")
+        else:
             lines.append(
-                f"  glibc malloc   arenas={glibc['arenas']:<4d} "
+                f"  {flavor} malloc   arenas={glibc['arenas']:<4d} "
                 f"from OS {glibc['system_current_bytes'] / MIB:9.1f} MB"
             )
             lines.append(
@@ -369,26 +378,33 @@ def render(report: Dict[str, Any], top: int = 20) -> str:
 
         lines.append("")
         lines.append("-- reconciliation ---------------------------------------------------------")
+
+        def row(label: str, kb: float) -> str:
+            return f"  {label:<32} {_mb(kb):9.1f} MB {pct(kb)}"
+
         file_kb = sum(
             vals["rss_kb"] for klass, vals in agg["by_class"].items() if klass in ("lib", "file", "sqlite", "shm", "dev")
         )
         pym_kb = pym.get("arena_total_bytes", 0) / KIB if pym.get("available") else 0
-        glibc_use_kb = glibc.get("in_use_bytes", 0) / KIB
-        glibc_free_kb = glibc.get("free_bytes", 0) / KIB
+        glibc_use_kb = (glibc.get("in_use_bytes") or 0) / KIB
+        glibc_free_kb = (glibc.get("free_bytes") or 0) / KIB
         # Allocations above the mmap threshold bypass the arenas entirely, so
         # they are absent from `system current` and have to be added back.
-        glibc_mmap_kb = glibc.get("mmapped_bytes", 0) / KIB
+        glibc_mmap_kb = (glibc.get("mmapped_bytes") or 0) / KIB
         stack_kb = agg["by_class"].get("stack", {}).get("rss_kb", 0)
         accounted = file_kb + pym_kb + glibc_use_kb + glibc_free_kb + glibc_mmap_kb + stack_kb
-        lines.append(f"  file-backed images (touched)     {_mb(file_kb):9.1f} MB {pct(file_kb)}")
-        lines.append(f"  pymalloc arenas (python objects) {_mb(pym_kb):9.1f} MB {pct(pym_kb)}")
-        lines.append(f"  glibc arenas, in use             {_mb(glibc_use_kb):9.1f} MB {pct(glibc_use_kb)}")
-        lines.append(f"  glibc arenas, free not returned  {_mb(glibc_free_kb):9.1f} MB {pct(glibc_free_kb)}")
-        lines.append(f"  glibc mmapped blocks (large)     {_mb(glibc_mmap_kb):9.1f} MB {pct(glibc_mmap_kb)}")
-        lines.append(f"  thread stacks                    {_mb(stack_kb):9.1f} MB {pct(stack_kb)}")
+        lines.append(row("file-backed images (touched)", file_kb))
+        lines.append(row("pymalloc arenas (python objects)", pym_kb))
+        lines.append(row(f"{flavor} heap, in use", glibc_use_kb))
+        if glibc.get("free_bytes") is None:
+            lines.append(f"  {'heap free but not returned':<32}    (not reported by this allocator)")
+        else:
+            lines.append(row("heap free but not returned", glibc_free_kb))
+            lines.append(row("heap mmapped blocks (large)", glibc_mmap_kb))
+        lines.append(row("thread stacks", stack_kb))
         lines.append(f"  {'-' * 60}")
-        lines.append(f"  accounted                        {_mb(accounted):9.1f} MB {pct(accounted)}")
-        lines.append(f"  residual (RSS - accounted)       {_mb(rss_kb - accounted):9.1f} MB {pct(rss_kb - accounted)}")
+        lines.append(row("accounted", accounted))
+        lines.append(row("residual (RSS - accounted)", rss_kb - accounted))
         lines.append("  note: allocator figures are bytes held from the OS, which for a")
         lines.append("  demand-paged region can exceed what is resident -- expect a small")
         lines.append("  negative residual rather than an exact sum.")

--- a/tools/memprobe/ciris_memprobe.py
+++ b/tools/memprobe/ciris_memprobe.py
@@ -83,12 +83,29 @@ def _malloc_info_xml() -> Optional[str]:
 
 
 def _parse_malloc_info(xml: str) -> Dict[str, Any]:
-    """Reduce the malloc_info XML to the numbers that decide the question.
+    """Reduce malloc_info XML to the numbers that decide the question.
 
-    Per-arena and in total, glibc reports `<system type="current">` (bytes held
-    from the kernel) alongside `<total type="rest">` and `<total type="fast">`
-    (bytes sitting free in bins).  in_use = system - free is the only figure
-    that corresponds to live objects.
+    The schema is the allocator's, not a standard, so dispatch on it and say so
+    when it is one we do not know -- reporting zeros for an unrecognised
+    allocator would look exactly like a process that allocates nothing.
+    """
+    if "<system " in xml:
+        return _parse_malloc_info_glibc(xml)
+    if 'version="jemalloc' in xml or "<allocated-bins>" in xml:
+        return _parse_malloc_info_bionic(xml)
+    return {
+        "available": False,
+        "flavor": "unrecognised",
+        "reason": "malloc_info schema not recognised; report the head below",
+        "xml_head": xml[:512],
+    }
+
+
+def _parse_malloc_info_glibc(xml: str) -> Dict[str, Any]:
+    """glibc reports, per arena and in total, bytes held from the kernel
+    (`<system type="current">`) alongside bytes sitting free in bins
+    (`<total type="rest">` / `"fast"`).  in_use = system - free is the only
+    figure that corresponds to live objects; the remainder is retention.
     """
     heaps: List[Dict[str, int]] = []
     for block in re.findall(r'<heap nr="(\d+)">(.*?)</heap>', xml, re.S):
@@ -120,6 +137,8 @@ def _parse_malloc_info(xml: str) -> Dict[str, Any]:
 
     free_bytes = totals["fast_bytes"] + totals["rest_bytes"]
     return {
+        "available": True,
+        "flavor": "glibc",
         "arenas": len(heaps),
         "system_current_bytes": totals["system_current"],
         "mmapped_bytes": totals["mmap_bytes"],
@@ -128,6 +147,44 @@ def _parse_malloc_info(xml: str) -> Dict[str, Any]:
         "in_use_bytes": max(0, totals["system_current"] - free_bytes),
         "retention_ratio": (free_bytes / totals["system_current"]) if totals["system_current"] else 0.0,
         "heaps": sorted(heaps, key=lambda h: -h["system_current"])[:16],
+    }
+
+
+def _parse_malloc_info_bionic(xml: str) -> Dict[str, Any]:
+    """Android reports only what is *allocated*, per heap and size class.
+
+    There is no counterpart to glibc's `<system>`, so retention cannot be read
+    off directly -- it has to be inferred against anonymous RSS by the caller.
+    Reporting only what Bionic actually states keeps that inference honest.
+    """
+    heaps: List[Dict[str, int]] = []
+    for block in re.findall(r'<heap nr="(\d+)">(.*?)</heap>', xml, re.S):
+        nr, body = int(block[0]), block[1]
+        heap = {"nr": nr}
+        for tag, key in (
+            ("allocated-large", "allocated_large"),
+            ("allocated-huge", "allocated_huge"),
+            ("allocated-bins", "allocated_bins"),
+            ("bins-total", "bins_total"),
+        ):
+            match = re.search(rf"<{tag}>(\d+)</{tag}>", body)
+            heap[key] = int(match.group(1)) if match else 0
+        heap["in_use_bytes"] = heap["allocated_large"] + heap["allocated_huge"] + heap["allocated_bins"]
+        heaps.append(heap)
+
+    in_use = sum(h["in_use_bytes"] for h in heaps)
+    return {
+        "available": True,
+        "flavor": "bionic",
+        "arenas": len(heaps),
+        "in_use_bytes": in_use,
+        # Bionic states none of these; leaving them absent rather than zero keeps
+        # "not reported" distinguishable from "measured as nothing".
+        "system_current_bytes": None,
+        "free_bytes": None,
+        "mmapped_bytes": None,
+        "retention_note": "bionic reports allocated bytes only; infer retention from anonymous RSS",
+        "heaps": sorted(heaps, key=lambda h: -h["in_use_bytes"])[:16],
     }
 
 

--- a/tools/memprobe/ciris_memprobe.py
+++ b/tools/memprobe/ciris_memprobe.py
@@ -1,0 +1,409 @@
+"""In-process memory composition probe.
+
+`/proc/PID/smaps` can say how much of a process is anonymous memory, but not who
+owns it.  This probe answers that from the inside, on demand, without a restart:
+it installs a SIGUSR1 handler that writes a JSON report and goes back to sleep.
+
+Three allocators sit under a CIRIS runtime and they are separately measurable:
+
+* **pymalloc** serves Python objects <=512 bytes out of arenas it mmaps itself,
+  so its footprint is invisible to glibc.  `sys._debugmallocstats()` reports it.
+* **glibc malloc** serves everything else -- large Python allocations *and* every
+  Rust allocation, since Rust's default allocator on Linux is the system one.
+  `malloc_info(3)` reports it per-arena, and crucially splits bytes obtained from
+  the OS from bytes sitting free in the arena, which is the difference between
+  "we allocated this" and "we freed this and glibc kept it".
+* **file mappings** (the .so images) are not heap at all and are attributed by
+  the out-of-process half, `tools/memory_composition.py`.
+
+Activation is via `sitecustomize.py` in this directory; see that file.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import gc
+import json
+import os
+import re
+import signal
+import sys
+import tempfile
+import threading
+import time
+from collections import Counter
+from typing import Any, Dict, List, Optional
+
+DEFAULT_OUT = "/tmp/ciris_memprobe.{pid}.json"
+
+_installed = False
+
+
+# --------------------------------------------------------------------------
+# glibc malloc
+# --------------------------------------------------------------------------
+
+
+def _malloc_info_xml() -> Optional[str]:
+    """Capture malloc_info(3) output.
+
+    malloc_info writes to a FILE*, so we hand it a real temp file through
+    fdopen rather than trying to build a stream in Python.
+    """
+    try:
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+    except OSError:
+        return None
+    if not hasattr(libc, "malloc_info"):
+        return None
+
+    libc.fdopen.restype = ctypes.c_void_p
+    libc.fdopen.argtypes = [ctypes.c_int, ctypes.c_char_p]
+    libc.malloc_info.argtypes = [ctypes.c_int, ctypes.c_void_p]
+    libc.fflush.argtypes = [ctypes.c_void_p]
+
+    fd, path = tempfile.mkstemp(prefix="memprobe-malloc-", suffix=".xml")
+    try:
+        # fdopen takes ownership of fd; do not close it ourselves afterwards.
+        stream = libc.fdopen(fd, b"w")
+        if not stream:
+            os.close(fd)
+            return None
+        libc.malloc_info(0, stream)
+        libc.fflush(stream)
+        with open(path, "r", encoding="utf-8", errors="replace") as handle:
+            return handle.read()
+    except Exception:
+        return None
+    finally:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def _parse_malloc_info(xml: str) -> Dict[str, Any]:
+    """Reduce the malloc_info XML to the numbers that decide the question.
+
+    Per-arena and in total, glibc reports `<system type="current">` (bytes held
+    from the kernel) alongside `<total type="rest">` and `<total type="fast">`
+    (bytes sitting free in bins).  in_use = system - free is the only figure
+    that corresponds to live objects.
+    """
+    heaps: List[Dict[str, int]] = []
+    for block in re.findall(r'<heap nr="(\d+)">(.*?)</heap>', xml, re.S):
+        nr, body = int(block[0]), block[1]
+        heap = {"nr": nr}
+        for kind in ("fast", "rest"):
+            match = re.search(rf'<total type="{kind}" count="(\d+)" size="(\d+)"', body)
+            heap[f"free_{kind}_bytes"] = int(match.group(2)) if match else 0
+            heap[f"free_{kind}_count"] = int(match.group(1)) if match else 0
+        for kind, key in (("current", "system_current"), ("max", "system_max")):
+            match = re.search(rf'<system type="{kind}" size="(\d+)"', body)
+            heap[key] = int(match.group(1)) if match else 0
+        match = re.search(r'<aspace type="total" size="(\d+)"', body)
+        heap["aspace_total"] = int(match.group(1)) if match else 0
+        heap["free_bytes"] = heap["free_fast_bytes"] + heap["free_rest_bytes"]
+        heap["in_use_bytes"] = max(0, heap["system_current"] - heap["free_bytes"])
+        heaps.append(heap)
+
+    tail = xml.rsplit("</heap>", 1)[-1] if "</heap>" in xml else xml
+    totals: Dict[str, int] = {}
+    for kind in ("fast", "rest", "mmap"):
+        match = re.search(rf'<total type="{kind}" count="(\d+)" size="(\d+)"', tail)
+        totals[f"{kind}_bytes"] = int(match.group(2)) if match else 0
+        totals[f"{kind}_count"] = int(match.group(1)) if match else 0
+    match = re.search(r'<system type="current" size="(\d+)"', tail)
+    totals["system_current"] = int(match.group(1)) if match else 0
+    match = re.search(r'<system type="max" size="(\d+)"', tail)
+    totals["system_max"] = int(match.group(1)) if match else 0
+
+    free_bytes = totals["fast_bytes"] + totals["rest_bytes"]
+    return {
+        "arenas": len(heaps),
+        "system_current_bytes": totals["system_current"],
+        "mmapped_bytes": totals["mmap_bytes"],
+        "mmapped_count": totals["mmap_count"],
+        "free_bytes": free_bytes,
+        "in_use_bytes": max(0, totals["system_current"] - free_bytes),
+        "retention_ratio": (free_bytes / totals["system_current"]) if totals["system_current"] else 0.0,
+        "heaps": sorted(heaps, key=lambda h: -h["system_current"])[:16],
+    }
+
+
+# --------------------------------------------------------------------------
+# pymalloc
+# --------------------------------------------------------------------------
+
+
+def _pymalloc_stats() -> Dict[str, Any]:
+    """Parse `sys._debugmallocstats()`, which only writes to stderr.
+
+    We dup a temp file over fd 2 for the duration rather than touching
+    sys.stderr, because the C function writes to the file descriptor directly.
+    """
+    if not hasattr(sys, "_debugmallocstats"):
+        return {"available": False}
+
+    text = ""
+    saved = None
+    try:
+        with tempfile.TemporaryFile("w+b") as sink:
+            saved = os.dup(2)
+            os.dup2(sink.fileno(), 2)
+            try:
+                sys._debugmallocstats()  # type: ignore[attr-defined]
+            finally:
+                os.dup2(saved, 2)
+                os.close(saved)
+                saved = None
+            sink.seek(0)
+            text = sink.read().decode("utf-8", "replace")
+    except Exception as exc:
+        if saved is not None:
+            try:
+                os.dup2(saved, 2)
+                os.close(saved)
+            except OSError:
+                pass
+        return {"available": False, "error": str(exc)}
+
+    stats: Dict[str, Any] = {"available": True}
+    for line in text.splitlines():
+        match = re.match(r"^#\s+(.+?)\s*=\s*([\d,]+)\s*$", line)
+        if match:
+            key = match.group(1).strip().replace(" ", "_").replace("-", "_")
+            stats[key] = int(match.group(2).replace(",", ""))
+            continue
+        match = re.match(r"^(\d+) arenas \* (\d+) bytes/arena\s*=\s*([\d,]+)", line)
+        if match:
+            stats["arena_count"] = int(match.group(1))
+            stats["arena_size_bytes"] = int(match.group(2))
+            stats["arena_total_bytes"] = int(match.group(3).replace(",", ""))
+    stats["allocated_blocks"] = sys.getallocatedblocks()
+    return stats
+
+
+# --------------------------------------------------------------------------
+# Python object census
+# --------------------------------------------------------------------------
+
+
+def _gc_census(top: int = 25) -> Dict[str, Any]:
+    """Count tracked objects by type, and shallow-size the heaviest types.
+
+    getsizeof is shallow, so these bytes under-report containers-of-containers;
+    the counts are what identify a runaway population.
+    """
+    try:
+        objects = gc.get_objects()
+    except Exception as exc:
+        return {"available": False, "error": str(exc)}
+
+    counts: Counter = Counter()
+    sizes: Counter = Counter()
+    for obj in objects:
+        try:
+            name = type(obj).__qualname__
+            counts[name] += 1
+            sizes[name] += sys.getsizeof(obj, 0)
+        except Exception:
+            continue
+    total_shallow = sum(sizes.values())
+    del objects
+
+    return {
+        "available": True,
+        "tracked_objects": sum(counts.values()),
+        "shallow_bytes_total": total_shallow,
+        "generation_counts": list(gc.get_count()),
+        "by_count": [{"type": n, "count": c, "shallow_bytes": sizes[n]} for n, c in counts.most_common(top)],
+        "by_bytes": [{"type": n, "shallow_bytes": b, "count": counts[n]} for n, b in sizes.most_common(top)],
+    }
+
+
+def _tracemalloc_top(top: int = 20) -> Dict[str, Any]:
+    try:
+        import tracemalloc
+    except ImportError:
+        return {"enabled": False}
+    if not tracemalloc.is_tracing():
+        return {"enabled": False}
+    current, peak = tracemalloc.get_traced_memory()
+    snapshot = tracemalloc.take_snapshot()
+    entries = []
+    for stat in snapshot.statistics("filename")[:top]:
+        frame = stat.traceback[0] if stat.traceback else None
+        entries.append(
+            {
+                "file": frame.filename if frame else "?",
+                "size_bytes": stat.size,
+                "count": stat.count,
+            }
+        )
+    return {"enabled": True, "traced_bytes": current, "peak_bytes": peak, "top": entries}
+
+
+def _threads() -> Dict[str, Any]:
+    """Thread names as Python sees them, plus every OS thread from /proc.
+
+    The two differ by exactly the threads Python did not create -- which is
+    where a native runtime's worker pool shows up.
+    """
+    python_names: Counter = Counter()
+    for thread in threading.enumerate():
+        python_names[re.sub(r"[-_]?\d+$", "", thread.name or "?")] += 1
+
+    os_names: Counter = Counter()
+    try:
+        task_dir = "/proc/self/task"
+        for tid in os.listdir(task_dir):
+            try:
+                with open(os.path.join(task_dir, tid, "comm"), encoding="utf-8") as handle:
+                    os_names[handle.read().strip()] += 1
+            except OSError:
+                continue
+    except OSError:
+        pass
+
+    return {
+        "python_thread_count": threading.active_count(),
+        "os_thread_count": sum(os_names.values()),
+        "python_by_name": dict(python_names.most_common()),
+        "os_by_comm": dict(os_names.most_common()),
+    }
+
+
+def _asyncio_tasks() -> Dict[str, Any]:
+    try:
+        import asyncio
+
+        # The handler runs in the main thread between bytecodes, so when the
+        # loop lives there it is genuinely "running" and get_running_loop works.
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.get_event_loop_policy().get_event_loop()
+        tasks = asyncio.all_tasks(loop)
+    except Exception:
+        return {"available": False}
+    names: Counter = Counter()
+    for task in tasks:
+        try:
+            names[re.sub(r"[-_]?\d+$", "", task.get_name())] += 1
+        except Exception:
+            continue
+    return {"available": True, "count": len(tasks), "by_name": dict(names.most_common(20))}
+
+
+def _rss_bytes() -> int:
+    try:
+        with open("/proc/self/statm", encoding="utf-8") as handle:
+            return int(handle.read().split()[1]) * os.sysconf("SC_PAGE_SIZE")
+    except Exception:
+        return 0
+
+
+# --------------------------------------------------------------------------
+# Report
+# --------------------------------------------------------------------------
+
+
+def collect(census: bool = True) -> Dict[str, Any]:
+    """Build the full in-process report."""
+    started = time.time()
+    xml = _malloc_info_xml()
+    report: Dict[str, Any] = {
+        "schema": "ciris-memprobe/1",
+        "pid": os.getpid(),
+        "timestamp": time.time(),
+        "python": sys.version.split()[0],
+        "rss_bytes": _rss_bytes(),
+        "loaded_modules": len(sys.modules),
+        "glibc_malloc": _parse_malloc_info(xml) if xml else {"available": False},
+        "pymalloc": _pymalloc_stats(),
+        "threads": _threads(),
+        "asyncio": _asyncio_tasks(),
+        "tracemalloc": _tracemalloc_top(),
+    }
+    report["gc"] = _gc_census() if census else {"available": False, "skipped": True}
+    report["collect_seconds"] = round(time.time() - started, 3)
+    return report
+
+
+def dump(path: Optional[str] = None, census: bool = True) -> str:
+    out = path or os.environ.get("CIRIS_MEMPROBE_OUT") or DEFAULT_OUT.format(pid=os.getpid())
+    report = collect(census=census)
+    tmp = f"{out}.partial"
+    with open(tmp, "w", encoding="utf-8") as handle:
+        json.dump(report, handle, indent=2, sort_keys=True)
+    os.replace(tmp, out)  # readers never see a half-written report
+    return out
+
+
+def trim() -> Dict[str, Any]:
+    """Ask glibc to return free heap to the OS, and measure what came back.
+
+    malloc_trim walks every arena and madvises away whole free pages.  It is the
+    difference between "this memory is free" and "this memory is the kernel's
+    again", so the delta it produces is the honest answer to how much of the
+    resident set is reclaimable without changing a line of allocation behaviour.
+    """
+    before = _rss_bytes()
+    started = time.time()
+    returned = -1
+    try:
+        libc = ctypes.CDLL("libc.so.6")
+        libc.malloc_trim.argtypes = [ctypes.c_size_t]
+        libc.malloc_trim.restype = ctypes.c_int
+        returned = int(libc.malloc_trim(0))
+    except Exception as exc:
+        return {"available": False, "error": str(exc)}
+    elapsed = time.time() - started
+    after = _rss_bytes()
+    return {
+        "available": True,
+        "released": bool(returned),
+        "rss_before_bytes": before,
+        "rss_after_bytes": after,
+        "reclaimed_bytes": before - after,
+        "seconds": round(elapsed, 3),
+    }
+
+
+def _trim_handler(signum: int, frame: Any) -> None:
+    try:
+        result = trim()
+        out = os.environ.get("CIRIS_MEMPROBE_OUT") or DEFAULT_OUT.format(pid=os.getpid())
+        path = f"{out}.trim"
+        tmp = f"{path}.partial"
+        with open(tmp, "w", encoding="utf-8") as handle:
+            json.dump(result, handle, indent=2, sort_keys=True)
+        os.replace(tmp, path)
+        print(f"[memprobe] trim reclaimed {result.get('reclaimed_bytes', 0) / 1048576:.1f} MB", file=sys.stderr)
+    except Exception as exc:
+        print(f"[memprobe] trim failed: {exc}", file=sys.stderr)
+
+
+def _handler(signum: int, frame: Any) -> None:
+    try:
+        census = os.environ.get("CIRIS_MEMPROBE_CENSUS", "1") != "0"
+        path = dump(census=census)
+        print(f"[memprobe] wrote {path}", file=sys.stderr)
+    except Exception as exc:
+        print(f"[memprobe] dump failed: {exc}", file=sys.stderr)
+
+
+def install() -> None:
+    """Register the SIGUSR1 handler.  Safe to call more than once."""
+    global _installed
+    if _installed:
+        return
+    signal.signal(signal.SIGUSR1, _handler)
+    signal.signal(signal.SIGUSR2, _trim_handler)
+    _installed = True
+    print(f"[memprobe] armed on SIGUSR1 (report) / SIGUSR2 (trim), pid {os.getpid()}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    print(json.dumps(collect(), indent=2, sort_keys=True))

--- a/tools/memprobe/sitecustomize.py
+++ b/tools/memprobe/sitecustomize.py
@@ -1,0 +1,23 @@
+"""Out-of-band activation hook for the CIRIS in-process memory probe.
+
+`site` imports any module named `sitecustomize` it finds on `sys.path`, before
+application code runs.  Putting *this directory* on PYTHONPATH is therefore the
+whole activation mechanism -- nothing in the shipped engine imports the probe,
+and an unset CIRIS_MEMPROBE makes this file a no-op:
+
+    PYTHONPATH=tools/memprobe CIRIS_MEMPROBE=1 python main.py --adapter api
+
+The directory deliberately has no __init__.py: it is a path entry, not a package.
+"""
+
+import os
+
+if os.environ.get("CIRIS_MEMPROBE"):
+    try:
+        import ciris_memprobe
+
+        ciris_memprobe.install()
+    except Exception as exc:  # never break the process we are measuring
+        import sys
+
+        print(f"[memprobe] install failed: {exc}", file=sys.stderr)

--- a/tools/qa_runner/__main__.py
+++ b/tools/qa_runner/__main__.py
@@ -14,8 +14,8 @@ except Exception:  # pragma: no cover - never let the shim stop the runner
     pass
 
 import argparse
-import os
 import logging
+import os
 import sys
 from pathlib import Path
 from typing import List
@@ -110,6 +110,14 @@ Available modules:
     )
     parser.add_argument("--port", type=int, default=8080, help="API server port (default: 8080)")
     parser.add_argument("--no-auto-start", action="store_true", help="Don't automatically start the API server")
+    parser.add_argument(
+        "--incidents-log",
+        default=None,
+        help=(
+            "Path to the backend's incidents_latest.log when the backend was not started by this runner "
+            "(e.g. pulled from an emulator). The incidents gate reads it and still fails closed if missing."
+        ),
+    )
     parser.add_argument("--no-mock-llm", action="store_true", help="Don't use mock LLM (requires real LLM)")
     parser.add_argument(
         "--adapter", default="api", choices=["api", "cli", "discord"], help="Adapter to use (default: api)"
@@ -142,7 +150,9 @@ Available modules:
         "--live", action="store_true", help="Use real LLM API instead of mock. Reads key from --live-key-file"
     )
     parser.add_argument(
-        "--live-key-file", default="~/.openrouter_key", help="Path to file containing API key (default: ~/.openrouter_key)"
+        "--live-key-file",
+        default="~/.openrouter_key",
+        help="Path to file containing API key (default: ~/.openrouter_key)",
     )
     parser.add_argument(
         "--live-model",
@@ -314,10 +324,7 @@ Available modules:
         "--safety-battery-limit",
         type=int,
         default=0,
-        help=(
-            "Run only the first N battery questions (0 = all). "
-            "Cycle-time lever for trace-flow troubleshooting."
-        ),
+        help=("Run only the first N battery questions (0 = all). " "Cycle-time lever for trace-flow troubleshooting."),
     )
     parser.add_argument(
         "--safety-battery-domain",
@@ -604,10 +611,7 @@ def main():
         from .staged_env import prepare as prepare_staged_env
 
         repo_root = Path(__file__).resolve().parent.parent.parent
-        print(
-            f"[staged] Preparing staged QA environment at {args.staged_root} "
-            f"(rebuild={args.rebuild_staged})"
-        )
+        print(f"[staged] Preparing staged QA environment at {args.staged_root} " f"(rebuild={args.rebuild_staged})")
         staged_env = prepare_staged_env(
             src=repo_root,
             root=args.staged_root,
@@ -634,6 +638,7 @@ def main():
         html_report=args.html,
         report_dir=Path(args.report_dir),
         auto_start_server=not args.no_auto_start,
+        incidents_log_path=Path(args.incidents_log) if args.incidents_log else None,
         mock_llm=use_mock_llm,
         adapter=args.adapter,
         database_backends=args.database_backends,
@@ -665,9 +670,7 @@ def main():
         model_eval_languages=[lang.strip() for lang in args.model_eval_languages.split(",") if lang.strip()],
         model_eval_concurrency=args.model_eval_concurrency,
         model_eval_profile_memory=not args.no_model_eval_memory_profile,
-        model_eval_question_categories=[
-            cat.strip() for cat in args.model_eval_questions.split(",") if cat.strip()
-        ],
+        model_eval_question_categories=[cat.strip() for cat in args.model_eval_questions.split(",") if cat.strip()],
         model_eval_questions_file=(args.model_eval_questions_file or None),
         safety_battery_lang=args.safety_battery_lang,
         safety_battery_limit=args.safety_battery_limit,

--- a/tools/qa_runner/config.py
+++ b/tools/qa_runner/config.py
@@ -2,8 +2,7 @@
 QA Runner configuration and module definitions.
 """
 
-from dataclasses import dataclass
-from dataclasses import field
+from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
@@ -58,7 +57,9 @@ class QAModule(Enum):
     DEGRADED_MODE = "degraded_mode"  # Degraded mode behavior testing (no LLM provider)
     MODEL_EVAL = "model_eval"  # Model quality evaluation with tough questions (requires --live)
     PARALLEL_LOCALES = "parallel_locales"  # 29-locale parallel multi-turn convo (per-user channels)
-    SAFETY_BATTERY = "safety_battery"  # Run a canonical safety battery (CIRISNodeCore SCHEMA.md §11) against the agent via A2A
+    SAFETY_BATTERY = (
+        "safety_battery"  # Run a canonical safety battery (CIRISNodeCore SCHEMA.md §11) against the agent via A2A
+    )
     SAFETY_INTERPRET = "safety_interpret"  # Apply a rubric's criteria.json to a capture bundle; emit signed verdicts (CIRISNodeCore FSD/JUDGE_MODEL.md)
     SECRETS_ENCRYPTION = "secrets_encryption"  # Secrets encryption testing (CIRISVerify v1.6.0+)
     MEMORY_BENCHMARK = "memory_benchmark"  # Memory usage benchmark under message load
@@ -85,7 +86,9 @@ class QAModule(Enum):
     SINGLE_STEP_SIMPLE = "single_step_simple"
     SINGLE_STEP_COMPREHENSIVE = "single_step_comprehensive"
     STREAMING = "streaming"  # H3ERE pipeline streaming verification
-    L4_ATTESTATION = "l4_attestation"  # Algorithm A (verify_tree) runtime contract — staged-QA L3+ floor + cache-population guard
+    L4_ATTESTATION = (
+        "l4_attestation"  # Algorithm A (verify_tree) runtime contract — staged-QA L3+ floor + cache-population guard
+    )
 
     # Full suites
     API_FULL = "api_full"
@@ -249,6 +252,11 @@ class QAConfig:
 
     # Server management
     auto_start_server: bool = True
+    # Where the backend under test writes incidents_latest.log, when it is not the
+    # server this runner started. The five-platform modular gate points this at a
+    # log pulled from an emulator or simulator; the gate still fails closed if the
+    # file is missing -- this only says WHERE to look, never whether to look.
+    incidents_log_path: Optional[Path] = None
     server_startup_timeout: float = (
         600.0  # Wakeup with rate-limited LLM: 60 LLM calls × ~40K tokens = 2.4M tokens, at 300K TPM = ~8-10 min
     )
@@ -268,7 +276,9 @@ class QAConfig:
     # Database backend configuration (for parallel testing)
     database_backends: List[str] = None  # None = ["sqlite"], or ["sqlite", "postgres"] for parallel
     postgres_url: str = "postgresql://ciris_test:ciris_test_password@localhost:5432/ciris_test_db"
-    postgres_api_port: int = 8001  # API-server port for the postgres-backend run (NOT the PG DB port — see postgres_url)
+    postgres_api_port: int = (
+        8001  # API-server port for the postgres-backend run (NOT the PG DB port — see postgres_url)
+    )
     parallel_backends: bool = False  # Run backend tests in parallel instead of sequentially
 
     # Live LLM configuration (--live flag)

--- a/tools/qa_runner/modules/comprehensive_api_tests.py
+++ b/tools/qa_runner/modules/comprehensive_api_tests.py
@@ -55,6 +55,24 @@ class ComprehensiveAPITestModule:
                 requires_auth=True,
                 description="Test single step processing execution",
             ),
+            # Memory give-back: the resource monitor's release path, driven from
+            # the API so every platform the gate runs proves the chain works
+            # there -- not just the Linux box it was measured on.
+            QATestCase(
+                name="Release memory to the OS",
+                module=QAModule.SYSTEM,
+                endpoint="/v1/system/runtime/memory/release",
+                method="POST",
+                expected_status=200,
+                requires_auth=True,
+                description="Admin-triggered gc + allocator give-back; asserts a real platform call was made",
+                validation_rules={
+                    "made_a_platform_call": lambda r: isinstance(r.get("data", {}).get("platform_call"), str)
+                    and r["data"]["platform_call"] not in ("", "none"),
+                    "reports_rss": lambda r: isinstance(r.get("data", {}).get("rss_after_mb"), int)
+                    and r["data"]["rss_after_mb"] > 0,
+                },
+            ),
         ]
 
     @staticmethod

--- a/tools/qa_runner/runner.py
+++ b/tools/qa_runner/runner.py
@@ -17,18 +17,17 @@ import asyncio
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 import time
-import re
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-from pydantic import BaseModel, ConfigDict
-
 import requests
+from pydantic import BaseModel, ConfigDict
 from rich.console import Console
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
@@ -56,85 +55,85 @@ logger = logging.getLogger(__name__)
 # Every entry names the module that drives it. Add one only with that
 # reason attached — an unexplained entry here is a silenced defect.
 EXPECTED_QA_INCIDENT_PATTERNS = [
-        "MOCK_MODULE_LOADED",
-        "MOCK LLM",
-        "RUNTIME SHUTDOWN",
-        "SYSTEM SHUTDOWN",
-        "GRACEFUL SHUTDOWN",
-        "[SIGNAL]",  # signal-handler lines (e.g. SIGTERM to stop the QA server)
-        "Edge already exists",
-        "duplicate edge",
-        "TSDB consolidation",
-        # The setup module deliberately validates bad LLM endpoints —
-        # the agent correctly logs the validation failure.
-        "[VALIDATE_LLM]",
-        # ciris_verify logs ERROR for an offline build-registry; in QA
-        # there is no registry and L4 file integrity is legitimately
-        # skipped — an environmental degradation, not a test failure.
-        "MANIFEST_CACHE MISS",
-        # CIRISVerify's file-integrity periodic re-check fails in CI
-        # because CI runs against the working tree, not a registry-
-        # published build. The re-check fires every ~3 minutes and on
-        # 2026-05-28 (run 26608575466) the SQLite-vs-Postgres timing
-        # diff made the third re-check land inside the SQLite test
-        # window while Postgres just missed it — flaking the SQLite
-        # backend. Both backends always produce ≥2 of these per run.
-        # Environmental; tracked at CIRISAgent#836.
-        "check_full: manifest integrity verification FAILED",
-        # QA/CI hosts have no TPM and no hardware Ed25519 key, so the
-        # CIRISVerify FFI key probe + TPM TCTI context creation log
-        # ERROR and fall back to software — expected, not a failure.
-        "get_ed25519_public_key: no key loaded",
-        "Error when creating a TCTI context",
-        "TPM: failed to create context",
-        # QA modules that DELIBERATELY exercise error / edge paths —
-        # the agent correctly logs the rejection; the ERROR line is
-        # the expected test outcome, not an incident (cf. VALIDATE_LLM):
-        #  - state_transitions test submits an invalid target state
-        "Invalid target state",
-        #  - adapter_manifest test unloads its scratch adapters, some
-        #    of which were never loaded
-        "qa_manifest_test_",
-        #  - adapter_manifest probes every ciris_adapters/* dir; the
-        #    shared MCP library `mcp_common` is not a loadable adapter
-        #    (no Adapter class — by design), and the loader correctly
-        #    says so. Expected probe noise, not an incident.
-        "ciris_adapters.mcp_common' has no attribute 'Adapter'",
-        #  - dsar_multi_source exercises the DSAR path for a test user
-        #    that has no consent record; the orchestrator correctly
-        #    reports the absence (the test asserts that behaviour).
-        "No consent found for user user_dsar",
-        #  - accord_metrics ships WBD deferrals to the lens; the QA
-        #    mock lens does not implement /accord/wbd/deferrals, so the
-        #    adapter correctly logs the 404 it received. Mock gap.
-        "WBD deferral rejected: Status 404",
-        #  - CIRISVerify's attestation probe reaches for the registry
-        #    over the network; CI has no route to it, so it correctly
-        #    logs a timeout and falls back to software. Environmental.
-        "ciris_verify_run_attestation: TIMEOUT",
-        #  - accord_metrics trace-signing is briefly blocked while an
-        #    attestation is in progress; the adapter retries (~500ms).
-        #    A transient, self-recovering condition, not a fault.
-        "Attestation in progress - sign_ed25519 blocked",
-        #  - adapter_config test submits an empty config to verify
-        #    validation rejects it
-        "Config validation failed: Configuration is empty",
-        #  - cognitive-state tests force unnatural WORK/DREAM
-        #    transitions; a force-transitioned DREAM seed thought has
-        #    no originating adapter channel. (Tracked as a follow-up:
-        #    DREAM seed thoughts should carry a synthetic channel.)
-        "No channel context found for thought thought_dream_",
-        "Failed to transition from AgentState.WORK to AgentState.WORK",
-        # High-frequency BENIGN warnings — routine per-thought / per-
-        # cache-gen chatter, not systemic malfunctions. Excluded so the
-        # WARNING-flood detector below isn't tripped by normal noise:
-        #  - the mock LLM's own diagnostic (QA fixture only — never
-        #    emitted in production, there is no mock LLM there)
-        "[MOCK_LLM] No user_input found in context",
-        #  - the tool-cache generator noting CIRISVerifyService is not
-        #    a tool-enumeration provider (true by design — it is a
-        #    verification service, not a tool service)
-        "[TOOL_CACHE] CIRISVerifyService: No get_all_tool_info",
+    "MOCK_MODULE_LOADED",
+    "MOCK LLM",
+    "RUNTIME SHUTDOWN",
+    "SYSTEM SHUTDOWN",
+    "GRACEFUL SHUTDOWN",
+    "[SIGNAL]",  # signal-handler lines (e.g. SIGTERM to stop the QA server)
+    "Edge already exists",
+    "duplicate edge",
+    "TSDB consolidation",
+    # The setup module deliberately validates bad LLM endpoints —
+    # the agent correctly logs the validation failure.
+    "[VALIDATE_LLM]",
+    # ciris_verify logs ERROR for an offline build-registry; in QA
+    # there is no registry and L4 file integrity is legitimately
+    # skipped — an environmental degradation, not a test failure.
+    "MANIFEST_CACHE MISS",
+    # CIRISVerify's file-integrity periodic re-check fails in CI
+    # because CI runs against the working tree, not a registry-
+    # published build. The re-check fires every ~3 minutes and on
+    # 2026-05-28 (run 26608575466) the SQLite-vs-Postgres timing
+    # diff made the third re-check land inside the SQLite test
+    # window while Postgres just missed it — flaking the SQLite
+    # backend. Both backends always produce ≥2 of these per run.
+    # Environmental; tracked at CIRISAgent#836.
+    "check_full: manifest integrity verification FAILED",
+    # QA/CI hosts have no TPM and no hardware Ed25519 key, so the
+    # CIRISVerify FFI key probe + TPM TCTI context creation log
+    # ERROR and fall back to software — expected, not a failure.
+    "get_ed25519_public_key: no key loaded",
+    "Error when creating a TCTI context",
+    "TPM: failed to create context",
+    # QA modules that DELIBERATELY exercise error / edge paths —
+    # the agent correctly logs the rejection; the ERROR line is
+    # the expected test outcome, not an incident (cf. VALIDATE_LLM):
+    #  - state_transitions test submits an invalid target state
+    "Invalid target state",
+    #  - adapter_manifest test unloads its scratch adapters, some
+    #    of which were never loaded
+    "qa_manifest_test_",
+    #  - adapter_manifest probes every ciris_adapters/* dir; the
+    #    shared MCP library `mcp_common` is not a loadable adapter
+    #    (no Adapter class — by design), and the loader correctly
+    #    says so. Expected probe noise, not an incident.
+    "ciris_adapters.mcp_common' has no attribute 'Adapter'",
+    #  - dsar_multi_source exercises the DSAR path for a test user
+    #    that has no consent record; the orchestrator correctly
+    #    reports the absence (the test asserts that behaviour).
+    "No consent found for user user_dsar",
+    #  - accord_metrics ships WBD deferrals to the lens; the QA
+    #    mock lens does not implement /accord/wbd/deferrals, so the
+    #    adapter correctly logs the 404 it received. Mock gap.
+    "WBD deferral rejected: Status 404",
+    #  - CIRISVerify's attestation probe reaches for the registry
+    #    over the network; CI has no route to it, so it correctly
+    #    logs a timeout and falls back to software. Environmental.
+    "ciris_verify_run_attestation: TIMEOUT",
+    #  - accord_metrics trace-signing is briefly blocked while an
+    #    attestation is in progress; the adapter retries (~500ms).
+    #    A transient, self-recovering condition, not a fault.
+    "Attestation in progress - sign_ed25519 blocked",
+    #  - adapter_config test submits an empty config to verify
+    #    validation rejects it
+    "Config validation failed: Configuration is empty",
+    #  - cognitive-state tests force unnatural WORK/DREAM
+    #    transitions; a force-transitioned DREAM seed thought has
+    #    no originating adapter channel. (Tracked as a follow-up:
+    #    DREAM seed thoughts should carry a synthetic channel.)
+    "No channel context found for thought thought_dream_",
+    "Failed to transition from AgentState.WORK to AgentState.WORK",
+    # High-frequency BENIGN warnings — routine per-thought / per-
+    # cache-gen chatter, not systemic malfunctions. Excluded so the
+    # WARNING-flood detector below isn't tripped by normal noise:
+    #  - the mock LLM's own diagnostic (QA fixture only — never
+    #    emitted in production, there is no mock LLM there)
+    "[MOCK_LLM] No user_input found in context",
+    #  - the tool-cache generator noting CIRISVerifyService is not
+    #    a tool-enumeration provider (true by design — it is a
+    #    verification service, not a tool service)
+    "[TOOL_CACHE] CIRISVerifyService: No get_all_tool_info",
     # - reddit adapter probe: QA has no Reddit credentials, so the adapter
     #   correctly refuses to load. Environmental, not a fault.
     "Reddit credentials are not configured",
@@ -150,11 +149,7 @@ def _expand_module_aggregates(modules: List[QAModule]) -> List[QAModule]:
     per-module logic must see the expanded list. Idempotent; order- and
     dedupe-preserving.
     """
-    from .config import (
-        ALL_1_MODULE_SEQUENCE,
-        ALL_2_MODULE_SEQUENCE,
-        ALL_MODULE_SEQUENCE,
-    )
+    from .config import ALL_1_MODULE_SEQUENCE, ALL_2_MODULE_SEQUENCE, ALL_MODULE_SEQUENCE
 
     aggregates = {
         QAModule.ALL: ALL_MODULE_SEQUENCE,
@@ -169,7 +164,6 @@ def _expand_module_aggregates(modules: List[QAModule]) -> List[QAModule]:
             if sm not in expanded:
                 expanded.append(sm)
     return expanded
-
 
 
 def _err_text(result: dict, limit: int = 100) -> str:
@@ -206,10 +200,7 @@ _IDENTITY_CLOSING = (("logout", "/auth/logout"),)
 
 
 def _closes_identity(test: Any) -> bool:
-    return any(
-        name in test.name.lower() and endpoint in test.endpoint
-        for name, endpoint in _IDENTITY_CLOSING
-    )
+    return any(name in test.name.lower() and endpoint in test.endpoint for name, endpoint in _IDENTITY_CLOSING)
 
 
 def _is_non_failing(status: str) -> bool:
@@ -320,16 +311,12 @@ class QARunner:
         # CIRIS agent just to throw it away is wasteful and surfaces
         # unrelated failure modes (e.g. CIRISVerify FFI on TPM-less
         # runners) that have nothing to do with the test in question.
-        if self.modules and all(
-            not getattr(_get_module_md(_m), "requires_ciris_server", True)
-            for _m in self.modules
-        ):
+        if self.modules and all(not getattr(_get_module_md(_m), "requires_ciris_server", True) for _m in self.modules):
             self._skip_ciris_server = True
             if self.config.auto_start_server:
                 self.config.auto_start_server = False
                 self.console.print(
-                    "[dim]Auto-disabled server start: all selected modules "
-                    "declare REQUIRES_CIRIS_SERVER=False[/dim]"
+                    "[dim]Auto-disabled server start: all selected modules " "declare REQUIRES_CIRIS_SERVER=False[/dim]"
                 )
         else:
             self._skip_ciris_server = False
@@ -513,9 +500,7 @@ class QARunner:
         # Get authentication token (skip for SETUP module - first-run has no users,
         # and skip when no module needs a CIRIS server at all)
         if getattr(self, "_skip_ciris_server", False):
-            self.console.print(
-                "[dim]Skipping authentication: no selected module requires a CIRIS server[/dim]"
-            )
+            self.console.print("[dim]Skipping authentication: no selected module requires a CIRIS server[/dim]")
         elif QAModule.SETUP not in modules:
             if not self._authenticate():
                 self.console.print("[red][FAIL] Authentication failed[/red]")
@@ -637,8 +622,7 @@ class QARunner:
                 self.console.print("[dim]Authenticating after SETUP wizard...[/dim]")
                 if not self._authenticate():
                     self.console.print(
-                        "[yellow]⚠️  Post-SETUP authentication failed — "
-                        "remaining modules may report 401[/yellow]"
+                        "[yellow]⚠️  Post-SETUP authentication failed — " "remaining modules may report 401[/yellow]"
                     )
 
         # Phase 2: remaining HTTP test modules (now token-wired).
@@ -670,7 +654,9 @@ class QARunner:
 
             if not mo_result["success"]:
                 success = False
-                self.console.print(f"[red][FAIL] Multi-occurrence integration test failed: {mo_result.get('errors')}[/red]")
+                self.console.print(
+                    f"[red][FAIL] Multi-occurrence integration test failed: {mo_result.get('errors')}[/red]"
+                )
             else:
                 self.console.print("[green][OK] Multi-occurrence integration test passed![/green]")
 
@@ -763,7 +749,9 @@ class QARunner:
                 # NOT the same failure as "incidents found". This one means the gate
                 # could not look at all — which used to silently PASS, making every
                 # green run only as trustworthy as the log file having existed.
-                self.console.print("[bold red][ALERT] RUN NOT CERTIFIED: THE INCIDENTS GATE COULD NOT RUN [ALERT][/bold red]")
+                self.console.print(
+                    "[bold red][ALERT] RUN NOT CERTIFIED: THE INCIDENTS GATE COULD NOT RUN [ALERT][/bold red]"
+                )
                 self.console.print(
                     "[bold red]No incidents were found because none could be looked for. "
                     "See the CANNOT CERTIFY block above for the expected path.[/bold red]"
@@ -971,7 +959,9 @@ class QARunner:
                 self.console.print(f"   ... and {len(unique_errors) - 10} more critical errors")
 
             # Make it impossible to miss
-            self.console.print(f"\n[bold red][ALERT] {len(unique_errors)} CRITICAL ISSUES REQUIRE ATTENTION! [ALERT][/bold red]")
+            self.console.print(
+                f"\n[bold red][ALERT] {len(unique_errors)} CRITICAL ISSUES REQUIRE ATTENTION! [ALERT][/bold red]"
+            )
         else:
             self.console.print("[bold green][OK] No critical issues found[/bold green]")
 
@@ -986,6 +976,12 @@ class QARunner:
         undetected and runs reported "no incidents" when they should have
         failed.
         """
+        explicit = getattr(self.config, "incidents_log_path", None)
+        if explicit:
+            # A backend we did not start (a phone's, a desktop app's) writes
+            # wherever it lives; the caller tells us where. Existence is still
+            # checked by the gate -- an absent file fails the run, as always.
+            return Path(explicit)
         server_manager = getattr(self, "server_manager", None)
         backend = getattr(server_manager, "database_backend", None) if server_manager else None
         if backend:
@@ -1026,9 +1022,7 @@ class QARunner:
         incidents_log = self._incidents_log_path()
 
         if not incidents_log.exists():
-            self.console.print(
-                "\n[bold red]❌ CANNOT CERTIFY THIS RUN — the incidents log does not exist.[/bold red]"
-            )
+            self.console.print("\n[bold red]❌ CANNOT CERTIFY THIS RUN — the incidents log does not exist.[/bold red]")
             self.console.print(
                 f"[red]   expected : {incidents_log.resolve()}[/red]\n"
                 f"[red]   backend  : {getattr(getattr(self, 'server_manager', None), 'database_backend', '<unknown>')}[/red]\n"
@@ -1193,7 +1187,7 @@ class QARunner:
 
         # Transport rooting + KEX from the [DELIVERY-PROBE] line the server logs
         # once the canonical roots (or times out).
-        backend = (self.database_backends[0] if getattr(self, "database_backends", None) else "sqlite")
+        backend = self.database_backends[0] if getattr(self, "database_backends", None) else "sqlite"
 
         def _read_probe_log() -> str:
             """Read the runtime log, tolerating a missing latest.log symlink.
@@ -1274,7 +1268,9 @@ class QARunner:
                 )
 
         self.console.print(f"  canonical peer      : {canonical_key or '<from probe>'}")
-        rooted_str = "✅ YES" if transport_rooted else ("❌ NO" if transport_rooted is False else "❓ probe verdict not found")
+        rooted_str = (
+            "✅ YES" if transport_rooted else ("❌ NO" if transport_rooted is False else "❓ probe verdict not found")
+        )
         self.console.print(f"  transport-rooted    : {rooted_str}  (edge.knows_peer — authoritative)")
         self.console.print(f"  peer KEX resolvable : {kex_state}  (gates the sealed-envelope TRACE path)")
 
@@ -1391,9 +1387,7 @@ class QARunner:
             self._diagnose_delivery_status(_read_probe_log)
         return rooted
 
-    def _trace_plane_from_node_state(
-        self, read_probe_log: Callable[[], str]
-    ) -> Optional[TracePlaneStanding]:
+    def _trace_plane_from_node_state(self, read_probe_log: Callable[[], str]) -> Optional[TracePlaneStanding]:
         """The node's `[TRACE-PLANE]` line, or None when it never logged one.
 
         READ, DO NOT CALL. `node_state()` is in-process to the server, and this
@@ -1417,9 +1411,7 @@ class QARunner:
             logger.debug("[FEDERATION-DELIVERY] trace-plane line unreadable: %s", exc)
             return None
 
-    def _peer_state_from_delivery_status(
-        self, read_probe_log: Callable[[], str]
-    ) -> Optional["CanonicalPeerState"]:
+    def _peer_state_from_delivery_status(self, read_probe_log: Callable[[], str]) -> Optional["CanonicalPeerState"]:
         """The canonical peer's entry from the last [DELIVERY-STATUS] line.
 
         Same source `_diagnose_delivery_status` renders, read as data instead of
@@ -1462,7 +1454,9 @@ class QARunner:
         try:
             lines = [ln for ln in read_probe_log().splitlines() if "[DELIVERY-STATUS]" in ln]
             if not lines:
-                self.console.print("  delivery_status     : (no [DELIVERY-STATUS] line — ciris_server <0.5.125 or probe not run)")
+                self.console.print(
+                    "  delivery_status     : (no [DELIVERY-STATUS] line — ciris_server <0.5.125 or probe not run)"
+                )
                 return
             m = re.search(r"\[DELIVERY-STATUS\]\s+phase=(\S+)\s+(\{.*\})", lines[-1])
             if not m:
@@ -1470,13 +1464,18 @@ class QARunner:
                 return
             phase, blob = m.group(1), m.group(2)
             st = _json.loads(blob)
-            self.console.print(f"  delivery_status     : phase={phase} started={st.get('delivery_started')} edge_up={st.get('edge_up')} targets={st.get('canonical_targets')}")
+            self.console.print(
+                f"  delivery_status     : phase={phase} started={st.get('delivery_started')} edge_up={st.get('edge_up')} targets={st.get('canonical_targets')}"
+            )
             hint = "  → "
             if not st.get("delivery_started"):
                 hint += "delivery_started=false — prime never ran/re-fired (call reprime_federation_delivery(); #288)"
             else:
                 peers = st.get("peers") or []
-                canon = next((p for p in peers if p.get("key_id") in (st.get("canonical_targets") or [])), peers[0] if peers else None)
+                canon = next(
+                    (p for p in peers if p.get("key_id") in (st.get("canonical_targets") or [])),
+                    peers[0] if peers else None,
+                )
                 if canon is None:
                     hint += "no peers in status — canonical not admitted yet"
                 elif not canon.get("knows_peer"):
@@ -1716,10 +1715,10 @@ class QARunner:
         )
         from .modules.accord_metrics_tests import AccordMetricsTests
         from .modules.adapter_autoload_tests import AdapterAutoloadTests
-        from .modules.agent_mode_tests import AgentModeTests
         from .modules.adapter_availability_tests import AdapterAvailabilityTests
         from .modules.adapter_config_tests import AdapterConfigTests
         from .modules.adapter_manifest_tests import AdapterManifestTests
+        from .modules.agent_mode_tests import AgentModeTests
         from .modules.billing_integration_tests import BillingIntegrationTests
         from .modules.cognitive_state_api_tests import CognitiveStateAPITests
         from .modules.context_enrichment_tests import ContextEnrichmentTests
@@ -1740,10 +1739,10 @@ class QARunner:
         from .modules.mesh_repro_tests import MeshReproTests
         from .modules.model_eval_tests import ModelEvalTests
         from .modules.parallel_locales_tests import ParallelLocalesTests
-        from .modules.safety_battery import SafetyBatteryTests
-        from .modules.safety_interpret import SafetyInterpretTests
         from .modules.play_live_tests import PlayLiveTests
         from .modules.reddit_tests import RedditTests
+        from .modules.safety_battery import SafetyBatteryTests
+        from .modules.safety_interpret import SafetyInterpretTests
         from .modules.secrets_encryption_tests import SecretsEncryptionTests
         from .modules.solitude_live_tests import SolitudeLiveTests
         from .modules.sql_external_data_tests import SQLExternalDataTests
@@ -1836,6 +1835,7 @@ class QARunner:
             # external API directly — don't try to open a CIRISClient
             # to a server that isn't running.
             from .modules._module_metadata import get_metadata as _md_lookup
+
             _module_needs_server = getattr(_md_lookup(module), "requires_ciris_server", True)
 
             from contextlib import asynccontextmanager
@@ -1944,6 +1944,7 @@ class QARunner:
                     )
                 elif module == QAModule.SAFETY_INTERPRET:
                     from pathlib import Path as _Path
+
                     _cap = getattr(self.config, "safety_interpret_capture_dir", None)
                     _crit = getattr(self.config, "safety_interpret_criteria_file", None)
                     _key = getattr(self.config, "safety_interpret_openrouter_key_file", None)
@@ -1971,9 +1972,7 @@ class QARunner:
                     self._mesh_repro_verdict = getattr(test_instance, "harness_verdict", None)
                 # Real wall time for this SDK module (accumulate — a module
                 # can run twice across a re-auth retry).
-                self._module_wall[module.value] = self._module_wall.get(module.value, 0.0) + (
-                    time.time() - _mod_t0
-                )
+                self._module_wall[module.value] = self._module_wall.get(module.value, 0.0) + (time.time() - _mod_t0)
 
                 # Store results in runner's results dict
                 for result in results:
@@ -2070,7 +2069,6 @@ class QARunner:
             for test in tests:
                 progress.update(task, description=f"Testing {test.name}...")
 
-
                 passed, result = self._run_single_test(test)
                 self.results[f"{test.module.value}::{test.name}"] = result
 
@@ -2083,27 +2081,27 @@ class QARunner:
                             self.console.print(f"[yellow] Re-authenticating after {test.name}...[/yellow]")
                         # Re-authenticate to restore token for subsequent tests
                         if not self._authenticate():
-                                # `/v1/auth/logout` is the NODE's now, and the node's
-                                # logout DEACTIVATES THE WA CERT rather than dropping a
-                                # token — deliberate upstream, because unauthenticated
-                                # logout was an account-lockout vector (CIRISServer#387).
-                                # A successful logout therefore ENDS the run's identity,
-                                # and re-auth cannot succeed: resolve_login and every
-                                # enumeration are active-only, so the cert is not merely
-                                # logged out, it is invisible.
-                                #
-                                # This produced 191 "Invalid session token" failures that
-                                # read as 191 defects and were one closed account. The
-                                # suite still TESTS logout — fully, asserting 204 — and
-                                # then stops depending on the account it just closed.
-                                self.console.print(
-                                    f"[yellow]🔒 {test.name} closed the run's account "
-                                    f"(node logout deactivates the WA cert, by design). "
-                                    f"Re-auth is impossible; later auth-dependent tests "
-                                    f"are skipped, not counted as failures.[/yellow]"
-                                )
-                                self._identity_closed_by = test.name
-                                self.token = None
+                            # `/v1/auth/logout` is the NODE's now, and the node's
+                            # logout DEACTIVATES THE WA CERT rather than dropping a
+                            # token — deliberate upstream, because unauthenticated
+                            # logout was an account-lockout vector (CIRISServer#387).
+                            # A successful logout therefore ENDS the run's identity,
+                            # and re-auth cannot succeed: resolve_login and every
+                            # enumeration are active-only, so the cert is not merely
+                            # logged out, it is invisible.
+                            #
+                            # This produced 191 "Invalid session token" failures that
+                            # read as 191 defects and were one closed account. The
+                            # suite still TESTS logout — fully, asserting 204 — and
+                            # then stops depending on the account it just closed.
+                            self.console.print(
+                                f"[yellow]🔒 {test.name} closed the run's account "
+                                f"(node logout deactivates the WA cert, by design). "
+                                f"Re-auth is impossible; later auth-dependent tests "
+                                f"are skipped, not counted as failures.[/yellow]"
+                            )
+                            self._identity_closed_by = test.name
+                            self.token = None
                         break
 
                 # Diagnostic auth gate — if this test corrupted the session
@@ -2117,7 +2115,9 @@ class QARunner:
                 if incidents:
                     result["incidents"] = incidents
                     if self.config.verbose:
-                        self.console.print(f"[yellow][WARN] Found {len(incidents)} incidents during {test.name}[/yellow]")
+                        self.console.print(
+                            f"[yellow][WARN] Found {len(incidents)} incidents during {test.name}[/yellow]"
+                        )
 
                 # Check for task appending warnings (messages appended to existing active tasks)
                 task_warnings = self._check_task_appending_warnings(test.name)
@@ -2768,9 +2768,7 @@ class QARunner:
             wall = self._module_wall.get(module_name)
             if wall is None:
                 wall = sum(
-                    (r.get("duration") or 0.0)
-                    for k, r in self.results.items()
-                    if k.split("::", 1)[0] == module_name
+                    (r.get("duration") or 0.0) for k, r in self.results.items() if k.split("::", 1)[0] == module_name
                 )
             if not wall:
                 wall = duration_seconds / len(module_results) if module_results else duration_seconds
@@ -2979,7 +2977,9 @@ class QARunner:
             except subprocess.TimeoutExpired:
                 proc.kill()
                 backend_results[backend] = {"success": False, "detail": f"timeout >{leg_timeout}s"}
-                self.console.print(f"[red][FAIL] {backend.upper()} backend subprocess timed out after {leg_timeout}s[/red]")
+                self.console.print(
+                    f"[red][FAIL] {backend.upper()} backend subprocess timed out after {leg_timeout}s[/red]"
+                )
 
         procs = {}
         for backend in self.database_backends:
@@ -3016,9 +3016,7 @@ class QARunner:
         self.console.print(table)
 
         self.console.print(f"\n[dim]Total Duration: {elapsed:.2f}s ({mode_label})[/dim]")
-        self.console.print(
-            "[dim]Per-backend test counts + incidents are in each subprocess's own summary above.[/dim]"
-        )
+        self.console.print("[dim]Per-backend test counts + incidents are in each subprocess's own summary above.[/dim]")
 
         self.console.print("\n[cyan] Log Locations:[/cyan]")
         for backend in self.database_backends:

--- a/tools/qa_runner/runner.py
+++ b/tools/qa_runner/runner.py
@@ -976,7 +976,8 @@ class QARunner:
         undetected and runs reported "no incidents" when they should have
         failed.
         """
-        explicit = getattr(self.config, "incidents_log_path", None)
+        # getattr on config too: the gate tests build a bare QARunner via __new__.
+        explicit = getattr(getattr(self, "config", None), "incidents_log_path", None)
         if explicit:
             # A backend we did not start (a phone's, a desktop app's) writes
             # wherever it lives; the caller tells us where. Existence is still
@@ -1022,7 +1023,9 @@ class QARunner:
         incidents_log = self._incidents_log_path()
 
         if not incidents_log.exists():
-            self.console.print("\n[bold red]❌ CANNOT CERTIFY THIS RUN — the incidents log does not exist.[/bold red]")
+            self.console.print(
+                "\n[bold red][FAIL] CANNOT CERTIFY THIS RUN — the incidents log does not exist.[/bold red]"
+            )
             self.console.print(
                 f"[red]   expected : {incidents_log.resolve()}[/red]\n"
                 f"[red]   backend  : {getattr(getattr(self, 'server_manager', None), 'database_backend', '<unknown>')}[/red]\n"


### PR DESCRIPTION
## 2.11.1 — release branch

Cut from `main` (`649d57656`, after #1158/#1159/#1160) with today's six commits on top, in order. Version on the branch: **2.11.1** (`CIRIS_VERSION`, Android 191 / 2.11.1, iOS CFBundleShortVersionString) — `check_version_alignment.py` green.

### What changed

1. **`e2c9cb548`, `124be8f90`, `7aab0519c` — attribute resident memory instead of just measuring it.** `tools/memory_composition.py` (smaps attribution, thread census, glibc + Bionic `malloc_info`, `malloc_trim` trial) and `tools/memprobe/` (SIGUSR1 report / SIGUSR2 trim, armed only via PYTHONPATH — zero footprint in shipped code). Reconciles to −0.5% against a synthetic target of known composition. The CI memory benchmark now runs `--composition` and uploads `composition.json`.

   **The finding:** at an 822 MB plateau, **347 MB (42%) was memory glibc had already been told was free**, held across 201 per-thread arenas driven by four native runtimes each sized to `available_parallelism()`. Live heap ≈ 176 MB native + 180 MB Python + 120 MB touched `.so`. True footprint ≈ 490 MB. One `malloc_trim(0)` returned 280 MB in 0.02 s; retention is core-count independent (346 MB at 4 cores). Upstream: **CIRISServer#577** (cap worker threads; sibling of #552).

2. **`d21cd189f` — the resource monitor gives memory back.** It emitted throttle/defer/reject/shutdown into a bus with **no subscribers**; crossing the 768 MB warning produced one log line. Now it subscribes to its own signals: a memory signal runs `memory_release.release_memory()` — `gc.collect` then the allocator's own give-back (glibc `malloc_trim`; Bionic `mallopt(M_PURGE_ALL)`/`M_PURGE`, verified against the NDK header; Darwin `malloc_zone_pressure_relief`) — and writes the post-release RSS into the snapshot. **Android `onTrimMemory` and iOS `didReceiveMemoryWarning` feed the same path** (neither was handled anywhere before). New admin `POST /v1/system/runtime/memory/release`; four new metrics. Bus handler type corrected (`Future` → `Awaitable`; it only passed mypy because nothing subscribed). Proven live: `rss 399 → 386 MB, reclaimed 13 MB via malloc_trim, 118 ms` on an idle agent.

3. **`c863792a3` — QA case** for the release endpoint in `extended_api` (25/25 locally).

4. **`bb3439d48` — five-platform *modular* QA.** `.github/workflows/five-platform-modular-qa.yml`: the UI gate's bring-up copied verbatim (a test fails on drift), `desktop-setup` for the wizard, then `python -m tools.qa_runner <modules> --no-auto-start` against the backend each platform actually runs. Runner gains `--incidents-log PATH` — says *where* the log is, never *whether* to look; fails closed as before.

### Budget ruling carried forward

`ResourceLimit(limit=1024, warning=768, critical=960)` is **unchanged**. The accommodation is reclaim, not a higher ceiling; any change must be explained by composition data.

### Not yet verified

- Nothing on a real phone: the Bionic/Darwin release branches follow their headers; the probe fails loud on an unrecognised allocator (Scudo).
- The modular gate has never run in CI (dispatch-only; linux smoke pending GitHub indexing the new workflow file).
- Run-without-AI: process-level purge covers the allocator; nothing asks the Rust node to drop caches (noted on #577).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J45bNgkggVC1ntnmp6DqQA
