### PR TITLE
Windows gets a memory give-back; the modular gate's first all-platform run, read out

### DIFF
--- a/ciris_engine/logic/utils/memory_release.py
+++ b/ciris_engine/logic/utils/memory_release.py
@@ -22,6 +22,10 @@ header where one was available:
                                               a harmless no-op on older devices
   Darwin  malloc_zone_pressure_relief(NULL, 0) what the OS itself calls on a
                                               memory warning
+  Windows _heapmin() + SetProcessWorkingSetSize  the CRT heap CPython sits on
+                                              gives back its free pages; the
+                                              working-set call then lets the
+                                              kernel trim what is no longer used
 """
 
 from __future__ import annotations
@@ -62,6 +66,10 @@ def _load_libc() -> Optional[ctypes.CDLL]:
         candidates = ["libc.so.6"]
     elif sys.platform in ("darwin", "ios"):
         candidates = ["libSystem.B.dylib", None]
+    elif sys.platform == "win32":
+        # ucrtbase is the Universal CRT every supported CPython links against;
+        # msvcrt is the legacy fallback and still exports _heapmin.
+        candidates = ["ucrtbase", "msvcrt"]
     else:
         candidates = []
     for name in candidates:
@@ -119,6 +127,26 @@ def _platform_release() -> str:
             libc.malloc_zone_pressure_relief.restype = ctypes.c_size_t
             libc.malloc_zone_pressure_relief(None, 0)
             return "malloc_zone_pressure_relief"
+        if sys.platform == "win32":
+            if not hasattr(libc, "_heapmin"):
+                return "unavailable:no _heapmin"
+            libc._heapmin.argtypes = []
+            libc._heapmin.restype = ctypes.c_int
+            libc._heapmin()
+            # Returning heap pages is only half of it on Windows: the working
+            # set keeps them resident until the kernel is told it may trim.
+            kernel32 = getattr(getattr(ctypes, "windll", None), "kernel32", None)
+            if kernel32 is not None:
+                try:
+                    kernel32.SetProcessWorkingSetSize.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_size_t]
+                    kernel32.SetProcessWorkingSetSize.restype = ctypes.c_int
+                    kernel32.SetProcessWorkingSetSize(
+                        kernel32.GetCurrentProcess(), ctypes.c_size_t(-1).value, ctypes.c_size_t(-1).value
+                    )
+                    return "_heapmin+SetProcessWorkingSetSize"
+                except Exception:
+                    pass
+            return "_heapmin"
     except Exception as exc:  # an allocator call must never take the process down
         return f"unavailable:{type(exc).__name__}"
     return "none"

--- a/tests/ciris_engine/logic/utils/test_memory_release.py
+++ b/tests/ciris_engine/logic/utils/test_memory_release.py
@@ -2,6 +2,7 @@
 
 import ctypes
 import sys
+import types
 
 import pytest
 
@@ -229,3 +230,55 @@ def test_is_android_detection_reads_the_environment(monkeypatch):
     assert memory_release._is_android() is False
     monkeypatch.setenv("ANDROID_DATA", "/data")
     assert memory_release._is_android() is True
+
+
+def test_windows_uses_heapmin_and_trims_the_working_set(monkeypatch):
+    """The Windows leg of the modular gate returned platform_call=none: a Windows
+    desktop was getting gc.collect() and nothing else."""
+    libc = _FakeLibc({"_heapmin"})
+    _use(monkeypatch, libc, platform="win32")
+    calls = []
+
+    class _WinFn:
+        argtypes = None
+        restype = None
+
+        def __call__(self, *a):
+            calls.append(a)
+            return 1
+
+    kernel32 = types.SimpleNamespace(SetProcessWorkingSetSize=_WinFn(), GetCurrentProcess=lambda: 42)
+    monkeypatch.setattr(memory_release.ctypes, "windll", types.SimpleNamespace(kernel32=kernel32), raising=False)
+    assert memory_release._platform_release() == "_heapmin+SetProcessWorkingSetSize"
+    assert libc.calls[0][0] == "_heapmin"
+    assert calls and calls[0][0] == 42
+
+
+def test_windows_without_kernel32_still_heapmins(monkeypatch):
+    libc = _FakeLibc({"_heapmin"})
+    _use(monkeypatch, libc, platform="win32")
+    monkeypatch.delattr(memory_release.ctypes, "windll", raising=False)
+    assert memory_release._platform_release() == "_heapmin"
+
+
+def test_windows_without_heapmin_reports_unavailable(monkeypatch):
+    _use(monkeypatch, _FakeLibc(set()), platform="win32")
+    assert memory_release._platform_release() == "unavailable:no _heapmin"
+
+
+def test_load_libc_tries_ucrtbase_then_msvcrt_on_windows(monkeypatch):
+    seen = []
+
+    def fake_cdll(name):
+        seen.append(name)
+        if name == "ucrtbase":
+            raise OSError("not found")
+        return object()
+
+    monkeypatch.setattr(memory_release.ctypes, "CDLL", fake_cdll)
+    monkeypatch.setattr(memory_release, "_libc", None)
+    monkeypatch.setattr(memory_release, "_libc_failed", False)
+    monkeypatch.setattr(memory_release, "_is_android", lambda: False)
+    monkeypatch.setattr(memory_release.sys, "platform", "win32")
+    assert memory_release._load_libc() is not None
+    assert seen == ["ucrtbase", "msvcrt"]

--- a/tools/qa_runner/modules/comprehensive_api_tests.py
+++ b/tools/qa_runner/modules/comprehensive_api_tests.py
@@ -67,8 +67,12 @@ class ComprehensiveAPITestModule:
                 requires_auth=True,
                 description="Admin-triggered gc + allocator give-back; asserts a real platform call was made",
                 validation_rules={
+                    # A KNOWN give-back call, not merely "not none": the first all-platform
+                    # run showed `unavailable:<why>` would have slipped through this rule.
                     "made_a_platform_call": lambda r: isinstance(r.get("data", {}).get("platform_call"), str)
-                    and r["data"]["platform_call"] not in ("", "none"),
+                    and r["data"]["platform_call"].startswith(
+                        ("malloc_trim", "mallopt(", "malloc_zone_pressure_relief", "_heapmin")
+                    ),
                     "reports_rss": lambda r: isinstance(r.get("data", {}).get("rss_after_mb"), int)
                     and r["data"]["rss_after_mb"] > 0,
                 },

--- a/tools/qa_runner/runner.py
+++ b/tools/qa_runner/runner.py
@@ -769,7 +769,7 @@ class QARunner:
         self.console.print("\n[cyan] Log Locations:[/cyan]")
         self.console.print(f"[dim]   • Console (early startup): {log_dir}/console.log[/dim]")
         self.console.print(f"[dim]   • Full logs: {log_dir}/latest.log[/dim]")
-        self.console.print(f"[dim]   • Incidents: {log_dir}/incidents_latest.log[/dim]")
+        self.console.print(f"[dim]   • Incidents: {self._incidents_log_path()}[/dim]")
 
         # Billing-specific reminder for billing integration tests
         if QAModule.BILLING_INTEGRATION in modules:
@@ -2464,6 +2464,17 @@ class QARunner:
                         result["success"] = False
                         if self.config.verbose:
                             self.console.print(f"[red][FAIL] {test.name}: Validation failed[/red]")
+                            # Say WHICH rule and WHAT came back. The first all-platform
+                            # modular run reported "Validation failed" for the memory
+                            # release on Windows and nothing else; the body was the answer.
+                            errors = validation_result.get("validation", {}).get("errors", [])
+                            if errors:
+                                self.console.print(f"[red]   rules: {'; '.join(map(str, errors))}[/red]")
+                            try:
+                                body = response.text
+                            except Exception:
+                                body = "<unreadable>"
+                            self.console.print(f"[red]   body: {body[:400]}[/red]")
                         return False, result
 
                     if self.config.verbose:


### PR DESCRIPTION
## What the first all-platform modular gate said (run 34426927040, on `main` @ 2.11.1)

Five platforms, nine API modules each, against the backend each platform actually runs:

| platform | suite | release call observed | incidents gate |
|---|---|---|---|
| linux | 55/55 | `malloc_trim` (423→392 MB idle) | certified, `$CIRIS_HOME/logs` |
| **windows** | **54/55** | **`none`** | certified |
| macos | 55/55 | `malloc_zone_pressure_relief` | certified |
| **android** | 55/55 | passed the rule — but see below | **certified on a 95 KB log mirrored via `run-as`** |
| ios | 55/55 | `malloc_zone_pressure_relief` | certified, app container |

The harness worked everywhere on its first outing: `desktop-setup` → re-forwarded `:8080` on Android → incidents log found where each platform writes it → `--no-auto-start` attach → 55 tests. The one red is a **product gap the gate found**, not harness noise.

### 1. Windows had no give-back at all (`ec650df88`)
`memory_release` covered glibc, Bionic and Darwin; on Windows `_load_libc()` had no candidates, so a Windows desktop got `gc.collect()` and not a byte returned. Now: ucrtbase (msvcrt fallback) `_heapmin()` — the CRT heap CPython's allocator sits on — then `SetProcessWorkingSetSize(-1,-1)` so the kernel may trim; without the second call the first is invisible in RSS. Fake-CRT/kernel32 tests cover the dispatch; the Windows leg is the real test.

### 2. Three things the run taught about the harness (`e50f011a2`)
- The runner printed `Validation failed` and nothing else; the body was the whole answer. Verbose mode now prints the failed rules and the first 400 bytes of the response.
- The release rule accepted anything that was not `""`/`"none"` — `unavailable:<why>` would have passed. It now requires a known call (`malloc_trim`, `mallopt(`, `malloc_zone_pressure_relief`, `_heapmin`). **Consequence: Android's actual call is not yet observable** — it passed the old rule, so it was one of `mallopt(M_PURGE_ALL)`, `mallopt(M_PURGE)` or `unavailable:no mallopt`; the INFO line is not in the incidents log and the Android `latest.log` was not pulled. The tightened rule makes the bad case fail loudly next run.
- The startup banner printed `logs/sqlite/incidents_latest.log` regardless of `--incidents-log`. The gate read the right file; the banner lied.

### Not a bug, worth knowing
macOS reported `rss 158 → 280 MB, reclaimed −122 MB`. The release fired while the `agent` module had the LLM gate saturated at 4 in-flight and DMA prompts loading (3,467 objects collected, 718 ms); the before/after bracketed heavy concurrent allocation. `reclaimed_mb` is documented as a live delta that can go negative; on a loaded agent it is not attributable to the call alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J45bNgkggVC1ntnmp6DqQA
