### PR TITLE
2.11.2: iOS ships the document parsers; Windows empties the working set only when the host asks

### DIFF
--- a/apps/android/build.gradle
+++ b/apps/android/build.gradle
@@ -25,8 +25,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 36
-        versionCode 191
-        versionName "2.11.1"
+        versionCode 192
+        versionName "2.11.2"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/apps/android/src/main/python/version.py
+++ b/apps/android/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.11.1"
+__version__ = "android-2.11.2"
 
 
 def get_version() -> str:

--- a/apps/ios/iosApp/Info.plist
+++ b/apps/ios/iosApp/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.11.1</string>
+	<string>2.11.2</string>
 	<key>CFBundleVersion</key>
-	<string>354</string>
+	<string>355</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -6,11 +6,11 @@ from typing import List
 from ciris_engine.schemas.runtime.canonical_peer import CanonicalBootstrapPeer
 
 # Version information
-CIRIS_VERSION = "2.11.1-stable"
+CIRIS_VERSION = "2.11.2-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
 CIRIS_VERSION_MINOR = 11
-CIRIS_VERSION_PATCH = 1
+CIRIS_VERSION_PATCH = 2
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/ciris_engine/logic/utils/memory_release.py
+++ b/ciris_engine/logic/utils/memory_release.py
@@ -97,8 +97,14 @@ def rss_bytes() -> int:
         return 0
 
 
-def _platform_release() -> str:
-    """Ask the system allocator to return free pages. Never raises."""
+def _platform_release(trigger: str = "manual") -> str:
+    """Ask the system allocator to return free pages. Never raises.
+
+    `trigger` matters on Windows only: emptying the working set is right when
+    the HOST asks for memory and too blunt for our own threshold -- it evicts
+    live pages too, which then soft-fault back in, so on a desktop that would
+    be a fault storm every time the warning trips.
+    """
     libc = _load_libc()
     if libc is None:
         return "none"
@@ -134,9 +140,12 @@ def _platform_release() -> str:
             libc._heapmin.restype = ctypes.c_int
             libc._heapmin()
             # Returning heap pages is only half of it on Windows: the working
-            # set keeps them resident until the kernel is told it may trim.
+            # set keeps them resident until the kernel is told it may trim. But
+            # SetProcessWorkingSetSize(-1, -1) empties the WHOLE working set, live
+            # pages included (the gate measured 279 -> 1 MB), so only do it when
+            # the host itself is asking -- that is the one time it is worth it.
             kernel32 = getattr(getattr(ctypes, "windll", None), "kernel32", None)
-            if kernel32 is not None:
+            if kernel32 is not None and trigger.startswith("host:"):
                 try:
                     kernel32.SetProcessWorkingSetSize.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_size_t]
                     kernel32.SetProcessWorkingSetSize.restype = ctypes.c_int
@@ -161,7 +170,7 @@ def release_memory(trigger: str = "manual") -> MemoryReleaseResult:
     started = time.perf_counter()
     before = rss_bytes()
     collected = gc.collect()
-    call = _platform_release()
+    call = _platform_release(trigger)
     after = rss_bytes()
     result = MemoryReleaseResult(
         trigger=trigger,

--- a/ciris_engine/logic/utils/memory_release.py
+++ b/ciris_engine/logic/utils/memory_release.py
@@ -97,6 +97,67 @@ def rss_bytes() -> int:
         return 0
 
 
+def _release_bionic(libc: ctypes.CDLL) -> str:
+    if not hasattr(libc, "mallopt"):
+        return "unavailable:no mallopt"
+    libc.mallopt.argtypes = [ctypes.c_int, ctypes.c_int]
+    libc.mallopt.restype = ctypes.c_int
+    # Newest first; an unrecognised option returns 0 and does nothing.
+    if libc.mallopt(_BIONIC_M_PURGE_ALL, 0):
+        return "mallopt(M_PURGE_ALL)"
+    libc.mallopt(_BIONIC_M_PURGE, 0)
+    return "mallopt(M_PURGE)"
+
+
+def _release_glibc(libc: ctypes.CDLL) -> str:
+    if not hasattr(libc, "malloc_trim"):
+        return "unavailable:no malloc_trim"
+    libc.malloc_trim.argtypes = [ctypes.c_size_t]
+    libc.malloc_trim.restype = ctypes.c_int
+    libc.malloc_trim(0)
+    return "malloc_trim"
+
+
+def _release_darwin(libc: ctypes.CDLL) -> str:
+    if not hasattr(libc, "malloc_zone_pressure_relief"):
+        return "unavailable:no malloc_zone_pressure_relief"
+    libc.malloc_zone_pressure_relief.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
+    libc.malloc_zone_pressure_relief.restype = ctypes.c_size_t
+    libc.malloc_zone_pressure_relief(None, 0)
+    return "malloc_zone_pressure_relief"
+
+
+def _trim_windows_working_set() -> bool:
+    """SetProcessWorkingSetSize(-1, -1): empties the WHOLE working set, live pages
+    included (the gate measured 279 -> 1 MB). Returns False when kernel32 is not
+    reachable or the call fails; never raises."""
+    kernel32 = getattr(getattr(ctypes, "windll", None), "kernel32", None)
+    if kernel32 is None:
+        return False
+    try:
+        kernel32.SetProcessWorkingSetSize.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_size_t]
+        kernel32.SetProcessWorkingSetSize.restype = ctypes.c_int
+        everything = ctypes.c_size_t(-1).value
+        kernel32.SetProcessWorkingSetSize(kernel32.GetCurrentProcess(), everything, everything)
+        return True
+    except Exception:
+        return False
+
+
+def _release_windows(libc: ctypes.CDLL, trigger: str) -> str:
+    if not hasattr(libc, "_heapmin"):
+        return "unavailable:no _heapmin"
+    libc._heapmin.argtypes = []
+    libc._heapmin.restype = ctypes.c_int
+    libc._heapmin()
+    # Returning heap pages is only half of it on Windows: the working set keeps
+    # them resident until the kernel is told it may trim. But that trim evicts
+    # live pages too, so only when the host itself is asking.
+    if trigger.startswith("host:") and _trim_windows_working_set():
+        return "_heapmin+SetProcessWorkingSetSize"
+    return "_heapmin"
+
+
 def _platform_release(trigger: str = "manual") -> str:
     """Ask the system allocator to return free pages. Never raises.
 
@@ -110,52 +171,13 @@ def _platform_release(trigger: str = "manual") -> str:
         return "none"
     try:
         if _is_android():
-            if not hasattr(libc, "mallopt"):
-                return "unavailable:no mallopt"
-            libc.mallopt.argtypes = [ctypes.c_int, ctypes.c_int]
-            libc.mallopt.restype = ctypes.c_int
-            # Newest first; an unrecognised option returns 0 and does nothing.
-            if libc.mallopt(_BIONIC_M_PURGE_ALL, 0):
-                return "mallopt(M_PURGE_ALL)"
-            libc.mallopt(_BIONIC_M_PURGE, 0)
-            return "mallopt(M_PURGE)"
+            return _release_bionic(libc)
         if sys.platform.startswith("linux"):
-            if not hasattr(libc, "malloc_trim"):
-                return "unavailable:no malloc_trim"
-            libc.malloc_trim.argtypes = [ctypes.c_size_t]
-            libc.malloc_trim.restype = ctypes.c_int
-            libc.malloc_trim(0)
-            return "malloc_trim"
+            return _release_glibc(libc)
         if sys.platform in ("darwin", "ios"):
-            if not hasattr(libc, "malloc_zone_pressure_relief"):
-                return "unavailable:no malloc_zone_pressure_relief"
-            libc.malloc_zone_pressure_relief.argtypes = [ctypes.c_void_p, ctypes.c_size_t]
-            libc.malloc_zone_pressure_relief.restype = ctypes.c_size_t
-            libc.malloc_zone_pressure_relief(None, 0)
-            return "malloc_zone_pressure_relief"
+            return _release_darwin(libc)
         if sys.platform == "win32":
-            if not hasattr(libc, "_heapmin"):
-                return "unavailable:no _heapmin"
-            libc._heapmin.argtypes = []
-            libc._heapmin.restype = ctypes.c_int
-            libc._heapmin()
-            # Returning heap pages is only half of it on Windows: the working
-            # set keeps them resident until the kernel is told it may trim. But
-            # SetProcessWorkingSetSize(-1, -1) empties the WHOLE working set, live
-            # pages included (the gate measured 279 -> 1 MB), so only do it when
-            # the host itself is asking -- that is the one time it is worth it.
-            kernel32 = getattr(getattr(ctypes, "windll", None), "kernel32", None)
-            if kernel32 is not None and trigger.startswith("host:"):
-                try:
-                    kernel32.SetProcessWorkingSetSize.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_size_t]
-                    kernel32.SetProcessWorkingSetSize.restype = ctypes.c_int
-                    kernel32.SetProcessWorkingSetSize(
-                        kernel32.GetCurrentProcess(), ctypes.c_size_t(-1).value, ctypes.c_size_t(-1).value
-                    )
-                    return "_heapmin+SetProcessWorkingSetSize"
-                except Exception:
-                    pass
-            return "_heapmin"
+            return _release_windows(libc, trigger)
     except Exception as exc:  # an allocator call must never take the process down
         return f"unavailable:{type(exc).__name__}"
     return "none"

--- a/tests/ciris_engine/logic/utils/test_memory_release.py
+++ b/tests/ciris_engine/logic/utils/test_memory_release.py
@@ -249,16 +249,38 @@ def test_windows_uses_heapmin_and_trims_the_working_set(monkeypatch):
 
     kernel32 = types.SimpleNamespace(SetProcessWorkingSetSize=_WinFn(), GetCurrentProcess=lambda: 42)
     monkeypatch.setattr(memory_release.ctypes, "windll", types.SimpleNamespace(kernel32=kernel32), raising=False)
-    assert memory_release._platform_release() == "_heapmin+SetProcessWorkingSetSize"
+    assert memory_release._platform_release("host:RUNNING_CRITICAL") == "_heapmin+SetProcessWorkingSetSize"
     assert libc.calls[0][0] == "_heapmin"
     assert calls and calls[0][0] == 42
+
+
+def test_windows_own_threshold_does_not_empty_the_working_set(monkeypatch):
+    """The gate measured 279 -> 1 MB from SetProcessWorkingSetSize: it evicts live
+    pages too. That is for the host's memory pressure, not our 768 MB warning."""
+    libc = _FakeLibc({"_heapmin"})
+    _use(monkeypatch, libc, platform="win32")
+    calls = []
+
+    class _WinFn:
+        argtypes = None
+        restype = None
+
+        def __call__(self, *a):
+            calls.append(a)
+            return 1
+
+    kernel32 = types.SimpleNamespace(SetProcessWorkingSetSize=_WinFn(), GetCurrentProcess=lambda: 42)
+    monkeypatch.setattr(memory_release.ctypes, "windll", types.SimpleNamespace(kernel32=kernel32), raising=False)
+    assert memory_release._platform_release("resource_monitor:defer") == "_heapmin"
+    assert libc.calls[0][0] == "_heapmin"
+    assert calls == []
 
 
 def test_windows_without_kernel32_still_heapmins(monkeypatch):
     libc = _FakeLibc({"_heapmin"})
     _use(monkeypatch, libc, platform="win32")
     monkeypatch.delattr(memory_release.ctypes, "windll", raising=False)
-    assert memory_release._platform_release() == "_heapmin"
+    assert memory_release._platform_release("host:COMPLETE") == "_heapmin"
 
 
 def test_windows_without_heapmin_reports_unavailable(monkeypatch):


### PR DESCRIPTION
## 2.11.2 — two fixes the modular gate's first all-platform runs surfaced, plus the bump

### iOS ships `pypdf` and `docx2txt` (`9ec5e65f0`)
The iOS leg's incidents gate (run 34431300463, #1165 item 5) flagged `document_parser: No document parsing libraries available` as an ERROR in the simulator backend. Desktop pins both parsers in `requirements.txt`, Android installs both in `build.gradle`; iOS was the one platform without them — an omission, not a decision. `Resources.zip` now carries **pypdf 6.0.0** (the CVE-fixed floor Android uses; its only 3.10 runtime dependency, `typing_extensions`, was already in the bundle) and **docx2txt 0.9**, both `py3-none-any`. Built from a scratch extraction of the checked-in zip plus the two wheels: 81 new entries, the original 5,877 untouched, built-from marker preserved. `check_ios_substrate_current.py` green.

### Windows: working-set trim only on host pressure (`2b7118b45`, `52250a135`)
The Windows leg measured the new give-back at `rss 279 → 1 MB via _heapmin+SetProcessWorkingSetSize`. The 1 MB is the tell — `SetProcessWorkingSetSize(-1,-1)` empties the **whole** working set, live pages included, which soft-fault back in. Right when the OS is short of memory; a fault storm every 60 s if it answers our own 768 MB warning. `_heapmin` stays for every trigger, the working-set trim only for `host:*`. Sonar then flagged the dispatcher at cognitive complexity 22/15 once Windows joined, so it is now one helper per allocator; behaviour unchanged, 22 dispatch tests pass.

### Version 2.11.1 → 2.11.2
Load-bearing for the iOS fix, not housekeeping: `PythonBridge.swift` re-extracts `Resources.zip` only when `CFBundleShortVersionString-CFBundleVersion` changes. `main` had also carried #1163 and this PR's first commits past the `v2.11.1-stable` tag without a bump. `check_version_alignment.py` green.

### Still open on #1165
The `ciris_verify` manifest-integrity / no-key pair on the simulator, and whether the iOS leg runs the `agent` module on the live wire given the 110 s interact ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J45bNgkggVC1ntnmp6DqQA