### PR TITLE
modular gate: a red suite on a leg's first platform must not skip its second

### DIFF
--- a/.github/workflows/five-platform-modular-qa.yml
+++ b/.github/workflows/five-platform-modular-qa.yml
@@ -709,7 +709,13 @@ jobs:
             fi
 
             # 4. THE SUITE, against the backend this platform brought up.
+            # `shell: bash` runs this script with -e. A non-zero runner exit here is
+            # a RESULT to record, not a reason to stop: unwrapped, it aborted the
+            # script before the verdict, the log copy and the leg's SECOND platform
+            # -- run 34494723581 lost iOS entirely behind one macOS incident, and
+            # run 34426927040 had no chat-windows.json for the same reason.
             qa_rc=0
+            set +e
             python -m tools.qa_runner $MODULES \
               --no-auto-start --port 8080 \
               --username qaadmin --password "qa_test_password_12345" \
@@ -717,6 +723,7 @@ jobs:
               --proceed-anyway --json --report-dir "artifacts/qa/$plat" -v \
               2>&1 | tee "artifacts/qa/$plat/runner.log"
             qa_rc=${PIPESTATUS[0]}
+            set -e
             [ -n "$mirror_pid" ] && { kill "$mirror_pid" 2>/dev/null || true; }
             if [ "$qa_rc" != 0 ]; then
               overall=1


### PR DESCRIPTION
\`shell: bash\` runs the driving step with \`-e\`. The runner was piped through \`tee\` outside any \`||\`/\`if\`, so a non-zero runner exit — a **result** the step exists to record — aborted the script before the verdict, the log copy, and the leg's second platform.

Evidence: run 34494723581 (2.11.2) produced no iOS run at all — the artifact has no \`logs/ios\`, the job log has no \`ios (ios)\` group — because macOS's runner exited 1 on a single \`INTERACT_TIMEOUT\` incident first. Run 34426927040 had no \`chat-windows.json\` for the same reason (Windows was 54/55).

Fix is the gate's own idiom around its trace check: \`set +e\` / capture \`PIPESTATUS\` / \`set -e\`. Bring-up untouched; the parity test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J45bNgkggVC1ntnmp6DqQA