### PR TITLE
2.11.3: desktop JAR launched with CIRIS_NODE_URL at the brain — the 404-on-everything a Windows user hit

### DIFF
--- a/apps/android/build.gradle
+++ b/apps/android/build.gradle
@@ -25,8 +25,8 @@ android {
         applicationId "ai.ciris.mobile"
         minSdk 24
         targetSdk 36
-        versionCode 192
-        versionName "2.11.2"
+        versionCode 193
+        versionName "2.11.3"
 
         ndk {
             // Include x86_64 for emulator testing (Chaquopy reads abiFilters at config time)

--- a/apps/android/src/main/python/version.py
+++ b/apps/android/src/main/python/version.py
@@ -7,7 +7,7 @@ The version hash is computed at build time from the main repository.
 
 # Static version - updated at build time by the Android build process
 # This avoids file-system hashing logic that doesn't work in the Android package
-__version__ = "android-2.11.2"
+__version__ = "android-2.11.3"
 
 
 def get_version() -> str:

--- a/apps/ios/iosApp/Info.plist
+++ b/apps/ios/iosApp/Info.plist
@@ -21,9 +21,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.11.2</string>
+	<string>2.11.3</string>
 	<key>CFBundleVersion</key>
-	<string>355</string>
+	<string>356</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/ciris_engine/constants.py
+++ b/ciris_engine/constants.py
@@ -6,11 +6,11 @@ from typing import List
 from ciris_engine.schemas.runtime.canonical_peer import CanonicalBootstrapPeer
 
 # Version information
-CIRIS_VERSION = "2.11.2-stable"
+CIRIS_VERSION = "2.11.3-stable"
 ACCORD_VERSION = "1.2-Beta"
 CIRIS_VERSION_MAJOR = 2
 CIRIS_VERSION_MINOR = 11
-CIRIS_VERSION_PATCH = 2
+CIRIS_VERSION_PATCH = 3
 CIRIS_VERSION_BUILD = 0
 CIRIS_VERSION_STAGE = "stable"
 CIRIS_CODENAME = "Context Engineering"  # Codename for this release

--- a/ciris_engine/desktop_launcher.py
+++ b/ciris_engine/desktop_launcher.py
@@ -15,7 +15,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional
 
 from ciris_engine.logic.utils import win_console as _win_console
 
@@ -182,7 +182,7 @@ def _print_java_install_instructions() -> None:
     print("=" * 70 + "\n", file=sys.stderr)
 
 
-def desktop_app_env(server_url: str, base: Optional[dict] = None) -> dict:
+def desktop_app_env(server_url: str, base: Optional[Dict[str, str]] = None) -> Dict[str, str]:
     """The environment the desktop JAR is launched with. ONE definition.
 
     The client reads two names: CIRIS_API_URL (the brain) and CIRIS_NODE_URL
@@ -200,7 +200,7 @@ def desktop_app_env(server_url: str, base: Optional[dict] = None) -> dict:
     So: both names point at the brain, an operator's explicit CIRIS_NODE_URL
     is honoured verbatim, and the harness derives its own values from here.
     """
-    env = dict(os.environ if base is None else base)
+    env: Dict[str, str] = dict(os.environ) if base is None else dict(base)
     env["CIRIS_API_URL"] = server_url
     explicit = (env.get("CIRIS_NODE_URL") or "").strip()
     env["CIRIS_NODE_URL"] = explicit or server_url

--- a/ciris_engine/desktop_launcher.py
+++ b/ciris_engine/desktop_launcher.py
@@ -182,6 +182,31 @@ def _print_java_install_instructions() -> None:
     print("=" * 70 + "\n", file=sys.stderr)
 
 
+def desktop_app_env(server_url: str, base: Optional[dict] = None) -> dict:
+    """The environment the desktop JAR is launched with. ONE definition.
+
+    The client reads two names: CIRIS_API_URL (the brain) and CIRIS_NODE_URL
+    (the node). Since ciris-client 0.5.213 it builds its ordinary API client
+    from CIRIS_NODE_URL alone and ignores CIRIS_API_URL there -- a deliberate
+    fix for the run-without-AI hand-off (CIRISClient#48/#52). This launcher
+    set only CIRIS_API_URL, so every desktop started by `ciris-agent` had its
+    UI pointed at the bare node on :4243, where only the node-native surface
+    and fourteen proxied brain prefixes exist: "Add provider" (PUT
+    /v1/setup/llm), list-models, /v1/system/llm, users, memory writes all
+    404'd. The QA gate never saw it because its harness set BOTH names to the
+    brain -- the intended configuration (routes/node_proxy.py makes :8080 the
+    one complete surface) -- while the product did not.
+
+    So: both names point at the brain, an operator's explicit CIRIS_NODE_URL
+    is honoured verbatim, and the harness derives its own values from here.
+    """
+    env = dict(os.environ if base is None else base)
+    env["CIRIS_API_URL"] = server_url
+    explicit = (env.get("CIRIS_NODE_URL") or "").strip()
+    env["CIRIS_NODE_URL"] = explicit or server_url
+    return env
+
+
 def launch_desktop_app(server_url: str = "http://localhost:8080") -> int:
     """
     Launch the CIRIS Desktop application.
@@ -221,9 +246,7 @@ def launch_desktop_app(server_url: str = "http://localhost:8080") -> int:
 
     print(f"Launching CIRIS Desktop from: {jar_path}")
 
-    # Set environment for desktop app
-    env = os.environ.copy()
-    env["CIRIS_API_URL"] = server_url
+    env = desktop_app_env(server_url)
 
     # Launch desktop app
     try:

--- a/tests/ciris_engine/test_desktop_launcher_env.py
+++ b/tests/ciris_engine/test_desktop_launcher_env.py
@@ -1,0 +1,45 @@
+"""The desktop JAR must be launched with BOTH backend names pointed at the brain.
+
+ciris-client >= 0.5.213 builds its ordinary API client from CIRIS_NODE_URL and
+ignores CIRIS_API_URL there. A launcher that sets only CIRIS_API_URL points the
+whole UI at the bare node on :4243 -- "Add provider" 404s, list-models 404s.
+"""
+
+import importlib
+
+from ciris_engine import desktop_launcher
+
+
+def test_both_names_point_at_the_brain_by_default():
+    env = desktop_launcher.desktop_app_env("http://localhost:8080", base={})
+    assert env["CIRIS_API_URL"] == "http://localhost:8080"
+    assert env["CIRIS_NODE_URL"] == "http://localhost:8080"
+
+
+def test_an_explicit_node_url_is_honoured_verbatim():
+    """An operator attached to someone else's node (CIRISClient#26) keeps it."""
+    env = desktop_launcher.desktop_app_env("http://localhost:8080", base={"CIRIS_NODE_URL": "http://10.0.0.7:4243"})
+    assert env["CIRIS_API_URL"] == "http://localhost:8080"
+    assert env["CIRIS_NODE_URL"] == "http://10.0.0.7:4243"
+
+
+def test_blank_node_url_does_not_count_as_explicit():
+    env = desktop_launcher.desktop_app_env("http://localhost:8080", base={"CIRIS_NODE_URL": "  "})
+    assert env["CIRIS_NODE_URL"] == "http://localhost:8080"
+
+
+def test_process_environment_is_inherited_not_replaced():
+    env = desktop_launcher.desktop_app_env("http://localhost:8080", base={"PATH": "/x", "JAVA_HOME": "/j"})
+    assert env["PATH"] == "/x" and env["JAVA_HOME"] == "/j"
+
+
+def test_qa_harness_launches_with_the_same_urls_as_the_product(monkeypatch):
+    """The gate must exercise the environment users get. This is the parity the
+    first real desktop user found missing."""
+    monkeypatch.delenv("CIRIS_DESKTOP_API_URL", raising=False)
+    monkeypatch.delenv("CIRIS_DESKTOP_NODE_URL", raising=False)
+    monkeypatch.delenv("CIRIS_NODE_URL", raising=False)
+    web_ui = importlib.import_module("tools.qa_runner.modules.web_ui.__main__")
+    api, node = web_ui._desktop_urls("http://localhost:8080")
+    env = desktop_launcher.desktop_app_env("http://localhost:8080", base={})
+    assert (api, node) == (env["CIRIS_API_URL"], env["CIRIS_NODE_URL"])

--- a/tools/qa_runner/modules/web_ui/__main__.py
+++ b/tools/qa_runner/modules/web_ui/__main__.py
@@ -57,28 +57,23 @@ import asyncio
 import glob
 import json
 import os
+import re
 import shutil
 import subprocess
-import tempfile
 import sys
+import tempfile
 import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List, Optional
 
-import re
 import requests
 
 from tools.qa_runner.platform_procs import temp_path
 
 from .browser_helper import BrowserConfig, ensure_playwright_installed
-from .desktop_app_helper import (
-    DesktopAppConfig,
-    DesktopAppHelper,
-    attribute_device_failure,
-    check_desktop_app_running,
-)
+from .desktop_app_helper import DesktopAppConfig, DesktopAppHelper, attribute_device_failure, check_desktop_app_running
 from .federation_walk_test import FederationWalkTest
 from .server_manager import ServerConfig
 from .test_cases import WebUITestConfig
@@ -169,8 +164,13 @@ class DesktopAppTestRunner:
         return any(
             k in text
             for k in (
-                "ConnectError", "ConnectTimeout", "RemoteProtocolError", "ReadError",
-                "All connection attempts failed", "Connection refused", "Connection reset",
+                "ConnectError",
+                "ConnectTimeout",
+                "RemoteProtocolError",
+                "ReadError",
+                "All connection attempts failed",
+                "Connection refused",
+                "Connection reset",
             )
         )
 
@@ -266,7 +266,9 @@ class DesktopAppTestRunner:
             if screen != "Interact":
                 self._log(f"no prior session (screen={screen}); the credential login is driven from here")
                 return
-            self._log("the post-setup auto-login already established a session — logging out to exercise the credential login")
+            self._log(
+                "the post-setup auto-login already established a session — logging out to exercise the credential login"
+            )
             await self._logout()
 
         await self.run_test("release_auto_login", release_auto_login)
@@ -470,9 +472,7 @@ class DesktopAppTestRunner:
             return r.json()["data"]["messages"]
 
         _http = httpx.AsyncClient(timeout=30.0)
-        _r = await _http.post(
-            f"{api_base}/v1/auth/login", json={"username": username, "password": password}
-        )
+        _r = await _http.post(f"{api_base}/v1/auth/login", json={"username": username, "password": password})
         _r.raise_for_status()
         _headers = {"Authorization": f"Bearer {_r.json()['access_token']}"}
         try:
@@ -481,7 +481,6 @@ class DesktopAppTestRunner:
             self._log(f"pre-send history unavailable ({type(exc).__name__}); baseline empty")
             baseline_ids = set()
         self._log(f"History baseline: {len(baseline_ids)} existing message(s)")
-
 
         # Click send button
         async def click_send():
@@ -655,9 +654,7 @@ class DesktopAppTestRunner:
         lines = [
             f"          {e.test_tag} = {e.text.strip()[:110]}"
             for e in elements
-            if getattr(e, "text", None)
-            and e.text.strip()
-            and any(e.test_tag.startswith(pfx) for pfx in prefixes)
+            if getattr(e, "text", None) and e.text.strip() and any(e.test_tag.startswith(pfx) for pfx in prefixes)
         ]
         if not lines:
             return (
@@ -872,6 +869,7 @@ class DesktopAppTestRunner:
         collapsed group or below the fold, and presence in /tree is not
         drivability (CIRISClient#39).
         """
+
         async def _sidebar_to_logout(tag: str, what: str) -> bool:
             if await self.helper.reveal_sidebar_row(tag):
                 return False
@@ -1004,7 +1002,10 @@ class DesktopAppTestRunner:
                     env["SIMCTL_CHILD_CIRIS_TEST_MODE"] = "true"
                     subprocess.run(
                         ["xcrun", "simctl", "launch", udid, bundle_id],
-                        capture_output=True, text=True, timeout=120, env=env,
+                        capture_output=True,
+                        text=True,
+                        timeout=120,
+                        env=env,
                     )
                     await asyncio.sleep(3.0)
                     await self.helper.reconnect()
@@ -1023,7 +1024,9 @@ class DesktopAppTestRunner:
                         first_run = True
                         break
                 except Exception as exc:  # noqa: BLE001 -- the server went away with the old process
-                    self._log(f"automation server not answering ({type(exc).__name__}) — the app is restarting; reconnecting")
+                    self._log(
+                        f"automation server not answering ({type(exc).__name__}) — the app is restarting; reconnecting"
+                    )
                     await asyncio.sleep(1.0)
                     await self.helper.reconnect()
                     continue
@@ -1037,7 +1040,9 @@ class DesktopAppTestRunner:
             #    imply either answer.
             platform = getattr(_LAST_ARGS, "platform", "desktop") or "desktop"
             if platform != "desktop":
-                self._log(f"NOT ASSERTED on {platform}: the .env lives on the device; the desktop legs assert its removal")
+                self._log(
+                    f"NOT ASSERTED on {platform}: the .env lives on the device; the desktop legs assert its removal"
+                )
                 return
             env_path = Path(os.environ.get("CIRIS_HOME") or (Path.home() / "ciris")) / ".env"
             deadline = time.time() + 20
@@ -1051,7 +1056,10 @@ class DesktopAppTestRunner:
                     self._log(f"{env_path} no longer records a configured install")
                     return
                 await asyncio.sleep(0.5)
-            raise RuntimeError(f"{env_path} still records the install 20s after the reset was confirmed (factory reset stopped clearing it)")
+            raise RuntimeError(
+                f"{env_path} still records the install 20s after the reset was confirmed (factory reset stopped clearing it)"
+            )
+
         await self.run_test("reset_took_effect", reset_took_effect)
         return all(r.success for r in self.results)
 
@@ -1176,8 +1184,7 @@ class DesktopAppTestRunner:
             has no toggles". Order fixed, and the skip made loud.
             """
             self._log(
-                f"YOU: without_ai={run_without_ai}, band={age_band}, username={username}, "
-                f"fed-ID label={fed_label}"
+                f"YOU: without_ai={run_without_ai}, band={age_band}, username={username}, " f"fed-ID label={fed_label}"
             )
 
             # 0. THE AI QUESTION — FIRST, because that is where the screen puts it.
@@ -1273,7 +1280,7 @@ class DesktopAppTestRunner:
             deadline = asyncio.get_event_loop().time() + 30.0
             while await self.helper.is_element_present(band_tag):
                 if await self.helper.is_element_present("toggle_announce_ownership"):
-                    break   # JOIN FEDERATION is on screen: YOU advanced
+                    break  # JOIN FEDERATION is on screen: YOU advanced
                 if asyncio.get_event_loop().time() > deadline:
                     await self._dump_tree("you_step:did-not-advance")
                     raise RuntimeError(
@@ -1534,7 +1541,11 @@ class DesktopAppTestRunner:
                         f"no CIRIS_RUN_WITHOUT_AI in {env_path}.\n"
                         "        The agent saw run_without_ai=false and took the accidental-no-key "
                         "branch"
-                        + (" (CIRIS_SERVICES_DISABLED=true is present, which is that branch's signature)" if disabled else "")
+                        + (
+                            " (CIRIS_SERVICES_DISABLED=true is present, which is that branch's signature)"
+                            if disabled
+                            else ""
+                        )
                         + ".\n"
                         "        So the screen was absent for another reason — most likely "
                         "clientMode=NODE on a fresh home, where hasAgent is false and hasAiStep is "
@@ -1574,9 +1585,7 @@ class DesktopAppTestRunner:
             # this off the flag rather than off a failed connect keeps a genuinely
             # dead agent on a with-AI leg loud instead of silently rerouted.
             login_base = (
-                node_url.rstrip("/")
-                if getattr(_args, "run_without_ai", False)
-                else f"http://127.0.0.1:{api_port}"
+                node_url.rstrip("/") if getattr(_args, "run_without_ai", False) else f"http://127.0.0.1:{api_port}"
             )
             # NO KEEP-ALIVE POOL. On a no-AI leg the peer behind :4243 changes
             # identity mid-step (the agent-hosted fold dies, the exec'd node takes
@@ -1632,8 +1641,11 @@ class DesktopAppTestRunner:
                         await asyncio.sleep(1.0)
                     self._log(
                         f"node read API at {login_base}: {'up' if node_up else 'NOT up after 60s'} "
-                        + ("after the hand-off transition (fold down, node up)" if saw_down
-                           else "with no transition seen in 4s -- in-process fold, no exec")
+                        + (
+                            "after the hand-off transition (fold down, node up)"
+                            if saw_down
+                            else "with no transition seen in 4s -- in-process fold, no exec"
+                        )
                     )
 
                 # NAME THE PEER THAT DROPPED US. Everything in this block talks to
@@ -1993,7 +2005,7 @@ Examples:
     parser.add_argument(
         "--run-without-ai",
         action="store_true",
-        help="Answer the wizard's AI question with \"without an AI assistant\" (client >= 0.5.203). "
+        help='Answer the wizard\'s AI question with "without an AI assistant" (client >= 0.5.203). '
         "The AI screen is then not shown, the agent records CIRIS_RUN_WITHOUT_AI=true, and the "
         "backend becomes a ciris-server node on :4243 (CIRISAgent#1149).",
     )
@@ -2223,14 +2235,12 @@ Examples:
         action="append",
         default=None,
         metavar="PATH",
-        help="For `flow`: a flow spec (.yaml) or a directory of them. Repeatable. "
-        "Default: tools/qa_runner/flows.",
+        help="For `flow`: a flow spec (.yaml) or a directory of them. Repeatable. " "Default: tools/qa_runner/flows.",
     )
     parser.add_argument(
         "--artifacts",
         default="artifacts",
-        help="For `flow`: where per-step screenshots and the JSON report are written "
-        "(default: artifacts).",
+        help="For `flow`: where per-step screenshots and the JSON report are written " "(default: artifacts).",
     )
     parser.add_argument(
         "--node-url",
@@ -2558,8 +2568,16 @@ def _desktop_urls(brain_base_url: str) -> "tuple[str, str]":
 
     Set CIRIS_DESKTOP_NODE_URL to drive a bare node deliberately.
     """
+    # Derived from the PRODUCT launcher, not restated here. This helper used
+    # to carry its own copy of the rule, and the copy was right while the
+    # launcher was wrong (it set only CIRIS_API_URL): the gate went green on all
+    # five platforms with an environment no user ever got, and the first real
+    # desktop user 404'd on "Add provider". One definition, two callers.
+    from ciris_engine.desktop_launcher import desktop_app_env
+
     api = os.environ.get("CIRIS_DESKTOP_API_URL", "").strip() or brain_base_url
-    node = os.environ.get("CIRIS_DESKTOP_NODE_URL", "").strip() or api
+    derived = desktop_app_env(api, base={})
+    node = os.environ.get("CIRIS_DESKTOP_NODE_URL", "").strip() or derived["CIRIS_NODE_URL"]
     return api, node
 
 
@@ -2944,7 +2962,9 @@ async def run_android_up(args: argparse.Namespace) -> int:
     if forward_node.returncode == 0:
         print(f"  forward: host:4243 -> {serial}:4243 (node read API, run-without-AI)")
     else:
-        print(f"  [WARN] adb forward 4243->4243 failed: {forward_node.stderr.strip()} -- node not observable from the host")
+        print(
+            f"  [WARN] adb forward 4243->4243 failed: {forward_node.stderr.strip()} -- node not observable from the host"
+        )
 
     # 5. Poll /health.
     print("[4/5] Waiting for AndroidTestAutomationServer to come up…")
@@ -3064,8 +3084,21 @@ async def run_desktop_up(args: argparse.Namespace) -> int:
     import subprocess as _sp
 
     _free = _sp.run(
-        [sys.executable, "tools/dev/free_ports.py", "4242", "4243", str(args.port), "--timeout", "30", "--label", "bring-up"],
-        capture_output=True, text=True, timeout=60, cwd=str(Path(__file__).resolve().parents[4]),
+        [
+            sys.executable,
+            "tools/dev/free_ports.py",
+            "4242",
+            "4243",
+            str(args.port),
+            "--timeout",
+            "30",
+            "--label",
+            "bring-up",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        cwd=str(Path(__file__).resolve().parents[4]),
     )
     print(_free.stdout.rstrip() or "  bring-up: free_ports produced no output")
     if _free.returncode != 0:
@@ -3235,8 +3268,21 @@ async def run_desktop_first_run_up(args: argparse.Namespace) -> int:
     import subprocess as _sp
 
     _free = _sp.run(
-        [sys.executable, "tools/dev/free_ports.py", "4242", "4243", str(args.port), "--timeout", "30", "--label", "bring-up"],
-        capture_output=True, text=True, timeout=60, cwd=str(Path(__file__).resolve().parents[4]),
+        [
+            sys.executable,
+            "tools/dev/free_ports.py",
+            "4242",
+            "4243",
+            str(args.port),
+            "--timeout",
+            "30",
+            "--label",
+            "bring-up",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        cwd=str(Path(__file__).resolve().parents[4]),
     )
     print(_free.stdout.rstrip() or "  bring-up: free_ports produced no output")
     if _free.returncode != 0:
@@ -3378,7 +3424,6 @@ def _is_new_agent_reply(msg: dict, baseline_ids: set, sent: str) -> bool:
     return bool(content) and content != sent
 
 
-
 def qa_log_dir() -> Path:
     """Where bring-up writes everything it learns, so CI can upload it.
 
@@ -3486,9 +3531,18 @@ def _ios_diagnostics(udid: str, bundle_id: str, process_name: str = "iosApp") ->
         (
             "ios-oslog",
             [
-                "xcrun", "simctl", "spawn", udid, "log", "show",
-                "--last", "10m", "--style", "syslog",
-                "--predicate", f'process == "{process_name}" OR subsystem CONTAINS "{bundle_id}"',
+                "xcrun",
+                "simctl",
+                "spawn",
+                udid,
+                "log",
+                "show",
+                "--last",
+                "10m",
+                "--style",
+                "syslog",
+                "--predicate",
+                f'process == "{process_name}" OR subsystem CONTAINS "{bundle_id}"',
             ],
         ),
     ]
@@ -3517,9 +3571,16 @@ def _ios_diagnostics(udid: str, bundle_id: str, process_name: str = "iosApp") ->
             fw_dir = Path(app_root[0]) / "Frameworks"
             names = sorted(p.name for p in fw_dir.iterdir()) if fw_dir.is_dir() else []
             (qa_log_dir() / "ios-app-frameworks.txt").write_text("\n".join(names) + "\n", encoding="utf-8")
-            ext = [n for n in names if n.endswith(".framework") and n not in ("shared.framework", "CIRISVerify.framework", "Python.framework")]
-            print(f"    app Frameworks/: {len(names)} entries, {len(ext)} Python extension framework(s); "
-                  f"_struct.framework {'present' if '_struct.framework' in names else 'MISSING'}")
+            ext = [
+                n
+                for n in names
+                if n.endswith(".framework")
+                and n not in ("shared.framework", "CIRISVerify.framework", "Python.framework")
+            ]
+            print(
+                f"    app Frameworks/: {len(names)} entries, {len(ext)} Python extension framework(s); "
+                f"_struct.framework {'present' if '_struct.framework' in names else 'MISSING'}"
+            )
         box = _simctl(["get_app_container", udid, bundle_id, "data"], timeout=60)
         root = (box.stdout or "").strip().splitlines()
         base = Path(root[0]) / "Documents" / "ciris" if root and root[0].startswith("/") else None
@@ -3549,8 +3610,7 @@ def _ios_diagnostics(udid: str, bundle_id: str, process_name: str = "iosApp") ->
                 for line in tail:
                     print(f"      {line[:160]}")
         else:
-            print("    ios-app-logs: no Documents/ciris in the container — the app "
-                  "had not started writing yet")
+            print("    ios-app-logs: no Documents/ciris in the container — the app " "had not started writing yet")
     except Exception as exc:  # noqa: BLE001
         print(f"    ios-app-logs: could not collect ({type(exc).__name__}: {exc})")
 
@@ -3589,13 +3649,9 @@ def _simctl(args: List[str], timeout: int = 120) -> subprocess.CompletedProcess:
         # a stack that points at subprocess.py, and the reader goes looking for a
         # bug in the automation. Fail as a normal non-zero result so the caller's
         # own diagnostics run and say something true.
-        proc = subprocess.CompletedProcess(
-            cmd, 127, "", "xcrun not found — this host has no Xcode command line tools."
-        )
+        proc = subprocess.CompletedProcess(cmd, 127, "", "xcrun not found — this host has no Xcode command line tools.")
     except subprocess.TimeoutExpired:
-        proc = subprocess.CompletedProcess(
-            cmd, 124, "", f"timed out after {timeout}s"
-        )
+        proc = subprocess.CompletedProcess(cmd, 124, "", f"timed out after {timeout}s")
     # Recorded unconditionally, not just on failure: the command BEFORE the one
     # that broke is usually what explains it, and by then it is too late to
     # re-run it in the same state.
@@ -3703,15 +3759,15 @@ async def run_ios_simulator_up(args: argparse.Namespace) -> int:
             _fail(
                 "no Xcode toolchain on this host",
                 hint="`xcrun` is not on PATH, so no simulator can exist here.\n"
-                     "iOS bring-up requires a macOS runner with Xcode; on Linux/Windows\n"
-                     "this platform should be SKIPPED, not attempted.",
+                "iOS bring-up requires a macOS runner with Xcode; on Linux/Windows\n"
+                "this platform should be SKIPPED, not attempted.",
             )
         else:
             _fail(
                 "no available iOS simulator",
                 hint="`xcrun simctl list devices available` shows what this host has.\n"
-                     "A GitHub macos runner ships at least one iPhone runtime; if the list\n"
-                     "is empty the Xcode selection is probably wrong (check xcode-select -p).",
+                "A GitHub macos runner ships at least one iPhone runtime; if the list\n"
+                "is empty the Xcode selection is probably wrong (check xcode-select -p).",
             )
         return 1
     print(f"  simulator: {udid}")
@@ -3747,10 +3803,10 @@ async def run_ios_simulator_up(args: argparse.Namespace) -> int:
             _fail(
                 "no *Debug-iphonesimulator*/*.app found and the bundle is not installed",
                 hint="Build it with `bash apps/ios/scripts/rebuild_and_deploy.sh`, which\n"
-                     "runs xcodegen, rebuilds Resources.zip and lays down the SIMULATOR\n"
-                     "Python bundle — a bare `xcodebuild -scheme iosApp` skips all three\n"
-                     "and produces an app that launches to nothing.\n"
-                     "Or pass --ios-app-path explicitly.",
+                "runs xcodegen, rebuilds Resources.zip and lays down the SIMULATOR\n"
+                "Python bundle — a bare `xcodebuild -scheme iosApp` skips all three\n"
+                "and produces an app that launches to nothing.\n"
+                "Or pass --ios-app-path explicitly.",
             )
             return 1
     else:
@@ -3777,8 +3833,8 @@ async def run_ios_simulator_up(args: argparse.Namespace) -> int:
             _fail(
                 f"port {port} is already owned on the host by {owner}",
                 hint="The simulator reaches the host's loopback, so the app's own health\n"
-                     "check and this gate's probes would both be answered by that process,\n"
-                     "not by the iOS app. Tear the previous platform down first.",
+                "check and this gate's probes would both be answered by that process,\n"
+                "not by the iOS app. Tear the previous platform down first.",
             )
             return 1
 
@@ -3786,10 +3842,13 @@ async def run_ios_simulator_up(args: argparse.Namespace) -> int:
     print("[3/5] Installing…" if app else "[3/5] Install skipped — already present")
     install = _simctl(["install", udid, str(app)], timeout=300) if app else None
     if install is not None and install.returncode != 0:
-        _fail(f"simctl install {app.name}", install,
-              hint="A device (iphoneos) build cannot install into a simulator — the\n"
-                   "architectures differ. Confirm this bundle came from an\n"
-                   "-sdk iphonesimulator build.")
+        _fail(
+            f"simctl install {app.name}",
+            install,
+            hint="A device (iphoneos) build cannot install into a simulator — the\n"
+            "architectures differ. Confirm this bundle came from an\n"
+            "-sdk iphonesimulator build.",
+        )
         _ios_diagnostics(udid, getattr(args, "ios_bundle_id", None) or "ai.ciris.mobile")
         return 1
 
@@ -3810,9 +3869,12 @@ async def run_ios_simulator_up(args: argparse.Namespace) -> int:
     )
     _record("simctl-launch", launch, ["xcrun", "simctl", "launch", udid, bundle_id])
     if launch.returncode != 0:
-        _fail(f"simctl launch {bundle_id}", launch,
-              hint="If this says the bundle is unknown, the install silently targeted a\n"
-                   "different simulator — check the UDID above against `simctl listapps`.")
+        _fail(
+            f"simctl launch {bundle_id}",
+            launch,
+            hint="If this says the bundle is unknown, the install silently targeted a\n"
+            "different simulator — check the UDID above against `simctl listapps`.",
+        )
         _ios_diagnostics(udid, bundle_id)
         return 1
 
@@ -3857,7 +3919,9 @@ async def run_ios_simulator_up(args: argparse.Namespace) -> int:
                 if backend_ok:
                     print(f" [OK] embedded backend reachable at {backend_url}")
                 else:
-                    print(f"  \u26a0\ufe0f  embedded backend not yet ready at {backend_url}; the wizard will proceed and the AI step may fail to list models")
+                    print(
+                        f"  \u26a0\ufe0f  embedded backend not yet ready at {backend_url}; the wizard will proceed and the AI step may fail to list models"
+                    )
                 return 0
         except Exception:  # noqa: BLE001
             pass
@@ -3896,8 +3960,8 @@ async def run_ios_simulator_up(args: argparse.Namespace) -> int:
                 _fail(
                     f"the app EXITED while we waited for {server_url}/health after {elapsed:.0f}s",
                     hint="It launched and then stopped, so this is a crash on startup\n"
-                         "rather than a slow one. The os_log dump below covers the\n"
-                         "launch window.",
+                    "rather than a slow one. The os_log dump below covers the\n"
+                    "launch window.",
                 )
                 _ios_diagnostics(udid, bundle_id)
                 return 1
@@ -3906,12 +3970,12 @@ async def run_ios_simulator_up(args: argparse.Namespace) -> int:
     _fail(
         f"no /health from {server_url} within {wait_secs}s",
         hint="The app launched but its TestAutomationServer never answered.\n"
-             "Most likely causes, in order:\n"
-             "  1. CIRIS_TEST_MODE did not reach the app — simctl only forwards env\n"
-             "     vars with the SIMCTL_CHILD_ prefix.\n"
-             "  2. This build does not embed the test server.\n"
-             "  3. The app crashed on launch — see the os_log dump below.\n"
-             "A simulator needs NO port forward: 9091 is reached directly on the host.",
+        "Most likely causes, in order:\n"
+        "  1. CIRIS_TEST_MODE did not reach the app — simctl only forwards env\n"
+        "     vars with the SIMCTL_CHILD_ prefix.\n"
+        "  2. This build does not embed the test server.\n"
+        "  3. The app crashed on launch — see the os_log dump below.\n"
+        "A simulator needs NO port forward: 9091 is reached directly on the host.",
     )
     _ios_diagnostics(udid, bundle_id)
     return 1


### PR DESCRIPTION
## The report
A Windows user on 2.11.2: "404 when I try to do anything" (Add provider). His agent log is clean — API on `:8080`, node on `:4243`, WORK state — and shows no sign of the request. It never reached the brain.

## Root cause — ours
Since ciris-client **0.5.213** the desktop builds its ordinary API client from `CIRIS_NODE_URL` and deliberately ignores `CIRIS_API_URL` (the CIRISClient#48/#52 hand-off fix). `desktop_launcher.py` — untouched since April — still set only `CIRIS_API_URL`. So every desktop started by `ciris-agent` (pip **and** the installer's `ciris-agent.exe`, same entry point) had its UI on the bare node: node-native surface + 14 proxied brain prefixes, and 404 for everything else — `PUT /v1/setup/llm` (Add provider), list-models, `/v1/system/llm/*`, users, memory writes. Setup "completed" via node-native `/v1/setup/root`; the brain never saw `/v1/setup/complete` — exactly his install's shape (`node holds 1 root cert`, `has_admin=False`).

## Why the gate was green
`tools/qa_runner/modules/web_ui/__main__.py::_desktop_urls` sets **both** names to the brain — its docstring even says pointing at the real node 404s. The intended design (`routes/node_proxy.py` makes `:8080` the one complete surface) was in the harness and not in the product. Five green platforms, an environment no user received.

## Fix
- `desktop_app_env()` in the launcher: both names → brain; an explicit `CIRIS_NODE_URL` honoured verbatim (CIRISClient#26).
- The harness derives its URLs from that helper; `test_qa_harness_launches_with_the_same_urls_as_the_product` pins parity.
- 2.11.2 → **2.11.3**.

Client-side follow-up filed on CIRISClient (the default of `:4243` when only `CIRIS_API_URL` is present is fragile regardless of this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J45bNgkggVC1ntnmp6DqQA