### PR TITLE
Gate hardening: one fault, one red — name the test-server failure instead of cascading it

### DIFF
--- a/.github/workflows/five-platform-live-qa.yml
+++ b/.github/workflows/five-platform-live-qa.yml
@@ -428,7 +428,7 @@ jobs:
           }
         env:
           IMAGE: "system-images;android-34;google_apis;x86_64"
-      
+
 
       # MATERIALIZE THE iOS PYTHON BUNDLE IN THE RUNNER.
       #
@@ -715,6 +715,7 @@ jobs:
             # browser). An emulator or simulator has its own display and the flag
             # means nothing there, so it is only passed for desktop.
             extra=""
+            noai_ok=1
             [ "$target" = "desktop" ] && extra="--headless"
             if [ "$target" = "ios" ]; then
               if [ -z "${IOS_APP:-}" ]; then
@@ -740,14 +741,25 @@ jobs:
               --username qaadmin --password "qa_test_password_12345" \
               --run-without-ai \
               --screenshot-on-success "artifacts/shots/$plat-setup-noai.png" \
-              -v || { overall=1; echo "::error::$plat run-without-AI setup failed"; python3 tools/dev/diagnose_gate_failure.py --platform "$plat" --phase setup-noai --logs artifacts "${CIRIS_QA_LOG_DIR:-artifacts/cmdlogs}" || true; }
+              -v || { overall=1; noai_ok=0; echo "::error::$plat run-without-AI setup failed"; python3 tools/dev/diagnose_gate_failure.py --platform "$plat" --phase setup-noai --logs artifacts "${CIRIS_QA_LOG_DIR:-artifacts/cmdlogs}" || true; }
 
-            python -m tools.qa_runner.modules.web_ui desktop-login \
-              --platform "$target" $extra \
-              --username qaadmin --password "qa_test_password_12345" \
-              --run-without-ai \
-              --screenshot-on-success "artifacts/shots/$plat-login-noai.png" \
-              -v || { overall=1; echo "::error::$plat run-without-AI login failed — Interact unreachable against a node-only backend"; python3 tools/dev/diagnose_gate_failure.py --platform "$plat" --phase login-noai --logs artifacts "${CIRIS_QA_LOG_DIR:-artifacts/cmdlogs}" || true; }
+            # ONE FAULT, ONE RED. If the no-AI setup never completed, a login
+            # failure here is its CONSEQUENCE, not a finding: the app is mid-wizard,
+            # so every element the driver waits for is legitimately absent. Nightly
+            # 34596459034 turned one unreachable test server into four reds that read
+            # as client defects, and the classifier called all of them UNKNOWN
+            # (CIRISAgent#1172). Skip loudly instead.
+            if [ "$noai_ok" = 1 ]; then
+              python -m tools.qa_runner.modules.web_ui desktop-login \
+                --platform "$target" $extra \
+                --username qaadmin --password "qa_test_password_12345" \
+                --run-without-ai \
+                --screenshot-on-success "artifacts/shots/$plat-login-noai.png" \
+                -v || { overall=1; echo "::error::$plat run-without-AI login failed — Interact unreachable against a node-only backend"; python3 tools/dev/diagnose_gate_failure.py --platform "$plat" --phase login-noai --logs artifacts "${CIRIS_QA_LOG_DIR:-artifacts/cmdlogs}" || true; }
+
+            else
+              echo "::notice::$plat run-without-AI login SKIPPED — setup-noai did not complete, so a failure here would be a consequence, not a finding"
+            fi
 
             # 0b. RESET THROUGH THE CLIENT, not with rm. The client's factory reset is
             #     what deletes the .env, and the .env is where CIRIS_RUN_WITHOUT_AI
@@ -755,10 +767,21 @@ jobs:
             #     node, so the with-AI pass below would have no :8080 to talk to.
             #     Driving the real button is also how we find out if that reset ever
             #     stops clearing the flag.
-            python -m tools.qa_runner.modules.web_ui desktop-reset \
-              --platform "$target" $extra \
-              --screenshot-on-success "artifacts/shots/$plat-reset.png" \
-              -v || { overall=1; echo "::error::$plat client reset failed — the with-AI pass starts from an unknown state"; python3 tools/dev/diagnose_gate_failure.py --platform "$plat" --phase reset --logs artifacts "${CIRIS_QA_LOG_DIR:-artifacts/cmdlogs}" || true; }
+            if [ "$noai_ok" = 1 ]; then
+              python -m tools.qa_runner.modules.web_ui desktop-reset \
+                --platform "$target" $extra \
+                --screenshot-on-success "artifacts/shots/$plat-reset.png" \
+                -v || { overall=1; echo "::error::$plat client reset failed — the with-AI pass starts from an unknown state"; python3 tools/dev/diagnose_gate_failure.py --platform "$plat" --phase reset --logs artifacts "${CIRIS_QA_LOG_DIR:-artifacts/cmdlogs}" || true; }
+
+            else
+              # The reset is the cleanup the with-AI pass depends on, and it cannot
+              # run through a UI that never got there. Clear the home directly so the
+              # with-AI result below is still trustworthy; best-effort because a
+              # Windows file lock must not end the leg.
+              echo "::notice::$plat client reset SKIPPED — setup-noai did not complete; wiping $CIRIS_HOME so the with-AI pass starts from a known state"
+              rm -rf "$CIRIS_HOME" 2>/dev/null || true
+              mkdir -p "$CIRIS_HOME"
+            fi
 
             # 0c. Reap the node the no-AI pass left behind. `--launch` tears down the
             #     app and `main.py --adapter api`, but a node-only backend is

--- a/tests/tools/qa_runner/test_desktop_test_server_wait.py
+++ b/tests/tools/qa_runner/test_desktop_test_server_wait.py
@@ -1,0 +1,133 @@
+"""The test-server wait must name WHICH fault it hit, not just that it waited.
+
+Nightly 34596459034's Windows leg printed "desktop test server didn't come up
+within 60s" while the app's own log said `[TestAutomation] Server started on
+http://localhost:9091` and the UI had already reached the Setup screen. One
+sentence covered three different faults, the orphaned app was left running, and
+three downstream legs then failed looking like product defects (CIRISAgent#1172).
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+web_ui = importlib.import_module("tools.qa_runner.modules.web_ui.__main__")
+
+
+class FakeProc:
+    """A Popen stand-in: `rc=None` is alive, an int is an exit code."""
+
+    def __init__(self, rc: Optional[int] = None) -> None:
+        self._rc = rc
+        self.killed = False
+        self.waited = False
+
+    def poll(self) -> Optional[int]:
+        return self._rc
+
+    def kill(self) -> None:
+        self.killed = True
+        self._rc = -9
+
+    def wait(self, timeout: float | None = None) -> int:
+        self.waited = True
+        return self._rc if self._rc is not None else 0
+
+
+class Resp:
+    def __init__(self, code: int) -> None:
+        self.status_code = code
+
+
+def _answer_on(monkeypatch, *hosts: str) -> list[str]:
+    """Make /health answer only for the given hosts; record every URL tried."""
+    tried: list[str] = []
+
+    def fake_get(url: str, timeout: float = 0):  # noqa: ANN202
+        tried.append(url)
+        if any(f"http://{h}:" in url for h in hosts):
+            return Resp(200)
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(web_ui.requests, "get", fake_get)
+    return tried
+
+
+def test_returns_the_url_that_answered_on_127(monkeypatch, tmp_path):
+    _answer_on(monkeypatch, "127.0.0.1")
+    log = tmp_path / "c.log"
+    log.write_text("")
+    url = web_ui._await_desktop_test_server(FakeProc(), log, 9091, budget_s=5)
+    assert url == "http://127.0.0.1:9091"
+
+
+def test_tries_localhost_too_when_127_refuses(monkeypatch, tmp_path):
+    """The Windows IPv6/IPv4 split: a server on one spelling is unreachable at
+    the other, and probing only one turns reachability into a false 'never came up'."""
+    tried = _answer_on(monkeypatch, "localhost")
+    log = tmp_path / "c.log"
+    log.write_text("")
+    url = web_ui._await_desktop_test_server(FakeProc(), log, 9091, budget_s=5)
+    assert url == "http://localhost:9091"
+    assert any("127.0.0.1" in u for u in tried), "must try 127.0.0.1 as well"
+
+
+def test_a_dead_jvm_is_reported_as_exited_and_does_not_wait_out_the_budget(monkeypatch, tmp_path, capsys):
+    _answer_on(monkeypatch)  # nothing answers
+    log = tmp_path / "c.log"
+    log.write_text("Exception in thread main java.lang.NoClassDefFoundError\n")
+    import time as _t
+
+    t0 = _t.monotonic()
+    assert web_ui._await_desktop_test_server(FakeProc(rc=1), log, 9091, budget_s=30) is None
+    assert _t.monotonic() - t0 < 10, "a dead JVM must not burn the whole budget"
+    out = capsys.readouterr().out
+    assert "EXITED rc=1" in out
+    assert "the app exited" in out
+    assert "NoClassDefFoundError" in out, "the tail must be shown"
+
+
+def test_serving_but_unreachable_is_called_reachability_not_startup(monkeypatch, tmp_path, capsys):
+    """THE WINDOWS CASE. The app is alive and its log says the server started, so
+    this is not a startup failure and must not be reported as one."""
+    _answer_on(monkeypatch)
+    log = tmp_path / "c.log"
+    log.write_text("[TestAutomation] Server started on http://localhost:9091\n")
+    assert web_ui._await_desktop_test_server(FakeProc(), log, 9091, budget_s=3) is None
+    out = capsys.readouterr().out
+    assert "REACHABILITY, not startup" in out
+    assert "NOT a client or product fault" in out
+    assert "jvm: ALIVE" in out
+
+
+def test_alive_and_silent_is_called_still_starting(monkeypatch, tmp_path, capsys):
+    _answer_on(monkeypatch)
+    log = tmp_path / "c.log"
+    log.write_text("[Desktop] Found localization directory\n")
+    assert web_ui._await_desktop_test_server(FakeProc(), log, 9091, budget_s=3) is None
+    out = capsys.readouterr().out
+    assert "still starting" in out
+    assert "REACHABILITY" not in out
+
+
+def test_a_missing_log_does_not_crash_the_diagnosis(monkeypatch, tmp_path, capsys):
+    _answer_on(monkeypatch)
+    assert web_ui._await_desktop_test_server(FakeProc(), tmp_path / "nope.log", 9091, budget_s=2) is None
+    assert "not reachable" in capsys.readouterr().out
+
+
+def test_the_orphan_is_killed_so_the_next_leg_starts_clean(capsys):
+    proc = FakeProc()
+    web_ui._kill_desktop_app(proc)
+    assert proc.killed and proc.waited
+    assert "stopped the app" in capsys.readouterr().out
+
+
+def test_killing_an_already_dead_app_is_a_no_op():
+    proc = FakeProc(rc=0)
+    web_ui._kill_desktop_app(proc)
+    assert not proc.killed

--- a/tests/tools/test_diagnose_gate_failure_phases.py
+++ b/tests/tools/test_diagnose_gate_failure_phases.py
@@ -1,0 +1,52 @@
+"""Every phase the gate passes must classify; and an unreachable test server is INFRA."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github/workflows/five-platform-live-qa.yml"
+
+_spec = importlib.util.spec_from_file_location("dgf", ROOT / "tools/dev/diagnose_gate_failure.py")
+assert _spec and _spec.loader
+dgf = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(dgf)
+
+
+def test_every_phase_the_workflow_passes_has_a_default():
+    """UNKNOWN is not a classification. The nightly's only failing leg produced
+    three of them because these keys were missing."""
+    passed = set(re.findall(r"--phase ([a-z-]+)", WORKFLOW.read_text()))
+    assert passed, "no --phase arguments found; did the workflow move?"
+    missing = sorted(passed - set(dgf.PHASE_DEFAULT))
+    assert not missing, f"phases with no PHASE_DEFAULT entry: {missing}"
+
+
+def test_an_unreachable_test_server_is_infra_not_client():
+    blob = (
+        " [FAIL] desktop test server not reachable within 90s\n"
+        "     jvm: ALIVE\n"
+        "     => REACHABILITY, not startup: the app is serving and we could not\n"
+    )
+    layer, meaning, _ = dgf.classify(blob, "setup-noai")
+    assert layer == "INFRA", (layer, meaning)
+
+
+def test_infra_outranks_the_cascaded_client_symptoms():
+    """The real log carries BOTH: the infra cause first, then the element-not-found
+    consequences. The cause must win."""
+    blob = (
+        " [FAIL] desktop test server not reachable within 90s\n"
+        " [FAIL] click_login_button: Element not found: btn_login_submit\n"
+        " [FAIL] reset_device: wait_for element 'btn_login_reset_device' timed out\n"
+    )
+    layer, _, _ = dgf.classify(blob, "reset")
+    assert layer == "INFRA", "the cascade must not be classified by its symptoms"
+
+
+def test_a_genuine_client_failure_is_still_client():
+    blob = " [FAIL] click_login_button: Element not found: btn_login_submit\n"
+    layer, _, _ = dgf.classify(blob, "login")
+    assert layer == "CLIENT"

--- a/tests/tools/test_five_platform_noai_cascade.py
+++ b/tests/tools/test_five_platform_noai_cascade.py
@@ -1,0 +1,82 @@
+"""One fault must produce one red.
+
+Nightly 34596459034: the Windows desktop test server was unreachable once, and
+the leg reported FOUR failures — setup-noai, login-noai, reset, each classified
+UNKNOWN — because the no-AI legs ran unconditionally against an app that was
+never driveable. The three downstream reds read as client defects (CIRISAgent#1172).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github/workflows/five-platform-live-qa.yml"
+
+
+def _driving_step() -> str:
+    doc = yaml.safe_load(WORKFLOW.read_text())
+    for job in doc["jobs"].values():
+        for step in job.get("steps") or []:
+            if isinstance(step, dict) and "Run the shared flow" in str(step.get("name", "")):
+                return step["run"]
+    raise AssertionError("driving step not found")
+
+
+GUARD = 'if [ "$noai_ok" = 1 ]; then'
+
+
+def _guarded_block(body: str, needle: str) -> str:
+    """The enclosing `if [ "$noai_ok" = 1 ] ... fi` around `needle`.
+
+    Bounded by the guard and its `fi` rather than a byte window, so a longer
+    command or another comment cannot make this assert the wrong thing.
+    """
+    i = body.index(needle)
+    start = body.rfind(GUARD, 0, i)
+    assert start != -1, f"{needle!r} is not inside a {GUARD!r} block"
+    # YAML block scalars strip the common indent, so match `fi` at any depth
+    # rather than at the indentation it happens to have in the file.
+    m = re.search(r"\n\s*fi\s*\n", body[i:])
+    assert m, f"no `fi` closes the block around {needle!r}"
+    return body[start : i + m.end()]
+
+
+def test_setup_noai_records_its_verdict():
+    body = _driving_step()
+    line = next(l for l in body.splitlines() if "run-without-AI setup failed" in l)
+    assert "noai_ok=0" in line, "setup-noai must record the verdict, not only count it"
+
+
+def test_the_flag_is_reset_per_platform():
+    """The loop walks two platforms per runner; a stale flag would skip the second."""
+    body = _driving_step()
+    assert re.search(r"^\s*noai_ok=1\s*$", body, re.M), "noai_ok must be initialised inside the loop"
+    init = body.index("noai_ok=1")
+    assert init < body.index("run-without-AI setup failed"), "initialise before the first use"
+
+
+def test_login_noai_only_runs_when_setup_noai_succeeded():
+    body = _driving_step()
+    ctx = _guarded_block(body, "desktop-login \\")
+    assert GUARD in ctx, "the no-AI login must be gated"
+    assert "SKIPPED" in ctx, "a skip must be announced, not silent"
+
+
+def test_reset_is_gated_and_the_home_is_cleared_when_it_cannot_run():
+    body = _driving_step()
+    ctx = _guarded_block(body, "desktop-reset \\")
+    assert GUARD in ctx, "the reset must be gated"
+    assert 'rm -rf "$CIRIS_HOME"' in ctx, (
+        "when the UI reset cannot run, the home must be cleared so the with-AI " "pass still starts from a known state"
+    )
+
+
+def test_the_with_ai_pass_is_not_gated_on_the_noai_flag():
+    """The with-AI pass is the gate's headline assertion and must always run."""
+    body = _driving_step()
+    withai = body[body.index("# 1. Setup wizard through the real UI") :]
+    assert "noai_ok" not in withai, "the with-AI pass must not depend on the no-AI outcome"

--- a/tools/dev/diagnose_gate_failure.py
+++ b/tools/dev/diagnose_gate_failure.py
@@ -73,34 +73,82 @@ def strip_advice(blob: str) -> str:
     run, for the same reason: the words we match on appear in text that is not
     about what we are diagnosing.
     """
-    return "\n".join(
-        l for l in blob.splitlines() if not ADVICE.search(l) and not NOT_THE_LLM.search(l)
-    )
+    return "\n".join(l for l in blob.splitlines() if not ADVICE.search(l) and not NOT_THE_LLM.search(l))
 
 
 SIGNATURES: list[tuple[str, str, str]] = [
-    ("WIRE", r"Key limit exceeded|insufficient[_ ]credits|quota exceeded", "provider refused: account limit or credit exhausted"),
-    ("WIRE", r"(?:HTTP|status|status_code|code)[ =:]*402\b|\b402 Payment Required|payment required", "provider refused: payment required"),
+    (
+        "WIRE",
+        r"Key limit exceeded|insufficient[_ ]credits|quota exceeded",
+        "provider refused: account limit or credit exhausted",
+    ),
+    (
+        "WIRE",
+        r"(?:HTTP|status|status_code|code)[ =:]*402\b|\b402 Payment Required|payment required",
+        "provider refused: payment required",
+    ),
     # "rate limited" only as an EVENT: a status line, the reason phrase, or the
     # provider naming it. A dict key like 'dns_us_rate_limited': False is not one.
-    ("WIRE", r"(?:HTTP|status|status_code|code)[ =:]*429\b|\b429 Too Many|Too Many Requests|rate.?limit(?:ed)? (?:exceeded|reached|hit)|rate.?limit.*retry.?after|(?:openrouter|provider|llm)[^\n]{0,40}rate.?limit(?!ed['\"]?[:=])", "provider refused: rate limited"),
-    ("WIRE", r"(?:HTTP|status|status_code|code)[ =:]*401\b.*(openrouter|provider|llm)|invalid[_ ]api[_ ]key|unauthorized.*llm", "provider refused: key rejected"),
-    ("WIRE", r"model_not_available|model not found|(?:HTTP|status|status_code|code)[ =:]*404\b.*model", "provider refused: model name not served"),
+    (
+        "WIRE",
+        r"(?:HTTP|status|status_code|code)[ =:]*429\b|\b429 Too Many|Too Many Requests|rate.?limit(?:ed)? (?:exceeded|reached|hit)|rate.?limit.*retry.?after|(?:openrouter|provider|llm)[^\n]{0,40}rate.?limit(?!ed['\"]?[:=])",
+        "provider refused: rate limited",
+    ),
+    (
+        "WIRE",
+        r"(?:HTTP|status|status_code|code)[ =:]*401\b.*(openrouter|provider|llm)|invalid[_ ]api[_ ]key|unauthorized.*llm",
+        "provider refused: key rejected",
+    ),
+    (
+        "WIRE",
+        r"model_not_available|model not found|(?:HTTP|status|status_code|code)[ =:]*404\b.*model",
+        "provider refused: model name not served",
+    ),
     ("WIRE", r"(connection|read) timed out.*(openrouter|api\.|llm)|provider.*unreachable", "provider unreachable"),
-    ("AGENT", r"(ERROR|CRITICAL)\b[^\n]*\bDMA\b|\b\w*DMA\w*(Evaluator)?\b[^\n]*\b(raised|failed:|exception|ValidationError)", "a DMA errored"),
+    (
+        "AGENT",
+        r"(ERROR|CRITICAL)\b[^\n]*\bDMA\b|\b\w*DMA\w*(Evaluator)?\b[^\n]*\b(raised|failed:|exception|ValidationError)",
+        "a DMA errored",
+    ),
     ("AGENT", r"(ERROR|CRITICAL)\b[^\n]*conscience|conscience[^\n]*(raised|failed:|exception)", "a conscience errored"),
     ("AGENT", r"Traceback \(most recent call last\)", "unhandled exception in the agent"),
     ("INFRA", r"none of the given log paths exist", "no logs were produced: the app or server never started"),
     ("INFRA", r"Address already in use|EADDRINUSE", "port already held"),
+    # Ordered BEFORE the CLIENT element/timeout signature on purpose: when the
+    # app's test server never answered, the driver's "element not found" lines
+    # are consequences, not evidence. Reading them as CLIENT is what sent three
+    # Windows legs hunting product defects that were not there.
+    (
+        "INFRA",
+        r"desktop test server (?:not reachable|didn't come up)|REACHABILITY, not startup",
+        "the desktop app's test server never answered the driver",
+    ),
     ("INFRA", r"no simulator \.app was built", "the iOS app was never built"),
-    ("CLIENT", r"element .*not found|no element with testTag|wait_for.*timed out|tagged but not dr", "the UI never reached the awaited state"),
+    (
+        "CLIENT",
+        r"element .*not found|no element with testTag|wait_for.*timed out|tagged but not dr",
+        "the UI never reached the awaited state",
+    ),
     ("DELIVERY", r"no \[DELIVERY-PROBE\] lines|highest rung reached", "traces did not reach the required rung"),
-    ("SILENT", r"message_type=='agent' row|agent did not answer|no reply", "the agent produced no reply and logged no error"),
+    (
+        "SILENT",
+        r"message_type=='agent' row|agent did not answer|no reply",
+        "the agent produced no reply and logged no error",
+    ),
 ]
 
+# EVERY phase the workflow passes must be a key here. `setup-noai`, `login-noai`
+# and `reset` were not, so nightly 34596459034's three Windows failures each
+# reported "UNKNOWN -- no known signature matched" -- the classifier had nothing
+# to say about the only leg that failed (CIRISAgent#1172). Keep this in step with
+# `grep -oE '--phase [a-z-]+' .github/workflows/five-platform-live-qa.yml`;
+# test_diagnose_phases_are_complete asserts exactly that.
 PHASE_DEFAULT = {
     "setup": ("CLIENT", "the setup wizard did not complete"),
+    "setup-noai": ("CLIENT", "the run-without-AI setup wizard did not complete"),
     "login": ("CLIENT", "login did not complete"),
+    "login-noai": ("CLIENT", "login against a node-only backend did not complete"),
+    "reset": ("CLIENT", "the client-side device reset did not complete"),
     "interact": ("SILENT", "no reply was rendered"),
     "delivery": ("DELIVERY", "trace delivery did not reach the required rung"),
     "identity": ("AGENT", "the one-holder-per-identity invariant broke"),
@@ -112,7 +160,11 @@ def read_logs(paths: list[str], cap: int = 400_000) -> str:
     out: list[str] = []
     for p in paths:
         path = pathlib.Path(p)
-        for f in ([path] if path.is_file() else sorted(path.rglob("*.log")) + sorted(path.rglob("*.txt")) if path.is_dir() else []):
+        for f in (
+            [path]
+            if path.is_file()
+            else sorted(path.rglob("*.log")) + sorted(path.rglob("*.txt")) if path.is_dir() else []
+        ):
             try:
                 out.append(f"--- {f} ---\n" + f.read_text(errors="replace")[-cap:])
             except OSError:
@@ -130,9 +182,7 @@ def probe_provider() -> tuple[str, str] | None:
     key = os.environ.get("OPENROUTER_API_KEY", "").strip()
     if not key:
         return ("WIRE?", "no OPENROUTER_API_KEY in this job -- cannot check the budget")
-    req = urllib.request.Request(
-        "https://openrouter.ai/api/v1/key", headers={"Authorization": f"Bearer {key}"}
-    )
+    req = urllib.request.Request("https://openrouter.ai/api/v1/key", headers={"Authorization": f"Bearer {key}"})
     try:
         with urllib.request.urlopen(req, timeout=20) as r:
             d = json.load(r).get("data", {})

--- a/tools/qa_runner/modules/web_ui/__main__.py
+++ b/tools/qa_runner/modules/web_ui/__main__.py
@@ -3051,6 +3051,107 @@ def _android_teardown(args: argparse.Namespace, keep_open: bool) -> None:
             pass
 
 
+#: Loopback spellings to try, in order. BOTH, because they are not the same host.
+#:
+#: The Windows leg of nightly 34596459034 failed with "desktop test server didn't
+#: come up within 60s" while the app's own log said
+#: `[TestAutomation] Server started on http://localhost:9091` and the UI had
+#: already reached the Setup screen. The app was fine; the probe could not reach
+#: it. On Windows `localhost` resolves to ::1 before 127.0.0.1, and a server bound
+#: to one of those is unreachable at the other -- so a single spelling turns a
+#: reachability question into a false "the app never started".
+_LOOPBACKS = ("127.0.0.1", "localhost")
+
+
+def _await_desktop_test_server(
+    proc: "subprocess.Popen[bytes]",
+    log_path: Path,
+    port: int,
+    budget_s: float = 90.0,
+) -> Optional[str]:
+    """Wait for the desktop app's TestAutomationServer. On failure, SAY WHY.
+
+    Returns the base URL that answered, or None.
+
+    THE FAILURE MESSAGE IS THE POINT. The old version of this loop printed
+    "didn't come up within 60s" and returned, which is three different faults
+    wearing one sentence:
+
+      * the JVM died          -> exit code and the tail of its log say so
+      * the JVM is still starting -> it is alive, and the budget was too short
+      * the JVM is serving, we cannot reach it -> its log says "Server started"
+        and something else holds the port, or we probed the wrong loopback
+
+    Only the first two are "didn't come up". The third is what actually happened
+    on Windows, and reporting it as a startup failure sent three downstream legs
+    looking for product defects that were not there (CIRISAgent#1172).
+    """
+    deadline = time.time() + budget_s
+    while time.time() < deadline:
+        if proc.poll() is not None:
+            break  # dead: no point waiting out the budget
+        for host in _LOOPBACKS:
+            base = f"http://{host}:{port}"
+            try:
+                if requests.get(f"{base}/health", timeout=2).status_code == 200:
+                    print(f" [OK] desktop test server up at {base}")
+                    return base
+            except Exception:  # noqa: BLE001 -- not up yet is the normal case
+                pass
+        time.sleep(1)
+
+    # ---- it did not answer: establish WHICH fault this is -------------------
+    rc = proc.poll()
+    alive = rc is None
+    try:
+        tail = log_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        tail = []
+    started = any("TestAutomation" in line and "Server started" in line for line in tail)
+
+    print(f" [FAIL] desktop test server not reachable within {budget_s:.0f}s")
+    print(f"     jvm: {'ALIVE' if alive else f'EXITED rc={rc}'}")
+    print(f"     its log says the server started: {'YES' if started else 'no'}")
+    if started and alive:
+        print("     => REACHABILITY, not startup: the app is serving and we could not")
+        print(f"        reach it on any of {list(_LOOPBACKS)}. Firewall, or a bound")
+        print("        interface we did not try. NOT a client or product fault.")
+    elif alive:
+        print("     => still starting when the budget expired: raise it, do not")
+        print("        read this as a product failure.")
+    else:
+        print("     => the app exited; the tail below is why.")
+    try:
+        from tools.qa_runner.platform_procs import pids_listening_on
+
+        holders = pids_listening_on(port)
+        print(f"     pids listening on {port}: {holders or '(could not tell)'}")
+    except Exception:  # noqa: BLE001
+        pass
+    print(f"     inspect: {log_path}")
+    for line in tail[-25:]:
+        print(f"     | {line[:200]}")
+    return None
+
+
+def _kill_desktop_app(proc: "subprocess.Popen[bytes]") -> None:
+    """Stop an app we launched and are about to give up on.
+
+    The old failure path left it running. The next leg then launched a SECOND
+    app against the same home and the same test port, so its failures were
+    races against our own orphan rather than anything the product did
+    (CIRISAgent#1172).
+    """
+    if proc.poll() is not None:
+        return
+    try:
+        proc.kill()
+        proc.wait(timeout=10)
+        print("     (stopped the app we gave up on, so the next leg starts clean)")
+    except Exception as exc:  # noqa: BLE001
+        print(f"     (could not stop the app: {exc})")
+
+
 async def run_desktop_up(args: argparse.Namespace) -> int:
     """End-to-end: wipe → start backend in first-run → setup → launch desktop → login.
 
@@ -3174,7 +3275,7 @@ async def run_desktop_up(args: argparse.Namespace) -> int:
             env["CIRIS_HOME"] = _home
         log_path = temp_path(f"ciris_desktop_up.{_launch_stamp()}.log")
         with open(log_path, "w") as log:
-            subprocess.Popen(
+            proc = subprocess.Popen(
                 ["java", "-jar", str(jar)],
                 stdout=log,
                 stderr=subprocess.STDOUT,
@@ -3183,18 +3284,12 @@ async def run_desktop_up(args: argparse.Namespace) -> int:
             )
         print(f"  logs: {log_path}")
 
-        # Wait for test server
-        deadline = time.time() + 60
-        server_url = f"http://localhost:{args.desktop_port}"
-        while time.time() < deadline:
-            try:
-                if requests.get(f"{server_url}/health", timeout=2).status_code == 200:
-                    break
-            except Exception:
-                pass
-            time.sleep(1)
-        else:
-            print(" [WARN] desktop test server didn't come up; continuing anyway")
+        reached = _await_desktop_test_server(proc, Path(log_path), args.desktop_port)
+        # Lenient by design HERE: this command drives the UI next, and a late
+        # server still works. The diagnosis above prints either way.
+        server_url = reached or f"http://localhost:{args.desktop_port}"
+        if reached is None:
+            print(" [WARN] continuing anyway — the UI steps below will say if it never arrived")
 
         # 5. Log in via the UI
         print("[5/5] Logging in via UI...")
@@ -3345,7 +3440,7 @@ async def run_desktop_first_run_up(args: argparse.Namespace) -> int:
     # ciris_desktop*.log, so a timestamped name is picked up with no other change.
     log_path = temp_path(f"ciris_desktop_setup.{_launch_stamp()}.log")
     with open(log_path, "w") as log:
-        subprocess.Popen(
+        proc = subprocess.Popen(
             ["java", "-jar", str(jar)],
             stdout=log,
             stderr=subprocess.STDOUT,
@@ -3354,20 +3449,9 @@ async def run_desktop_first_run_up(args: argparse.Namespace) -> int:
         )
     print(f"  logs: {log_path}")
 
-    # Wait for the desktop test server
-    deadline = time.time() + 60
-    server_url = f"http://localhost:{args.desktop_port}"
-    while time.time() < deadline:
-        try:
-            if requests.get(f"{server_url}/health", timeout=2).status_code == 200:
-                print(f" [OK] desktop test server up at {server_url}")
-                break
-        except Exception:
-            pass
-        time.sleep(1)
-    else:
-        print(" [FAIL] desktop test server didn't come up within 60s")
-        print(f"     inspect: {log_path}")
+    server_url = _await_desktop_test_server(proc, Path(log_path), args.desktop_port)
+    if server_url is None:
+        _kill_desktop_app(proc)
         return 1
 
     print(f"[OK] First-run stack ready. Backend: {server.base_url} (first-run) Desktop: {server_url}")


### PR DESCRIPTION
## What happened
Nightly **34596459034**'s Windows leg reported **four** failures and the classifier called every one `UNKNOWN -- no known signature matched`.

There was **one** fault, and it was not in the product. The app's own log:

```
[TestAutomation] Server started on http://localhost:9091
...
[CIRISApp] [DEBUG][Screen.Setup] Rendering setup screen (hasAgent=true)
```

while the harness printed `[FAIL] desktop test server didn't come up within 60s`. The app was serving and driveable; **the probe could not reach it**. The second launch in the same job reached it fine.

## Three things turned that into three client-looking defects

**1. One sentence for three faults.** "didn't come up" covered a dead JVM, a slow JVM, and a live JVM we couldn't reach. `_await_desktop_test_server` now keeps the `Popen` handle and reports which:

```
 [FAIL] desktop test server not reachable within 90s
     jvm: ALIVE
     its log says the server started: YES
     => REACHABILITY, not startup: the app is serving and we could not
        reach it on any of ['127.0.0.1', 'localhost']. Firewall, or a bound
        interface we did not try. NOT a client or product fault.
     pids listening on 9091: [4312]
```

Both loopback spellings are probed — on Windows `localhost` resolves to `::1` before `127.0.0.1`, and a server bound to one is unreachable at the other, which is the most likely reading of this run. Budget 60s → 90s, and a dead JVM short-circuits instead of burning it.

**2. The orphan was left running.** The failing path returned without stopping the app it launched, so the next leg started a *second* app against the same home and test port — racing our own orphan. `_kill_desktop_app` ends it.

**3. The cascade ran anyway.** `login-noai` and `reset` executed against an app that was never driveable, so their element-not-found failures read as product defects. Both are now gated on `noai_ok` with an announced skip. When the UI reset can't run, the home is cleared directly so the **with-AI pass — the gate's headline assertion, deliberately never gated on the no-AI outcome — still starts from a known state**.

Plus: `setup-noai`, `login-noai` and `reset` had no `PHASE_DEFAULT` entry (hence three UNKNOWNs), and the new INFRA signature is ordered **ahead** of the CLIENT element/timeout one so a cascade is classified by its cause, not its symptoms.

## Tests
Every branch of the diagnosis (dead / slow / serving-but-unreachable, both loopbacks, missing log), the orphan kill, that every `--phase` the workflow passes has a classification, that INFRA outranks cascaded CLIENT symptoms *while a genuine CLIENT failure still reads CLIENT*, and the workflow's gating structure — including that the with-AI pass is never gated. **616 pass** across `tools/` and every `web_ui`-touching suite.

No version bump: #1169 is taking 2.11.4 and edits the same constants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J45bNgkggVC1ntnmp6DqQA